### PR TITLE
add support for ^id2

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Code should adhere to the [Google Python Style Guide](https://google.github.io/s
 * Familiarize yourself with how to use a command prompt and Git Bash (if you can't do this you will have a baaaaaaad time) (though in Git all you have to do is git clone so you don't actually need to know everything)
 
 ## Installing Miru Dependencies
-* For Romanji/Kana conversion you will use Romkan. This is a bit tricky to install so we'll go over it first. This is a required dependency even if you don't think you need it, just do it.
+* For Romanji/Kana conversion you will use Romkan. This is a bit tricky to install so we'll go over it first.
+    * If you want to skip this, you can locally comment out all calls to it, but this might be annoying when syncing your code if you're editing files that import it, so you should probably just do it. But if figuring this out is a barrier to entry to start actually coding, feel free to skip at least at the start.
     * git clone [this repo](https://github.com/soimort/python-romkan) into any folder you want.
     * Open setup.py in the text editor or IDE of your choice. Make the following replacement (basically add `encoding='utf8'` in 3 places):
     ```python

--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ Code should adhere to the [Google Python Style Guide](https://google.github.io/s
     * padguide2
     * padinfo
 * After you have done all of this, restart the bot again. Hopefully by now `^id ` should work!
+
+## Other
+
+### Emoji
+* If you want emojis in `^id` commands, and you are setting this up for DEV PURPOSES ONLY, you can talk to tactical_retreat about getting your bot invited to the emoji servers. If you want to make your own separate Miru instance though, you're on your own for that.
+* Give t_r your bot's invite link & ask him for the server IDs
+* Then use `^padinfo setemojiservers` with the IDs he gives you. The main Miru server is one of them, you can get that ID yourself.
+
 # Puzzle and Dragons
 
 Most cogs here relate to the mobile game 'Puzzle and Dragons'. Data is sourced from the

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Code should adhere to the [Google Python Style Guide](https://google.github.io/s
 * Familiarize yourself with how to use a command prompt and Git Bash (if you can't do this you will have a baaaaaaad time) (though in Git all you have to do is git clone so you don't actually need to know everything)
 
 ## Installing Miru Dependencies
-* For Romanji/Kana conversion you will use Romkan. This is a bit tricky to install.
+* For Romanji/Kana conversion you will use Romkan. This is a bit tricky to install so we'll go over it first. This is a required dependency even if you don't think you need it, just do it.
     * git clone [this repo](https://github.com/soimort/python-romkan) into any folder you want.
     * Open setup.py in the text editor or IDE of your choice. Make the following replacement (basically add `encoding='utf8'` in 3 places):
     ```python

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Code should adhere to the [Google Python Style Guide](https://google.github.io/s
     * dill
     * prettytable
     * ply
+    * aiohttp
+    * discord
 ## Setting up the bot
 * Install Red - [Windows Install](https://twentysix26.github.io/Red-Docs/red_install_windows/) (or switch to whichever OS you want)
 * Create your bot account & have it join a private server with just you and the bot, for testing. Probably don't name it Miru to avoid confusion. This step is also explained in the above instructions.
@@ -56,7 +58,6 @@ Code should adhere to the [Google Python Style Guide](https://google.github.io/s
     * rpadutils
     * padguide2
     * padinfo
-    * padsearch
 * After you have done all of this, restart the bot again. Hopefully by now `^id ` should work!
 # Puzzle and Dragons
 

--- a/padguide2/padguide2.py
+++ b/padguide2/padguide2.py
@@ -2280,10 +2280,11 @@ class MonsterIndex(object):
     
     
 
-    def find_monster_multiple_prefixes(self, query):
-        """Search with multiple prefixes allowed.
+    def find_monster2(self, query):
+        """Search with alternative method for resolving prefixes.
         
         Implements the lookup for id2, where you are allowed to specify multiple prefixes for a card.
+        All prefixes are required to be exactly matched by the card.
         Follows a similar logic to the regular id but after each check, will remove any potential match that doesn't
         contain every single specified prefix.
         """
@@ -2351,8 +2352,7 @@ class MonsterIndex(object):
                 if prefix not in m.prefixes:
                     to_remove.add(m)
                     break
-        for m in to_remove:
-            matches.remove(m)
+        matches.difference_update(to_remove)
     
     def pickBestMonster(self, named_monster_list):
         return max(named_monster_list, key=lambda x: (not x.is_low_priority, x.rarity, x.monster_no_na))

--- a/padguide2/padguide2.py
+++ b/padguide2/padguide2.py
@@ -2340,7 +2340,7 @@ class MonsterIndex(object):
         return None, "Could not find a match for: " + query, None
         
     
-    # verify that potential matches od in fact have the prefixes that we want
+    # verify that potential matches do in fact have the prefixes that we want
     def remove_potential_matches_without_all_prefixes(self, matches, query_prefixes):
         to_remove = set()
         for m in matches:

--- a/padguide2/padguide2.py
+++ b/padguide2/padguide2.py
@@ -2279,9 +2279,14 @@ class MonsterIndex(object):
         return None, "Could not find a match for: " + query, None
     
     
-    # implements the lookup for id2, where you are allowed to specify multiple prefixes for a card
-    # search is not as robust as standard id because you should be able to be a lot more specific just from prefixes
+
     def find_monster_multiple_prefixes(self, query):
+        """Search with multiple prefixes allowed.
+        
+        Implements the lookup for id2, where you are allowed to specify multiple prefixes for a card.
+        Follows a similar logic to the regular id but after each check, will remove any potential match that doesn't
+        contain every single specified prefix.
+        """
         query = rpadutils.rmdiacritics(query).lower().strip()
         # id search
         if query.isdigit():
@@ -2305,7 +2310,6 @@ class MonsterIndex(object):
         # so break up the query into an array of prefixes, and a string (new_query) that will be the lookup
         query_prefixes = []
         parts_of_query = query.split()
-        parts_of_new_query = []
         new_query = ''
         for i, part in enumerate(parts_of_query):
             if part in self.all_prefixes:
@@ -2328,7 +2332,6 @@ class MonsterIndex(object):
         
         # if we don't have any candidates yet, pick a new method
         if not len(matches):
-            
             # try matching on exact names next
             for nickname, m in self.all_na_name_to_monsters.items():
                 if new_query in m.name_na.lower() or new_query in m.name_jp.lower():

--- a/padguide2/padguide2.py
+++ b/padguide2/padguide2.py
@@ -1,1102 +1,2504 @@
+"""
+Provides access to PadGuide data.
+
+Loads every PadGuide related JSON into a simple data structure, and then
+combines them into a an in-memory interconnected database.
+
+Don't hold on to any of the dastructures exported from here, or the
+entire database could be leaked when the module is reloaded.
+"""
+from _collections import defaultdict
 import asyncio
-from builtins import filter, map
-from collections import OrderedDict
-from collections import defaultdict
-import io
+import csv
+from datetime import datetime
+from datetime import timedelta
+import difflib
+from itertools import groupby
 import json
+from operator import itemgetter
+import os
 import re
+import time
 import traceback
 
-from dateutil import tz
+import aiohttp
 import discord
 from discord.ext import commands
 from enum import Enum
-import prettytable
+import pytz
+import romkan
 
-from __main__ import user_allowed, send_cmd_help
+from __main__ import send_cmd_help
 
-from . import padguide2
 from . import rpadutils
-from .rpadutils import *
 from .rpadutils import CogSettings
 from .utils import checks
-from .utils.chat_formatting import *
+from .utils.chat_formatting import box, inline
 from .utils.dataIO import dataIO
 
 
-HELP_MSG = """
-^helpid : shows this message
-^id <query> : look up a monster and print a link to puzzledragonx
-^pic <query> : Look up a monster and display its image inline
+DUMMY_FILE_PATTERN = 'data/padguide2/{}.dummy'
+JSON_FILE_PATTERN = 'data/padguide2/{}.json'
+CSV_FILE_PATTERN = 'data/padguide2/{}.csv'
+ATTR_EXPORT_PATH = 'data/padguide2/card_data.csv'
+NAMES_EXPORT_PATH = 'data/padguide2/computed_names.json'
+BASENAMES_EXPORT_PATH = 'data/padguide2/base_names.json'
+TRANSLATEDNAMES_EXPORT_PATH = 'data/padguide2/translated_names.json'
 
-Options for <query>
-    <id> : Find a monster by ID
-        ^id 1234 (picks sun quan)
-    <name> : Take the best guess for a monster, picks the most recent monster
-        ^id kali (picks uvo d kali)
-    <prefix> <name> : Limit by element or awoken, e.g.
-        ^id ares  (selects the most recent, awoken ares)
-        ^id aares (explicitly selects awoken ares)
-        ^id a ares (spaces work too)
-        ^id rd ares (select a specific evo for ares, the red/dark one)
-        ^id r/d ares (slashes, spaces work too)
+SHEETS_PATTERN = 'https://docs.google.com/spreadsheets/d/1EoZJ3w5xsXZ67kmarLE4vfrZSIIIAfj04HXeZVST3eY/pub?gid={}&single=true&output=csv'
+GROUP_BASENAMES_OVERRIDES_SHEET = SHEETS_PATTERN.format('2070615818')
+NICKNAME_OVERRIDES_SHEET = SHEETS_PATTERN.format('0')
 
-computed nickname list and overrides: https://docs.google.com/spreadsheets/d/1EyzMjvf8ZCQ4K-gJYnNkiZlCEsT9YYI9dUd-T5qCirc/pubhtml
-submit an override suggestion: https://docs.google.com/forms/d/1kJH9Q0S8iqqULwrRqB9dSxMOMebZj6uZjECqi4t9_z0/edit"""
-
-EMBED_NOT_GENERATED = -1
+NICKNAME_FILE_PATTERN = CSV_FILE_PATTERN.format('nicknames')
+BASENAME_FILE_PATTERN = CSV_FILE_PATTERN.format('basenames')
 
 
-INFO_PDX_TEMPLATE = 'http://www.puzzledragonx.com/en/monster.asp?n={}'
-RPAD_PIC_TEMPLATE = 'https://f002.backblazeb2.com/file/miru-data/padimages/{}/full/{}.png'
-RPAD_PORTRAIT_TEMPLATE = 'https://f002.backblazeb2.com/file/miru-data/padimages/{}/portrait/{}.png'
-VIDEO_TEMPLATE = 'https://f002.backblazeb2.com/file/miru-data/padimages/animated/{}.mp4'
-GIF_TEMPLATE = 'https://f002.backblazeb2.com/file/miru-data/padimages/animated/{}.gif'
-
-YT_SEARCH_TEMPLATE = 'https://www.youtube.com/results?search_query={}'
-SKYOZORA_TEMPLATE = 'http://pad.skyozora.com/pets/{}'
-
-
-def get_pdx_url(m):
-    return INFO_PDX_TEMPLATE.format(rpadutils.get_pdx_id(m))
-
-
-def get_portrait_url(m):
-    if int(m.monster_no) != m.monster_no_na:
-        return RPAD_PORTRAIT_TEMPLATE.format('na', m.monster_no_na)
-    else:
-        return RPAD_PORTRAIT_TEMPLATE.format('jp', m.monster_no_jp)
-
-
-def get_pic_url(m):
-    if int(m.monster_no) != m.monster_no_na:
-        return RPAD_PIC_TEMPLATE.format('na', m.monster_no_na)
-    else:
-        return RPAD_PIC_TEMPLATE.format('jp', m.monster_no_jp)
-
-
-class PadInfo:
+class PadGuide2(object):
     def __init__(self, bot):
         self.bot = bot
+        self._is_ready = asyncio.Event(loop=self.bot.loop)
 
-        self.settings = PadInfoSettings("padinfo")
+        self.settings = PadGuide2Settings("padguide2")
+        self.reload_task = None
 
-        self.index_all = padguide2.empty_index()
-        self.index_na = padguide2.empty_index()
+        self._standard_refresh = [
+            PgAttribute,
+            PgAwakening,
+            PgDungeon,
+            # PgDungeonDamage,
+            PgDungeonMonsterDrop,
+            PgDungeonMonster,
+            # PgDungeonSkill,
+            # PgDungeonType,
+            PgEggInstance,
+            PgEggMonster,
+            PgEggName,
+            PgEvent,
+            PgEvolution,
+            PgEvolutionMaterial,
+            PgMonster,
+            PgMonsterAddInfo,
+            PgMonsterInfo,
+            PgMonsterPrice,
+            PgSeries,
+            PgSkillLeaderData,
+            PgSkill,
+            PgSkillRotation,
+            PgSkillRotationDated,
+            # PgSubDungeon,
+            PgType,
+        ]
 
-        self.menu = Menu(bot)
+        self._quick_refresh = [
+            PgScheduledEvent,
+        ]
 
-        # These emojis are the keys into the idmenu submenus
-        self.id_emoji = '\N{INFORMATION SOURCE}'
-        self.evo_emoji = char_to_emoji('e')
-        self.mats_emoji = char_to_emoji('m')
-        self.ls_emoji = '\N{INFORMATION SOURCE}'
-        self.left_emoji = char_to_emoji('l')
-        self.right_emoji = char_to_emoji('r')
-        self.pantheon_emoji = '\N{CLASSICAL BUILDING}'
-        self.skillups_emoji = '\N{MEAT ON BONE}'
-        self.pic_emoji = '\N{FRAME WITH PICTURE}'
-        self.other_info_emoji = '\N{SCROLL}'
+        # A string -> int mapping, nicknames to monster_id_na
+        self.nickname_overrides = {}
 
-        self.historic_lookups_file_path = "data/padinfo/historic_lookups.json"
-        if not dataIO.is_valid_json(self.historic_lookups_file_path):
-            print("Creating empty historic_lookups.json...")
-            dataIO.save_json(self.historic_lookups_file_path, {})
+        # An int -> set(string), monster_id_na to set of basename overrides
+        self.basename_overrides = defaultdict(set)
 
-        self.historic_lookups = dataIO.load_json(self.historic_lookups_file_path)
+        self.database = PgRawDatabase(skip_load=True)
+
+        # Map of google-translated JP names to EN names
+        self.translated_names = {}
+
+    @asyncio.coroutine
+    def wait_until_ready(self):
+        """Wait until the PadGuide2 cog is ready.
+
+        Call this from other cogs to wait until PadGuide2 finishes refreshing its database
+        for the first time.
+        """
+        yield from self._is_ready.wait()
+
+    def create_index(self, accept_filter=None):
+        """Exported function that allows a client cog to create a monster index"""
+        return MonsterIndex(self.database, self.nickname_overrides, self.basename_overrides, accept_filter=accept_filter)
+
+    def get_monster_by_no(self, monster_no: int):
+        """Exported function that allows a client cog to get a full PgMonster by monster_no"""
+        return self.database.getMonster(monster_no)
+
+    def get_translated_jp_name(self, jp_name):
+        return self.translate_names.get(jp_name, None)
+
+    def register_tasks(self):
+        self.reload_task = self.bot.loop.create_task(self.reload_data_task())
 
     def __unload(self):
         # Manually nulling out database because the GC for cogs seems to be pretty shitty
-        self.index_all = padguide2.empty_index()
-        self.index_na = padguide2.empty_index()
-        self.historic_lookups = {}
+        self.database = None
+        self._is_ready.clear()
 
-    async def reload_nicknames(self):
+    async def reload_data_task(self):
         await self.bot.wait_until_ready()
-        while self == self.bot.get_cog('PadInfo'):
-            try:
-                await self.refresh_index()
-                print('Done refreshing PadInfo')
-            except Exception as ex:
-                print("reload padinfo loop caught exception " + str(ex))
-                traceback.print_exc()
-
-            await asyncio.sleep(60 * 60 * 1)
-
-    async def refresh_index(self):
-        """Refresh the monster indexes."""
-        pg_cog = self.bot.get_cog('PadGuide2')
-        await pg_cog.wait_until_ready()
-        self.index_all = pg_cog.create_index()
-        self.index_na = pg_cog.create_index(lambda m: m.on_na)
-
-    def get_monster_by_no(self, monster_no: int):
-        pg_cog = self.bot.get_cog('PadGuide2')
-        return pg_cog.get_monster_by_no(monster_no)
-
-    @commands.command(pass_context=True)
-    async def skillrotation(self, ctx, server: str='NA'):
-        """Print the current rotating skillups for a server (NA/JP)"""
-        server = normalizeServer(server)
-        if server not in ['NA', 'JP']:
-            await self.bot.say(inline('Supported servers are NA, JP'))
-            return
-
-        pg_cog = self.bot.get_cog('PadGuide2')
-        monsters = pg_cog.database.rotating_skillups(server)
-
-        for page in pagify(monsters_to_rotation_list(monsters, server, self.index_all)):
-            await self.bot.say(box(page))
-
-    @commands.command(pass_context=True)
-    async def jpname(self, ctx, *, query: str):
-        """Print the Japanese name of a monster"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self.bot.say(monsterToHeader(m))
-            await self.bot.say(box(m.name_jp))
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-
-    @commands.command(name="id", pass_context=True)
-    async def _do_id_all(self, ctx, *, query: str):
-        """Monster info (main tab)"""
-        await self._do_id(ctx, query)
-
-    @commands.command(name="idna", pass_context=True)
-    async def _do_id_na_multiple_prefixes(self, ctx, *, query: str):
-        """Monster info (limited to NA monsters ONLY)"""
-        await self._do_id(ctx, query, na_only=True)
-
-    @commands.command(name="id2", pass_context=True)
-    async def _do_id_all_multiple_prefixes(self, ctx, *, query: str):
-        """Monster info (main tab)"""
-        await self._do_id(ctx, query, multiple_prefixes=True)
-
-    @commands.command(name="idna2", pass_context=True)
-    async def _do_id_na(self, ctx, *, query: str):
-        """Monster info (limited to NA monsters ONLY)"""
-        await self._do_id(ctx, query, na_only=True, multiple_prefixes=True)
-    
-    async def _do_id(self, ctx, query: str, na_only=False, multiple_prefixes=False):
-        m, err, debug_info = self.findMonster(query, na_only=na_only, multiple_prefixes=multiple_prefixes)
-        if m is not None:
-            await self._do_idmenu(ctx, m, self.id_emoji)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-
-    @commands.command(name="evos", pass_context=True)
-    async def evos(self, ctx, *, query: str):
-        """Monster info (evolutions tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self._do_idmenu(ctx, m, self.evo_emoji)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-
-    @commands.command(name="mats", pass_context=True, aliases=['evomats', 'evomat'])
-    async def evomats(self, ctx, *, query: str):
-        """Monster info (evo materials tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self._do_idmenu(ctx, m, self.mats_emoji)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-
-    @commands.command(pass_context=True)
-    async def pantheon(self, ctx, *, query: str):
-        """Monster info (pantheon tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            menu = await self._do_idmenu(ctx, m, self.pantheon_emoji)
-            if menu == EMBED_NOT_GENERATED:
-                await self.bot.say(inline('Not a pantheon monster'))
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-
-    @commands.command(pass_context=True)
-    async def skillups(self, ctx, *, query: str):
-        """Monster info (evolutions tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            menu = await self._do_idmenu(ctx, m, self.skillups_emoji)
-            if menu == EMBED_NOT_GENERATED:
-                await self.bot.say(inline('No skillups available'))
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-
-    async def _do_idmenu(self, ctx, m, starting_menu_emoji):
-        id_embed = monsterToEmbed(m, self.get_emojis())
-        evo_embed = monsterToEvoEmbed(m)
-        mats_embed = monsterToEvoMatsEmbed(m)
-        animated = self.check_monster_animated(m.monster_no_jp)
-        pic_embed = monsterToPicEmbed(m, animated=animated)
-        other_info_embed = monsterToOtherInfoEmbed(m)
-
-        emoji_to_embed = OrderedDict()
-        emoji_to_embed[self.id_emoji] = id_embed
-        emoji_to_embed[self.evo_emoji] = evo_embed
-        emoji_to_embed[self.mats_emoji] = mats_embed
-        emoji_to_embed[self.pic_emoji] = pic_embed
-
-        pantheon_embed = monsterToPantheonEmbed(m)
-        if pantheon_embed:
-            emoji_to_embed[self.pantheon_emoji] = pantheon_embed
-
-        skillups_embed = monsterToSkillupsEmbed(m)
-        if skillups_embed:
-            emoji_to_embed[self.skillups_emoji] = skillups_embed
-
-        emoji_to_embed[self.other_info_emoji] = other_info_embed
-
-        return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed)
-
-    async def _do_evolistmenu(self, ctx, sm):
-        monsters = sm.alt_evos
-        monsters.sort(key=lambda m: m.monster_no)
-
-        emoji_to_embed = OrderedDict()
-        for idx, m in enumerate(monsters):
-            emoji = char_to_emoji(str(idx))
-            emoji_to_embed[emoji] = monsterToEmbed(m, self.get_emojis())
-            if m == sm:
-                starting_menu_emoji = emoji
-
-        return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed, timeout=60)
-
-    async def _do_menu(self, ctx, starting_menu_emoji, emoji_to_embed, timeout=30):
-        if starting_menu_emoji not in emoji_to_embed:
-            # Selected menu wasn't generated for this monster
-            return EMBED_NOT_GENERATED
-
-        remove_emoji = self.menu.emoji['no']
-        emoji_to_embed[remove_emoji] = self.menu.reaction_delete_message
 
         try:
-            result_msg, result_embed = await self.menu.custom_menu(ctx, emoji_to_embed, starting_menu_emoji, timeout=timeout)
-            if result_msg and result_embed:
-                # Message is finished but not deleted, clear the footer
-                result_embed.set_footer(text=discord.Embed.Empty)
-                await self.bot.edit_message(result_msg, embed=result_embed)
+            # Try and load the PadGuide database the first time with existing files
+            self.database = PgRawDatabase(data_dir=self.settings.dataDir())
+            self._is_ready.set()
+            print('Finished initial PadGuide2 load with existing database')
         except Exception as ex:
-            print('Menu failure', ex)
+            print(ex)
+            print('Initial PadGuide2 database load failed, waiting for download')
 
-    @commands.command(pass_context=True, aliases=['img'])
-    async def pic(self, ctx, *, query: str):
-        """Monster info (full image tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self._do_idmenu(ctx, m, self.pic_emoji)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
+        while self == self.bot.get_cog('PadGuide2'):
+            short_wait = False
+            try:
+                await self.download_and_refresh_nicknames()
+                print('Done refreshing PadGuide2, triggering ready')
+                self._is_ready.set()
+            except Exception as ex:
+                short_wait = True
+                print("padguide2 data download/refresh failed", ex)
+                traceback.print_exc()
 
-    @commands.command(pass_context=True, aliases=['stats'])
-    async def otherinfo(self, ctx, *, query: str):
-        """Monster info (misc info tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self._do_idmenu(ctx, m, self.other_info_emoji)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
+            try:
+                await self.translate_names()
+            except Exception as ex:
+                print("translations failed", ex)
+                traceback.print_exc()
 
-    @commands.command(pass_context=True)
-    async def lookup(self, ctx, *, query: str):
-        """Short info results for a monster query"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            embed = monsterToHeaderEmbed(m)
-            await self.bot.say(embed=embed)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
+            try:
+                wait_time = 60 if short_wait else 60 * 60 * 4
+                await asyncio.sleep(wait_time)
+            except Exception as ex:
+                print("padguide2 data wait loop failed", ex)
+                traceback.print_exc()
+                raise ex
 
-    @commands.command(pass_context=True)
-    async def evolist(self, ctx, *, query):
-        """Monster info (for all monsters in the evo tree)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self._do_evolistmenu(ctx, m)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
+    async def reload_config_files(self):
+        os.remove(NICKNAME_FILE_PATTERN)
+        os.remove(BASENAME_FILE_PATTERN)
+        await self.download_and_refresh_nicknames()
 
-    @commands.command(pass_context=True, aliases=['leaders', 'leaderskills', 'ls'])
-    async def leaderskill(self, ctx, left_query: str, right_query: str=None, *, bad=None):
-        """Display the multiplier and leaderskills for two monsters
+    async def translate_names(self):
+        if os.path.exists(TRANSLATEDNAMES_EXPORT_PATH):
+            with open(TRANSLATEDNAMES_EXPORT_PATH) as f:
+                self.translated_names = json.load(f)
 
-        If either your left or right query contains spaces, wrap in quotes.
-        e.g.: ^leaderskill "r sonia" "b sonia"
-        """
-        if bad:
-            await self.bot.say(inline('Too many inputs. Try wrapping your queries in quotes.'))
-            return
+        for m in self.database.all_monsters():
+            name_jp = m.name_jp
+            if rpadutils.containsJp(name_jp) and name_jp not in self.translated_names:
+                self.translated_names[name_jp] = await rpadutils.translate_jp_en(self.bot, name_jp)
+            m.translated_jp_name = self.translated_names.get(name_jp, None)
 
-        # Handle a very specific failure case, user typing something like "uuvo ragdra"
-        if ' ' not in left_query and right_query is not None and ' ' not in right_query and bad is None:
-            combined_query = left_query + ' ' + right_query
-            nm, err, debug_info = self._findMonster(combined_query)
-            if nm and left_query in nm.prefixes:
-                left_query = combined_query
-                right_query = None
+        with open(TRANSLATEDNAMES_EXPORT_PATH, 'w', encoding='utf-8') as f:
+            json.dump(self.translated_names, f, sort_keys=True, indent=4)
 
-        left_m, left_err, _ = self.findMonster(left_query)
-        if right_query:
-            right_m, right_err, _ = self.findMonster(right_query)
-        else:
-            right_m, right_err, = left_m, left_err
+    async def download_and_refresh_nicknames(self):
+        if not self.settings.dataDir():
+            await self._download_files()
+        await self._download_override_files()
 
-        err_msg = '{} query failed to match a monster: [ {} ]. If your query is multiple words, wrap it in quotes.'
-        if left_err:
-            await self.bot.say(inline(err_msg.format('Left', left_query)))
-            return
-        if right_err:
-            await self.bot.say(inline(err_msg.format('Right', right_query)))
-            return
+        nickname_overrides = self._csv_to_tuples(NICKNAME_FILE_PATTERN)
+        basename_overrides = self._csv_to_tuples(BASENAME_FILE_PATTERN)
 
-        emoji_to_embed = OrderedDict()
-        emoji_to_embed[self.ls_emoji] = monstersToLsEmbed(left_m, right_m)
-        emoji_to_embed[self.left_emoji] = monsterToEmbed(left_m, self.get_emojis())
-        emoji_to_embed[self.right_emoji] = monsterToEmbed(right_m, self.get_emojis())
+        self.nickname_overrides = {x[0].lower(): int(x[1])
+                                   for x in nickname_overrides if x[1].isdigit()}
 
-        await self._do_menu(ctx, self.ls_emoji, emoji_to_embed)
+        self.basename_overrides = defaultdict(set)
+        for x in basename_overrides:
+            k, v = x
+            if k.isdigit():
+                self.basename_overrides[int(k)].add(v.lower())
 
-    @commands.command(name="helpid", pass_context=True, aliases=['helppic', 'helpimg'])
-    async def _helpid(self, ctx):
-        """Whispers you info on how to craft monster queries for ^id"""
-        await self.bot.whisper(box(HELP_MSG))
+        self.database = PgRawDatabase(data_dir=self.settings.dataDir())
+        self.index = MonsterIndex(self.database, self.nickname_overrides, self.basename_overrides)
 
-    @commands.command(pass_context=True)
-    async def padsay(self, ctx, server, *, query: str=None):
-        """Speak the voice line of a monster into your current chat"""
-        voice = ctx.message.author.voice
-        channel = voice.voice_channel
-        if channel is None:
-            await self.bot.say(inline('You must be in a voice channel to use this command'))
-            return
+        self.write_monster_attr_data()
+        self.write_monster_computed_names()
 
-        speech_cog = self.bot.get_cog('Speech')
-        if not speech_cog:
-            await self.bot.say(inline('Speech seems to be offline'))
-            return
+    def write_monster_computed_names(self):
+        results = {}
+        for name, nm in self.index.all_entries.items():
+            results[name] = int(rpadutils.get_pdx_id(nm))
 
-        if server.lower() not in ['na', 'jp']:
-            query = server + ' ' + (query or '')
-            server = 'na'
-        query = query.strip().lower()
+        with open(NAMES_EXPORT_PATH, 'w', encoding='utf-8') as f:
+            json.dump(results, f, sort_keys=True)
 
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            base_dir = '/home/tactical0retreat/pad_data/voices/fixed'
-            voice_file = os.path.join(base_dir, server, '{}.wav'.format(m.monster_no_na))
-            header = '{} ({})'.format(monsterToHeader(m), server)
-            if not os.path.exists(voice_file):
-                await self.bot.say(inline('Could not find voice for ' + header))
-                return
-            await self.bot.say('Speaking for ' + header)
-            await speech_cog.play_path(channel, voice_file)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
+        results = {}
+        for nm in self.index.all_monsters:
+            entry = {'bn': list(nm.group_basenames)}
+            if nm.extra_nicknames:
+                entry['nn'] = list(nm.extra_nicknames)
+            results[int(rpadutils.get_pdx_id(nm))] = entry
+
+        with open(BASENAMES_EXPORT_PATH, 'w', encoding='utf-8') as f:
+            json.dump(results, f, sort_keys=True)
+
+    def write_monster_attr_data(self):
+        """Write id,server,attr1,attr2 to be used by the portrait generation process."""
+        attr_short_prefix_map = {
+            Attribute.Fire: 'r',
+            Attribute.Water: 'b',
+            Attribute.Wood: 'g',
+            Attribute.Light: 'l',
+            Attribute.Dark: 'd',
+        }
+
+        # Monsters who exist only in na have the same na/jp id but differing monster_no
+        na_only = [x for x in self.database._monster_map.values() if x.monster_no !=
+                   x.monster_no_na and x.monster_no_na == x.monster_no_jp]
+
+        na_only_base_no = [x.monster_no for x in na_only]
+        na_only_server_no = [x.monster_no_na for x in na_only]
+
+        with open(ATTR_EXPORT_PATH, 'w') as csvfile:
+            writer = csv.writer(csvfile, delimiter=',', lineterminator='\n')
+            for m in self.database._monster_map.values():
+                attr1 = attr_short_prefix_map[m.attr1]
+                attr2 = attr_short_prefix_map[m.attr2] if m.attr2 else ''
+                if m.monster_no in na_only_base_no:
+                    # Writes stuff like voltron
+                    writer.writerow([m.monster_no_na, 'na', attr1, attr2])
+                elif m.monster_no_jp in na_only_server_no:
+                    # Writes stuff like crows
+                    writer.writerow([m.monster_no_jp, 'jp', attr1, attr2])
+                else:
+                    # writes everything else
+                    writer.writerow([m.monster_no_na, 'na', attr1, attr2])
+                    writer.writerow([m.monster_no_jp, 'jp', attr1, attr2])
+
+    def _csv_to_tuples(self, file_path: str, cols: int=2):
+        # Loads a two-column CSV into an array of tuples.
+        results = []
+        with open(file_path, encoding='utf-8') as f:
+            file_reader = csv.reader(f, delimiter=',')
+            for row in file_reader:
+                if len(row) < 2:
+                    continue
+
+                data = [None] * cols
+                for i in range(0, min(cols, len(row))):
+                    data[i] = row[i].strip()
+
+                if not len(data[0]):
+                    continue
+
+                results.append(data)
+        return results
+
+    async def _download_files(self):
+        # twelve hours expiry
+        standard_expiry_secs = 12 * 60 * 60
+        # four hours expiry
+        quick_expiry_secs = 4 * 60 * 60
+
+        # Use a dummy file to proxy for the entire database being out of date
+        general_dummy_file = DUMMY_FILE_PATTERN.format('general')
+        download_all = rpadutils.checkPadguideCacheFile(general_dummy_file, quick_expiry_secs)
+
+        async with aiohttp.ClientSession() as client_session:
+            for type in self._standard_refresh:
+                endpoint = type.file_name()
+                result_file = JSON_FILE_PATTERN.format(endpoint)
+                if download_all or rpadutils.should_download(result_file, quick_expiry_secs):
+                    await rpadutils.async_cached_padguide_request(client_session, endpoint, result_file)
+                    # Sleep to avoid overwhelming with requests
+                    await asyncio.sleep(1)
+
+            for type in self._quick_refresh:
+                cur_time = int(round(time.time() * 1000))
+                three_weeks_ago = cur_time - 3 * 7 * 24 * 60 * 60 * 1000
+                endpoint = type.file_name()
+                result_file = JSON_FILE_PATTERN.format(endpoint)
+                if download_all or rpadutils.should_download(result_file, quick_expiry_secs):
+                    await rpadutils.async_cached_padguide_request(client_session, endpoint, result_file, time_ms=three_weeks_ago)
+
+    async def _download_override_files(self):
+        overrides_expiry_secs = 1 * 60 * 60
+        await rpadutils.makeAsyncCachedPlainRequest(
+            NICKNAME_FILE_PATTERN, NICKNAME_OVERRIDES_SHEET, overrides_expiry_secs)
+        await rpadutils.makeAsyncCachedPlainRequest(
+            BASENAME_FILE_PATTERN, GROUP_BASENAMES_OVERRIDES_SHEET, overrides_expiry_secs)
 
     @commands.group(pass_context=True)
     @checks.is_owner()
-    async def padinfo(self, ctx):
-        """PAD info management"""
+    async def padguide2(self, ctx):
+        """PAD database management"""
         if ctx.invoked_subcommand is None:
             await send_cmd_help(ctx)
 
-    @padinfo.command(pass_context=True)
+    @padguide2.command(pass_context=True)
     @checks.is_owner()
-    async def setemojiservers(self, ctx, *, emoji_servers=''):
-        """Set the emoji servers by ID (csv)"""
-        self.settings.emojiServers().clear()
-        if emoji_servers:
-            self.settings.setEmojiServers(emoji_servers.split(','))
-        await self.bot.say(inline('Set {} servers'.format(len(self.settings.emojiServers()))))
-
-    def get_emojis(self):
-        server_ids = self.settings.emojiServers()
-        return [e for s in self.bot.servers if s.id in server_ids for e in s.emojis]
-
-    def makeFailureMsg(self, err):
-        msg = 'Lookup failed: {}.\n'.format(err)
-        msg += 'Try one of <id>, <name>, [argbld]/[rgbld] <name>. Unexpected results? Use ^helpid for more info.'
-        return box(msg)
-
-    def findMonster(self, query, na_only=False, multiple_prefixes=False):
-        query = rmdiacritics(query)
-        nm, err, debug_info = self._findMonster(query, na_only, multiple_prefixes)
-
-        monster_no = nm.monster_no if nm else -1
-        self.historic_lookups[query] = monster_no
-        dataIO.save_json(self.historic_lookups_file_path, self.historic_lookups)
-
-        m = self.get_monster_by_no(nm.monster_no) if nm else None
-
-        return m, err, debug_info
-
-    def _findMonster(self, query, na_only=False, multiple_prefixes=False):
-        monster_index = self.index_na if na_only else self.index_all
-        if multiple_prefixes:
-            return monster_index.find_monster_multiple_prefixes(query)
-        else:
-            return monster_index.find_monster(query)
-
-    def map_awakenings_text(self, m):
-        """Exported for use in other cogs"""
-        return _map_awakenings_text(m)
-
-    @padinfo.command(pass_context=True)
-    @checks.is_owner()
-    async def setanimationdir(self, ctx, *, animation_dir=''):
-        """Set a directory containing animated images"""
-        self.settings.setAnimationDir(animation_dir)
+    async def setdatadir(self, ctx, *, data_dir):
+        """Set a local path to padguide data instead of downloading it."""
+        self.settings.setDataDir(data_dir)
         await self.bot.say(inline('Done'))
 
-    def check_monster_animated(self, monster_id: int):
-        if not self.settings.animationDir():
-            return False
 
-        try:
-            animated_ids = set()
-            for f in os.listdir(self.settings.animationDir()):
-                f = f.replace('.mp4', '')
-                if f.isdigit() and int(f) == monster_id:
-                    return True
-        except:
-            pass
-
-        return False
-
-
-def setup(bot):
-    print('padinfo bot setup')
-    n = PadInfo(bot)
-    bot.add_cog(n)
-    bot.loop.create_task(n.reload_nicknames())
-    print('done adding padinfo bot')
-
-
-class PadInfoSettings(CogSettings):
+class PadGuide2Settings(CogSettings):
     def make_default_settings(self):
         config = {
-            'animation_dir': '',
+            'data_dir': '',
         }
         return config
 
-    def emojiServers(self):
-        key = 'emoji_servers'
-        if key not in self.bot_settings:
-            self.bot_settings[key] = []
-        return self.bot_settings[key]
+    def dataDir(self):
+        return self.bot_settings['data_dir']
 
-    def setEmojiServers(self, emoji_servers):
-        es = self.emojiServers()
-        es.clear()
-        es.extend(emoji_servers)
-        self.save_settings()
-
-    def animationDir(self):
-        return self.bot_settings['animation_dir']
-
-    def setAnimationDir(self, animation_dir):
-        self.bot_settings['animation_dir'] = animation_dir
+    def setDataDir(self, data_dir):
+        self.bot_settings['data_dir'] = data_dir
         self.save_settings()
 
 
-def monsterToHeader(m: padguide2.PgMonster, link=False):
-    msg = 'No. {} {}'.format(m.monster_no_na, m.name_na)
-    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
-
-
-def monsterToJpSuffix(m: padguide2.PgMonster):
-    suffix = ""
-    if m.roma_subname:
-        suffix += ' [{}]'.format(m.roma_subname)
-    if not m.on_na:
-        suffix += ' (JP only)'
-    return suffix
-
-
-def monsterToLongHeader(m: padguide2.PgMonster, link=False):
-    msg = monsterToHeader(m) + monsterToJpSuffix(m)
-    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
-
-
-def monsterToLongHeaderWithAttr(m: padguide2.PgMonster, link=False):
-    header = 'No. {} {} {}'.format(
-        m.monster_no_na,
-        "({}{})".format(attr_prefix_map[m.attr1], "/" +
-                        attr_prefix_map[m.attr2] if m.attr2 else ""),
-        m.name_na)
-    msg = header + monsterToJpSuffix(m)
-    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
-
-
-def monsterToEvoText(m: padguide2.PgMonster):
-    output = monsterToLongHeader(m)
-    for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
-        output += "\n\t- {}".format(monsterToLongHeader(ae))
-    return output
-
-
-def monsterToThumbnailUrl(m: padguide2.PgMonster):
-    return get_portrait_url(m)
-
-
-def monsterToBaseEmbed(m: padguide2.PgMonster):
-    header = monsterToLongHeader(m)
-    embed = discord.Embed()
-    embed.set_thumbnail(url=monsterToThumbnailUrl(m))
-    embed.title = header
-    embed.url = get_pdx_url(m)
-    embed.set_footer(text='Requester may click the reactions below to switch tabs')
-    return embed
-
-
-def monsterToEvoEmbed(m: padguide2.PgMonster):
-    embed = monsterToBaseEmbed(m)
-
-    if not len(m.alt_evos):
-        embed.description = 'No alternate evos'
-        return embed
-
-    field_name = '{} alternate evos'.format(len(m.alt_evos))
-    field_data = ''
-    for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
-        field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
-
-    embed.add_field(name=field_name, value=field_data)
-
-    return embed
-
-
-def monsterToEvoMatsEmbed(m: padguide2.PgMonster):
-    embed = monsterToBaseEmbed(m)
-
-    mats_for_evo_size = len(m.mats_for_evo)
-    material_of_size = len(m.material_of)
-
-    field_name = 'Evo materials'
-    field_data = ''
-    if mats_for_evo_size:
-        for ae in m.mats_for_evo:
-            field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
-    else:
-        field_data = 'None'
-    embed.add_field(name=field_name, value=field_data)
-
-    if not material_of_size:
-        return embed
-
-    field_name = 'Material for'
-    field_data = ''
-    if material_of_size > 5:
-        field_data = '{} monsters'.format(material_of_size)
-    else:
-        item_count = min(material_of_size, 5)
-        for ae in sorted(m.material_of, key=lambda x: x.monster_no_na, reverse=True)[:item_count]:
-            field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
-    embed.add_field(name=field_name, value=field_data)
-
-    return embed
-
-
-def monsterToPantheonEmbed(m: padguide2.PgMonster):
-    full_pantheon = m.series.monsters
-    pantheon_list = list(filter(lambda x: x.evo_from is None, full_pantheon))
-    if len(pantheon_list) == 0 or len(pantheon_list) > 6:
-        return None
-
-    embed = monsterToBaseEmbed(m)
-
-    field_name = 'Pantheon: ' + m.series.name
-    field_data = ''
-    for monster in sorted(pantheon_list, key=lambda x: x.monster_no_na):
-        field_data += '\n' + monsterToHeader(monster, link=True)
-    embed.add_field(name=field_name, value=field_data)
-
-    return embed
-
-
-def monsterToSkillupsEmbed(m: padguide2.PgMonster):
-    skillups_list = m.active_skill.monsters_with_active if m.active_skill else []
-    skillups_list = list(filter(lambda m: m.sell_mp < 3000, skillups_list))
-    server_skillups = m.active_skill.server_skillups if m.active_skill else []
-
-    if len(skillups_list) + len(server_skillups) == 0:
-        return None
-
-    embed = monsterToBaseEmbed(m)
-
-    skillups_to_skip = []
-    for server, skillup in server_skillups.items():
-        skillup_header = 'Skillup in ' + server
-        skillup_body = monsterToHeader(skillup, link=True)
-        embed.add_field(name=skillup_header, value=skillup_body)
-        skillups_to_skip.append(skillup.monster_no_na)
-
-    field_name = 'Skillups'
-    field_data = ''
-
-    # Prevent huge skillup lists
-    if len(skillups_list) > 8:
-        field_data = '({} skillups omitted)'.format(len(skillups_list) - 8)
-        skillups_list = skillups_list[0:8]
-
-    for monster in sorted(skillups_list, key=lambda x: x.monster_no_na):
-        if monster.monster_no_na in skillups_to_skip:
-            continue
-        field_data += '\n' + monsterToHeader(monster, link=True)
-
-    if len(field_data.strip()):
-        embed.add_field(name=field_name, value=field_data)
-
-    return embed
-
-
-def monsterToPicUrl(m: padguide2.PgMonster):
-    return get_pic_url(m)
-
-
-def monsterToPicEmbed(m: padguide2.PgMonster, animated=False):
-    embed = monsterToBaseEmbed(m)
-    url = monsterToPicUrl(m)
-    embed.set_image(url=url)
-    # Clear the thumbnail, don't need it on pic
-    embed.set_thumbnail(url='')
-    if animated:
-        description = '[{}]({}) –– [{}]({})'.format(
-            'HQ (MP4)', monsterToVideoUrl(m), 'LQ (GIF)', monsterToGifUrl(m))
-        embed.add_field(name='Animated links', value=description)
-
-    return embed
-
-
-def monsterToVideoUrl(m: padguide2.PgMonster):
-    return VIDEO_TEMPLATE.format(m.monster_no_jp)
-
-
-def monsterToGifUrl(m: padguide2.PgMonster):
-    return GIF_TEMPLATE.format(m.monster_no_jp)
-
-
-def monsterToGifEmbed(m: padguide2.PgMonster):
-    embed = monsterToBaseEmbed(m)
-    url = monsterToGifUrl(m)
-    embed.set_image(url=url)
-    # Clear the thumbnail, don't need it on pic
-    embed.set_thumbnail(url='')
-    return embed
-
-
-def monstersToLsEmbed(left_m: padguide2.PgMonster, right_m: padguide2.PgMonster):
-    lhp, latk, lrcv, lresist = left_m.leader_skill_data.get_data()
-    rhp, ratk, rrcv, rresist = right_m.leader_skill_data.get_data()
-    multiplier_text = createMultiplierText(lhp, latk, lrcv, lresist, rhp, ratk, rrcv, rresist)
-
-    embed = discord.Embed()
-    embed.title = 'Multiplier [{}]\n\n'.format(multiplier_text)
-    description = ''
-    description += '\n**{}**\n{}'.format(
-        monsterToHeader(left_m, link=True),
-        left_m.leader_skill.desc if left_m.leader_skill else 'None/Missing')
-    description += '\n**{}**\n{}'.format(
-        monsterToHeader(right_m, link=True),
-        right_m.leader_skill.desc if right_m.leader_skill else 'None/Missing')
-    embed.description = description
-
-    return embed
-
-
-def monsterToHeaderEmbed(m: padguide2.PgMonster):
-    header = monsterToLongHeader(m, link=True)
-    embed = discord.Embed()
-    embed.description = header
-    return embed
-
-
-def monsterToTypeString(m: padguide2.PgMonster):
-    output = m.type1
-    if m.type2:
-        output += '/' + m.type2
-    if m.type3:
-        output += '/' + m.type3
-    return output
-
-
-def monsterToAcquireString(m: padguide2.PgMonster):
-    acquire_text = None
-    if m.farmable and not m.mp_evo:
-        # Some MP shop monsters 'drop' in PADR
-        acquire_text = 'Farmable'
-    elif m.farmable_evo and not m.mp_evo:
-        acquire_text = 'Farmable Evo'
-    elif m.in_pem:
-        acquire_text = 'In PEM'
-    elif m.pem_evo:
-        acquire_text = 'PEM Evo'
-    elif m.in_rem:
-        acquire_text = 'In REM'
-    elif m.rem_evo:
-        acquire_text = 'REM Evo'
-    elif m.in_mpshop:
-        acquire_text = 'MP Shop'
-    elif m.mp_evo:
-        acquire_text = 'MP Shop Evo'
-    return acquire_text
-
-
-def match_emoji(emoji_list, name):
-    for e in emoji_list:
-        if e.name == name:
-            return e
-    return None
-
-
-def monsterToEmbed(m: padguide2.PgMonster, emoji_list):
-    embed = monsterToBaseEmbed(m)
-
-    info_row_1 = monsterToTypeString(m)
-    acquire_text = monsterToAcquireString(m)
-
-    info_row_2 = '**Rarity** {}\n**Cost** {}'.format(m.rarity, m.cost)
-    if acquire_text:
-        info_row_2 += '\n**{}**'.format(acquire_text)
-    if m.is_inheritable:
-        info_row_2 += '\n**Inheritable**'
-    else:
-        info_row_2 += '\n**Not inheritable**'
-
-    embed.add_field(name=info_row_1, value=info_row_2)
-
-    if m.limitbreak_stats and m.limitbreak_stats > 1:
-        def lb(x): return int(round(m.limitbreak_stats * x))
-        stats_row_1 = 'Weighted {} | LB {}'.format(m.weighted_stats, lb(m.weighted_stats))
-        stats_row_2 = '**HP** {} ({})\n**ATK** {} ({})\n**RCV** {} ({})'.format(
-            m.hp, lb(m.hp), m.atk, lb(m.atk), m.rcv, lb(m.rcv))
-    else:
-        stats_row_1 = 'Weighted {}'.format(m.weighted_stats)
-        stats_row_2 = '**HP** {}\n**ATK** {}\n**RCV** {}'.format(m.hp, m.atk, m.rcv)
-    embed.add_field(name=stats_row_1, value=stats_row_2)
-
-    awakenings_row = ''
-    for idx, a in enumerate(m.awakenings):
-        a = a.get_name()
-        mapped_awakening = AWAKENING_NAME_MAP_RPAD.get(a, a)
-        mapped_awakening = match_emoji(emoji_list, mapped_awakening)
-
-        if mapped_awakening is None:
-            mapped_awakening = AWAKENING_NAME_MAP.get(a, a)
-
-        # Wrap superawakenings to the next line
-        if len(m.awakenings) - idx == m.superawakening_count:
-            awakenings_row += '\n{}'.format(mapped_awakening)
+def setup(bot):
+    n = PadGuide2(bot)
+    bot.add_cog(n)
+    n.register_tasks()
+
+
+class PgRawDatabase(object):
+    def __init__(self, skip_load=False, data_dir=None):
+        self._skip_load = skip_load
+        self._data_dir = data_dir
+        self._all_pg_items = []
+
+        # Load raw data items into id->value maps
+        self._attribute_map = self._load(PgAttribute)
+        self._awakening_map = self._load(PgAwakening)
+        self._dungeon_map = self._load(PgDungeon)
+        # self._dungeon_damage_map = self._load(PgDungeonDamage)
+        self._dungeon_monster_drop_map = self._load(PgDungeonMonsterDrop)
+        self._dungeon_monster_map = self._load(PgDungeonMonster)
+        # self._dungeon_skill_map = self._load(PgDungeonSkill)
+        # self._dungeon_type_map = self._load(PgDungeonType)
+        self._event_map = self._load(PgEvent)
+        self._evolution_map = self._load(PgEvolution)
+        self._evolution_material_map = self._load(PgEvolutionMaterial)
+        self._monster_map = self._load(PgMonster)
+        self._monster_add_info_map = self._load(PgMonsterAddInfo)
+        self._monster_info_map = self._load(PgMonsterInfo)
+        self._monster_price_map = self._load(PgMonsterPrice)
+        self._series_map = self._load(PgSeries)
+        self._scheduled_event_map = self._load(PgScheduledEvent)
+        self._skill_leader_data_map = self._load(PgSkillLeaderData)
+        self._skill_map = self._load(PgSkill)
+        self._skill_rotation_map = self._load(PgSkillRotation)
+        self._skill_rotation_dated_map = self._load(PgSkillRotationDated)
+        # self._sub_dungeon_map = self._load(PgSubDungeon)
+        self._type_map = self._load(PgType)
+
+        self._egg_instance_map = self._load(PgEggInstance)
+        self._egg_monster_map = self._load(PgEggMonster)
+        self._egg_name_map = self._load(PgEggName)
+
+        # Ensure that every item has loaded its dependencies
+        for i in self._all_pg_items:
+            self._ensure_loaded(i)
+
+        # Finish loading now that all the dependencies are resolved
+        for i in self._all_pg_items:
+            i.finalize()
+
+        # Stick the monsters into groups so that we can calculate info across
+        # the entire group
+        self.grouped_monsters = list()
+        for m in self._monster_map.values():
+            if m.cur_evo_type != EvoType.Base:
+                continue
+            self.grouped_monsters.append(MonsterGroup(m))
+
+        # Used to normalize from monster NA values back to monster number
+        self.monster_no_na_to_monster_no = {
+            m.monster_no_na: m.monster_no for m in self._monster_map.values()}
+
+        # Skill rotation map
+        self._server_to_rotating_skillups = {
+            'NA': [],
+            'JP': [],
+        }
+        for m in self._monster_map.values():
+            for server in m.server_actives:
+                self._server_to_rotating_skillups[server].append(m)
+
+    def _load(self, itemtype):
+        if self._skip_load:
+            return {}
+
+        if self._data_dir:
+            file_path = os.path.join(self._data_dir, '{}.json'.format(itemtype.file_name()))
         else:
-            awakenings_row += ' {}'.format(mapped_awakening)
+            file_path = JSON_FILE_PATTERN.format(itemtype.file_name())
+        item_list = []
 
-    awakenings_row = awakenings_row.strip()
+        if dataIO.is_valid_json(file_path):
+            json_data = dataIO.load_json(file_path)
+            item_list = [itemtype(item) for item in json_data['items']]
 
-    if not len(awakenings_row):
-        awakenings_row = 'No Awakenings'
+        result_map = {item.key(): item for item in item_list if not item.deleted()}
 
-    killers = compute_killers(m.type1, m.type2, m.type3)
-    killers_row = '**Available Killers:** {}'.format(' '.join(killers))
+        self._all_pg_items.extend(result_map.values())
 
-    embed.description = '{}\n{}'.format(awakenings_row, killers_row)
+        return result_map
 
-    if len(m.server_actives) >= 2:
-        for server, active in m.server_actives.items():
-            active_header = '({} Server) Active Skill ({} -> {})'.format(server,
-                                                                         active.turn_max, active.turn_min)
-            active_body = active.desc
-            embed.add_field(name=active_header, value=active_body, inline=False)
-    else:
-        active_header = 'Active Skill'
-        active_body = 'None/Missing'
-        if m.active_skill:
-            active_header = 'Active Skill ({} -> {})'.format(m.active_skill.turn_max,
-                                                             m.active_skill.turn_min)
-            active_body = m.active_skill.desc
-        embed.add_field(name=active_header, value=active_body, inline=False)
+    def _ensure_loaded(self, item: 'PgItem'):
+        if item:
+            item.ensure_loaded(self)
+        return item
 
-    ls_row = m.leader_skill.desc if m.leader_skill else 'None/Missing'
-    ls_header = 'Leader Skill'
-    if m.leader_skill_data:
-        hp, atk, rcv, resist = m.leader_skill_data.get_data()
-        multiplier_text = createMultiplierText(hp, atk, rcv, resist)
-        ls_header += " [ {} ]".format(multiplier_text)
-    embed.add_field(name=ls_header, value=ls_row, inline=False)
+    def normalize_monster_no_na(self, monster_no_na: int):
+        if monster_no_na > 10000:
+            # Allows crows to be referenced
+            return monster_no_na - 10000
+        return self.monster_no_na_to_monster_no[monster_no_na]
 
-    return embed
+    def all_monsters(self):
+        """Exported for access to the full monster list."""
+        return list(self._monster_map.values())
+
+    def all_dungeons(self):
+        """Exported for access to the full dungeon list."""
+        return list(self._dungeon_map.values())
+
+    def all_egg_instances(self):
+        """Exported for access to the full egg machine list."""
+        return list(self._egg_instance_map.values())
+
+    def all_scheduled_events(self):
+        """Exported for access to event list."""
+        se = list(self._scheduled_event_map.values())
+        return se
+
+    def rotating_skillups(self, server: str):
+        """Gets monsters used as rotating skillups for the specified server"""
+        return list(self._server_to_rotating_skillups[server])
+
+    def getAttributeEnum(self, ta_seq: int):
+        attr = self._ensure_loaded(self._attribute_map.get(ta_seq))
+        return attr.value if attr else None
+
+    def getAwakening(self, tma_seq: int):
+        return self._ensure_loaded(self._awakening_map.get(tma_seq))
+
+    def getDungeon(self, dungeon_seq: int):
+        return self._ensure_loaded(self._dungeon_map.get(dungeon_seq))
+
+#    def getDungeonDamage(self, tds_seq: int):
+#        return self._ensure_loaded(self._dungeon_damage_map.get(tds_seq))
+
+    def getDungeonMonsterDrop(self, tdmd_seq: int):
+        return self._ensure_loaded(self._dungeon_monster_drop_map.get(tdmd_seq))
+
+    def getDungeonMonster(self, tdm_seq: int):
+        return self._ensure_loaded(self._dungeon_monster_map.get(tdm_seq))
+
+#    def getDungeonType(self, tdt_seq: int):
+#        return self._ensure_loaded(self._dungeon_type_map.get(tdt_seq))
+
+    def getEvent(self, event_seq: int):
+        return self._ensure_loaded(self._event_map.get(event_seq))
+
+    def getEvolution(self, tv_seq: int):
+        return self._ensure_loaded(self._evolution_map.get(tv_seq))
+
+    def getEvolutionMaterial(self, tem_seq: int):
+        return self._ensure_loaded(self._evolution_material_map.get(tem_seq))
+
+    def getMonster(self, monster_no: int):
+        return self._ensure_loaded(self._monster_map.get(monster_no))
+
+    def getMonsterAddInfo(self, monster_no: int):
+        return self._ensure_loaded(self._monster_add_info_map.get(monster_no))
+
+    def getMonsterInfo(self, monster_no: int):
+        return self._ensure_loaded(self._monster_info_map.get(monster_no))
+
+    def getMonsterPrice(self, monster_no: int):
+        return self._ensure_loaded(self._monster_price_map.get(monster_no))
+
+    def getSeries(self, tsr_seq: int):
+        return self._ensure_loaded(self._series_map.get(tsr_seq))
+
+    def getScheduledEvent(self, schedule_seq: int):
+        return self._ensure_loaded(self._scheduled_event_map.get(schedule_seq))
+
+    def getSkill(self, ts_seq: int):
+        return self._ensure_loaded(self._skill_map.get(ts_seq))
+
+    def getSkillLeaderData(self, ts_seq: int):
+        skill_leader = self._skill_leader_data_map.get(ts_seq)
+        if skill_leader:
+            return self._ensure_loaded(skill_leader)
+        else:
+            return PgSkillLeaderData.empty()
+
+    def getSkillRotation(self, tsr_seq: int):
+        return self._ensure_loaded(self._skill_rotation_map.get(tsr_seq))
+
+    def getSkillRotationDated(self, tsrl_seq: int):
+        return self._ensure_loaded(self._skill_rotation_dated_map.get(tsrl_seq))
+
+#    def getSubDungeon(self, tsd_seq: int):
+#        return self._ensure_loaded(self._sub_dungeon_map.get(tsd_seq))
+
+    def getTypeName(self, tt_seq: int):
+        type = self._ensure_loaded(self._type_map.get(tt_seq))
+        return type.name if type else None
+
+    def getEggInstance(self, tet_seq: int):
+        return self._ensure_loaded(self._egg_instance_map.get(tet_seq))
+
+    def getEggMonster(self, tem_seq: int):
+        return self._ensure_loaded(self._egg_monster_map.get(tem_seq))
+
+    def getEggName(self, tetn_seq: int):
+        return self._ensure_loaded(self._egg_name_map.get(tetn_seq))
 
 
-def monsterToOtherInfoEmbed(m: padguide2.PgMonster):
-    embed = monsterToBaseEmbed(m)
-    # Clear the thumbnail, takes up too much space
-    embed.set_thumbnail(url='')
+class PgItem(object):
+    """Base class for all items loaded from PadGuide.
 
-    stat_cols = ['', 'Max', 'M297', 'Inh', 'I297']
-    tbl = prettytable.PrettyTable(stat_cols)
-    tbl.hrules = prettytable.NONE
-    tbl.vrules = prettytable.NONE
-    tbl.align = "r"
-    hhp = m.hp + 99 * 10
-    hatk = m.atk + 99 * 5
-    hrcv = m.rcv + 99 * 3
-    tbl.add_row(['HP', m.hp, hhp, int(m.hp * .1), int(hhp * .1)])
-    tbl.add_row(['ATK', m.atk, hatk, int(m.atk * .05), int(hatk * .05)])
-    tbl.add_row(['RCV', m.rcv, hrcv, int(m.rcv * .15), int(hrcv * .15)])
+    You must call super().__init__() in your constructor.
+    You must override key() and load().
+    """
 
-    body_text = box(tbl.get_string())
+    def __init__(self):
+        self._loaded = False
 
-    search_text = YT_SEARCH_TEMPLATE.format(m.name_jp)
-    skyozora_text = SKYOZORA_TEMPLATE.format(m.monster_no_jp)
-    body_text += "\n**JP Name**: {} | [YouTube]({}) | [Skyozora]({})".format(
-        m.name_jp, search_text, skyozora_text)
+    def key(self):
+        """Used to look up an item by id."""
+        raise NotImplementedError()
 
-    if m.history_us:
-        body_text += '\n**History:** {}'.format(m.history_us)
+    def deleted(self):
+        """Is this item marked for deletion. Discard if true. Not all items can be deleted."""
+        return False
 
-    body_text += '\n**Series:** {}'.format(m.series.name)
-    body_text += '\n**Sell MP:** {:,}'.format(m.sell_mp)
-    if m.buy_mp > 0:
-        body_text += "  **Buy MP:** {:,}".format(m.buy_mp)
+    def ensure_loaded(self, database: PgRawDatabase):
+        """Ensures that the dependencies have been loaded, or loads them."""
+        if not self._loaded:
+            self._loaded = True
+            self._loading_error = False
+            try:
+                self.load(database)
+            except Exception as ex:
+                self._loading_error = False
+                print('Error occurred while loading item')
+                print(type(self), 'key=', self.key())
+                traceback.print_exc()
 
-    if m.exp < 1000000:
-        xp_text = '{:,}'.format(m.exp)
-    else:
-        xp_text = '{:.1f}'.format(m.exp / 1000000).rstrip('0').rstrip('.') + 'M'
-    body_text += '\n**XP to Max:** {}'.format(xp_text)
-    body_text += '  **Max Level:**: {}'.format(m.max_level)
-    body_text += '\n**Rarity:** {} **Cost:** {}'.format(m.rarity, m.cost)
+        return self
 
-    if m.translated_jp_name:
-        body_text += '\n**Google Translated:** {}'.format(m.translated_jp_name)
+    def load(self, database: PgRawDatabase):
+        """Override to inject dependencies."""
+        raise NotImplementedError()
 
-    embed.description = body_text
-
-    return embed
+    def finalize(self):
+        """Finish filling in anything that requires completion but no dependencies."""
+        pass
 
 
-def monsters_to_rotation_list(monster_list, server: str, index_all: padguide2.MonsterIndex):
-    # Shorten some of the longer names
-    name_remap = {
-        'Extreme King Metal Tamadra': 'Fat Tama',
-        'Extreme King Metal Dragon': 'EKMD',
-        'Ancient Green Sacred Mask': 'Green Mask',
-        'Ancient Blue Sacred Mask': 'Blue Mask',
-    }
-    ignore_monsters = [
-        'Ancient Draggie Knight',
-    ]
+class Attribute(Enum):
+    """Standard 5 PAD colors in enum form. Values correspond to PadGuide values."""
+    Fire = 1
+    Water = 2
+    Wood = 3
+    Light = 4
+    Dark = 5
 
-    monster_list.sort(key=lambda m: m.monster_no, reverse=True)
-    next_rotation_date = None
-    for m in monster_list:
-        if server in m.future_skillup_rotation:
-            next_rotation_date = m.future_skillup_rotation[server].rotation_date_str
-            break
 
-    cols = [server + ' Skillup', 'Current']
-    if next_rotation_date:
-        cols.append(next_rotation_date)
-    tbl = prettytable.PrettyTable(cols)
-    tbl.hrules = prettytable.HEADER
-    tbl.vrules = prettytable.NONE
-    tbl.align = "l"
+# attributeList
+# {
+#     "ORDER_IDX": "2",
+#     "TA_NAME_JP": "\u6c34",
+#     "TA_NAME_KR": "\ubb3c",
+#     "TA_NAME_US": "Water",
+#     "TA_SEQ": "2",
+#     "TSTAMP": "1372947975226"
+# },
+class PgAttribute(PgItem):
+    @staticmethod
+    def file_name():
+        return 'attributeList'
 
-    def cell_name(m: padguide2.PgMonster):
-        nm = index_all.monster_no_to_named_monster[m.monster_no]
-        name = nm.group_computed_basename.title()
-        return name_remap.get(name, name)
+    def __init__(self, item):
+        super().__init__()
+        self.ta_seq = int(item['TA_SEQ'])  # unique id
+        self.name = item['TA_NAME_US']
 
-    for m in monster_list:
-        skill = m.server_actives[server]
+        self.value = Attribute(self.ta_seq)
 
-        sm = skill.monsters_with_active
-        # Since some newer monsters like jewel of creation are being used as
-        # skillups, exclude them from the list of skillup targets.
+    def key(self):
+        return self.ta_seq
 
-        def is_bad_type(m):
-            return set(['enhance', 'evolve', 'vendor']).intersection(set(m.types))
-        sm = max(sm, key=lambda x: (not is_bad_type(x), x.monster_no))
+    def load(self, database: PgRawDatabase):
+        pass
 
-        skillup_name = cell_name(m)
-        if skillup_name in ignore_monsters:
-            continue
-        row = [skillup_name, cell_name(sm)]
-        if next_rotation_date:
-            if server in m.future_skillup_rotation:
-                next_skill = m.future_skillup_rotation[server].skill
-                nm = max(next_skill.monsters_with_active, key=lambda x: x.monster_no)
-                row.append(cell_name(nm))
+
+# awokenSkillList
+# {
+#     "DEL_YN": "N",
+#     "IS_SUPER": "1",
+#     "MONSTER_NO": "661",
+#     "ORDER_IDX": "1",
+#     "TMA_SEQ": "1",
+#     "TSTAMP": "1380587210665",
+#     "TS_SEQ": "2769"
+# },
+class PgAwakening(PgItem):
+    @staticmethod
+    def file_name():
+        return 'awokenSkillList'
+
+    def __init__(self, item):
+        super().__init__()
+        self.tma_seq = int(item['TMA_SEQ'])  # unique id
+        self.ts_seq = int(item['TS_SEQ'])  # PgSkill id - awakening info
+        self.deleted_yn = item['DEL_YN']  # Either Y(discard) or N.
+        self.monster_no = int(item['MONSTER_NO'])  # PgMonster id - monster this belongs to
+        self.order = int(item['ORDER_IDX'])  # display order
+        self.is_super = item.get('IS_SUPER', '0') == '1'
+
+        self.skill = None  # type: PgSkill  # The awakening skill
+        self.monster = None  # type: PgMonster # The monster the awakening belongs to
+
+    def key(self):
+        return self.tma_seq
+
+    def deleted(self):
+        return self.deleted_yn == 'Y'
+
+    def load(self, database: PgRawDatabase):
+        self.skill = database.getSkill(self.ts_seq)
+        self.monster = database.getMonster(self.monster_no)
+
+        self.monster.awakenings.append(self)
+        self.skill.monsters_with_awakening.append(self.monster)
+
+    def get_name(self):
+        return self.skill.name
+
+
+# dungeonList
+# {
+#     "APP_VERSION": "",
+#     "COMMENT_JP": "",
+#     "COMMENT_KR": "",
+#     "COMMENT_US": "",
+#     "DUNGEON_SEQ": "102",
+#     "DUNGEON_TYPE": "1",
+#     "ICON_SEQ": "666",
+#     "NAME_JP": "ECO\u30b3\u30e9\u30dc",
+#     "NAME_KR": "ECO \ucf5c\ub77c\ubcf4",
+#     "NAME_US": "ECO Collab",
+#     "ORDER_IDX": "3",
+#     "SHOW_YN": "1",
+#     "TDT_SEQ": "10",
+#     "TSTAMP": "1373289123410"
+# },
+class PgDungeon(PgItem):
+    @staticmethod
+    def file_name():
+        return 'dungeonList'
+
+    def __init__(self, item):
+        super().__init__()
+        self.dungeon_seq = int(item['DUNGEON_SEQ'])
+        self.dungeon_type = int(item['DUNGEON_TYPE'])
+        # TODO: merge these two, delete DungeonType from padevents
+        self.dungeon_type_value = DungeonType(self.dungeon_type)
+        self.name = item['NAME_US']
+        self.name_jp = item['NAME_JP']
+        # TODO: load tdt type
+        self.tdt_seq = int_or_none(item['TDT_SEQ'])
+        self.show = item['SHOW_YN'] == 1
+        self.icon = int(item['ICON_SEQ'])
+
+        self.tdungeon_type = None
+        self.tdungeon_type_name = 'no_type'
+
+        self.monsters = []
+        self.subdungeons = []
+
+    def key(self):
+        return self.dungeon_seq
+
+    def deleted(self):
+        return False
+#         return not self.show
+
+    def load(self, database: PgRawDatabase):
+        pass
+#        if self.tdt_seq:
+#            self.tdungeon_type = database.getDungeonType(self.tdt_seq)
+#            # Somehow this can still fail
+#            if self.tdungeon_type:
+#                self.tdungeon_type_name = self.tdungeon_type.name
+
+
+class DungeonType(Enum):
+    Unknown = -1
+    Normal = 0
+    CoinDailyOther = 1
+    Technical = 2
+    Etc = 3
+
+
+# {
+#     "COIN_MAX": "2496",
+#     "COIN_MIN": "2496",
+#     "DUNGEON_SEQ": "81",
+#     "EXP_MAX": "2420",
+#     "EXP_MIN": "2420",
+#     "ORDER_IDX": "96",
+#     "STAGE": "5",
+#     "STAMINA": "15",
+#     "TSD_NAME_JP": "\u65ad\u7f6a\u306e\u7114 \u4e2d\u7d1a",
+#     "TSD_NAME_KR": "\ub2e8\uc8c4\uc758 \ubd88\uaf43 \uc911\uae09",
+#     "TSD_NAME_US": "Flame of Conviction - Int",
+#     "TSD_SEQ": "1365",
+#     "TSTAMP": "1373446281337"
+# },
+class PgSubDungeon(PgItem):
+    @staticmethod
+    def file_name():
+        return 'subDungeonList'
+
+    def __init__(self, item):
+        super().__init__()
+        self.dungeon_seq = int(item['DUNGEON_SEQ'])
+        self.exp_max = int(item['EXP_MAX'])
+        self.exp_min = int(item['EXP_MIN'])
+        self.order = int(item['ORDER_IDX'])
+        self.stage = int(item['STAGE'])
+        self.stamina = int(item['STAMINA'])
+        self.name = item['TSD_NAME_US']
+        self.tsd_seq = int(item['TSD_SEQ'])
+
+        self.monsters = []
+        self.floor_to_monsters = defaultdict(list)
+
+    def key(self):
+        return self.tsd_seq
+
+    def load(self, database: PgRawDatabase):
+        self.dungeon = database.getDungeon(self.dungeon_seq)
+        self.dungeon.subdungeons.append(self)
+
+
+# dungeonMonsterDropList.jsp
+# {
+#     "MONSTER_NO": "3427",
+#     "ORDER_IDX": "20",
+#     "STATUS": "0",
+#     "TDMD_SEQ": "967",
+#     "TDM_SEQ": "17816",
+#     "TSTAMP": "1489371218890"
+# },
+# Seems to be dedicated skillups only, like collab drops
+class PgDungeonMonsterDrop(PgItem):
+    @staticmethod
+    def file_name():
+        return 'dungeonMonsterDropList'
+
+    def __init__(self, item):
+        super().__init__()
+        self.tdmd_seq = int(item['TDMD_SEQ'])  # unique id
+        self.monster_no = int(item['MONSTER_NO'])
+        self.status = item['STATUS']  # if 1, good, if 0, bad
+        self.tdm_seq = int(item['TDM_SEQ'])  # PgDungeonMonster id
+
+        self.monster = None  # type: PgMonster
+        self.dungeon_monster = None  # type: PgDungeonMonster
+
+    def key(self):
+        return self.tdmd_seq
+
+    def deleted(self):
+        # TODO: Should we be checking status == 1?
+        return False
+
+    def load(self, database: PgRawDatabase):
+        self.monster = database.getMonster(self.monster_no)
+        self.dungeon_monster = database.getDungeonMonster(self.tdm_seq)
+
+
+# dungeonMonsterList
+# {
+#     "AMOUNT": "1",
+#     "ATK": "9810",
+#     "COMMENT_JP": "",
+#     "COMMENT_KR": "",
+#     "COMMENT_US": "",
+#     "DEF": "340",
+#     "DROP_NO": "2789",
+#     "DUNGEON_SEQ": "150",
+#     "FLOOR": "5",
+#     "HP": "3011250",
+#     "MONSTER_NO": "2789",
+#     "ORDER_IDX": "50",
+#     "TDM_SEQ": "53122",
+#     "TSD_SEQ": "4564",
+#     "TSTAMP": "1480298353178",
+#     "TURN": "1"
+# },
+class PgDungeonMonster(PgItem):
+    @staticmethod
+    def file_name():
+        return 'dungeonMonsterList'
+
+    def __init__(self, item):
+        super().__init__()
+        self.tdm_seq = int(item['TDM_SEQ'])  # unique id
+        self.amount = int(item['AMOUNT'])
+        self.atk = int(item['ATK'])
+        self.defence = int(item['DEF'])
+        self.drop_monster_no = int(item['DROP_NO'])  # PgMonster unique id
+        self.dungeon_seq = int(item['DUNGEON_SEQ'])  # PgDungeon uniqueId
+        self.floor = int(item['FLOOR'])
+        self.hp = int(item['HP'])
+        self.monster_no = int(item['MONSTER_NO'])  # PgMonster unique id
+        self.order = int(item['ORDER_IDX'])
+        self.tsd_seq = int(item['TSD_SEQ'])  # Sub Dungeon ID
+        self.turn = int(item['TURN'])
+
+        self.skills = []
+
+    def key(self):
+        return self.tdm_seq
+
+    def load(self, database: PgRawDatabase):
+        self.monster = database.getMonster(self.monster_no)
+
+        self.dungeon = database.getDungeon(self.dungeon_seq)
+        if self.dungeon:
+            self.dungeon.monsters.append(self)
+
+#         self.sub_dungeon = database.getSubDungeon(self.tsd_seq)
+#         self.sub_dungeon.monsters.append(self)
+#         self.sub_dungeon.floor_to_monsters[self.floor].append(self)
+
+        self.drop_monster = database.getMonster(self.drop_monster_no)
+        if self.drop_monster and self.dungeon:
+            self.drop_monster.drop_dungeons.append(self.dungeon)
+
+
+# {
+#     "TDM_SEQ": "15044", # dungeon monster
+#     "TDS_SEQ": "8934", # damage
+#     "TSTAMP": "100",
+#     "TS_SEQ": "2190" # skill
+# },
+class PgDungeonSkill(PgItem):
+    @staticmethod
+    def file_name():
+        return 'dungeonSkillList'
+
+    def __init__(self, item):
+        super().__init__()
+        self.tdm_seq = int(item['TDM_SEQ'])
+        self.tds_seq = int(item['TDS_SEQ'])
+        self.ts_seq = int(item['TS_SEQ'])
+
+    def key(self):
+        return '{},{},{}'.format(self.tdm_seq, self.tds_seq, self.ts_seq)
+
+    def load(self, database: PgRawDatabase):
+        self.dungeon_monster = database.getDungeonMonster(self.tdm_seq)
+        if self.dungeon_monster:
+            self.dungeon_monster.skills.append(self)
+        self.damage = database.getDungeonDamage(self.tds_seq)
+        self.skill = database.getSkill(self.ts_seq)
+
+
+# {
+#     "DAMAGE": "16538.0",
+#     "TDS_SEQ": "14631",
+#     "TSTAMP": "1401764306350"
+# },
+class PgDungeonDamage(PgItem):
+    @staticmethod
+    def file_name():
+        return 'dungeonSkillDamageList'
+
+    def __init__(self, item):
+        super().__init__()
+        self.tds_seq = int(item['TDS_SEQ'])
+        self.amount = float(item['DAMAGE'])
+
+        self.monsters = []
+        self.floor_to_monsters = defaultdict(list)
+
+    def key(self):
+        return self.tds_seq
+
+    def load(self, database: PgRawDatabase):
+        pass
+
+
+# {
+#     "ORDER_IDX": "120",
+#     "TDT_NAME_JP": "\u30a2\u30f3\u30b1\u30fc\u30c8",
+#     "TDT_NAME_KR": "\uc559\ucf00\uc774\ud2b8",
+#     "TDT_NAME_US": "Survey",
+#     "TDT_SEQ": "9",
+#     "TSTAMP": "1388128221704"
+# },
+class PgDungeonType(PgItem):
+    @staticmethod
+    def file_name():
+        return 'dungeonTypeList'
+
+    def __init__(self, item):
+        super().__init__()
+        self.name = item['TDT_NAME_US']
+        self.tdt_seq = int(item['TDT_SEQ'])
+
+    def key(self):
+        return self.tdt_seq
+
+    def load(self, database: PgRawDatabase):
+        pass
+
+
+class EvoType(Enum):
+    """Evo types supported by PadGuide. Numbers correspond to their id values."""
+    Base = -1  # Represents monsters who didn't require evo
+    Evo = 0
+    UvoAwoken = 1
+    UuvoReincarnated = 2
+
+
+# evolutionList
+# {
+#     "APP_VERSION": "",
+#     "COMMENT_JP": "",
+#     "COMMENT_KR": "",
+#     "COMMENT_US": "",
+#     "MONSTER_NO": "1",
+#     "TO_NO": "2",
+#     "TSTAMP": "1371788673999",
+#     "TV_SEQ": "331",
+#     "TV_TYPE": "0"
+# },
+class PgEvolution(PgItem):
+    @staticmethod
+    def file_name():
+        return 'evolutionList'
+
+    def __init__(self, item):
+        super().__init__()
+        self.tv_seq = int(item['TV_SEQ'])  # unique id
+        self.from_monster_no = int(item['MONSTER_NO'])  # PgMonster id - base monster
+        self.to_monster_no = int(item['TO_NO'])  # PgMonster id - target monster
+        self.tv_type = int(item['TV_TYPE'])
+        self.evo_type = EvoType(self.tv_type)
+
+    def key(self):
+        return self.tv_seq
+
+    def deleted(self):
+        # Really rare and unusual bug
+        return self.from_monster_no == 0 or self.to_monster_no == 0
+
+    def load(self, database: PgRawDatabase):
+        self.from_monster = database.getMonster(self.from_monster_no)
+        self.to_monster = database.getMonster(self.to_monster_no)
+
+        if self.to_monster:
+            self.to_monster.cur_evo_type = self.evo_type
+            if self.from_monster:
+                self.to_monster.evo_from = self.from_monster
+                self.from_monster.evo_to.append(self.to_monster)
+
+
+# evoMaterialList
+# {
+#     "MONSTER_NO": "153",
+#     "ORDER_IDX": "1",
+#     "TEM_SEQ": "1429",
+#     "TSTAMP": "1371788674011",
+#     "TV_SEQ": "332"
+# },
+class PgEvolutionMaterial(PgItem):
+    @staticmethod
+    def file_name():
+        return 'evoMaterialList'
+
+    def __init__(self, item):
+        super().__init__()
+        self.tem_seq = int(item['TEM_SEQ'])  # unique id
+        self.tv_seq = int(item['TV_SEQ'])  # evo id
+        self.fodder_monster_no = int(item['MONSTER_NO'])  # material monster
+        self.order = int(item['ORDER_IDX'])  # display order
+
+        self.evolution = None  # type: PgEvolution
+        self.fodder_monster = None  # type: PgMonster
+
+    def key(self):
+        return self.tem_seq
+
+    def load(self, database: PgRawDatabase):
+        self.evolution = database.getEvolution(self.tv_seq)
+        self.fodder_monster = database.getMonster(self.fodder_monster_no)
+
+        if self.evolution is None or self.evolution.to_monster is None:
+            # Really rare and unusual bug
+            return
+
+        target_monster = self.evolution.to_monster
+        # TODO: this is unsorted
+        target_monster.mats_for_evo.append(self.fodder_monster)
+
+        # Prevent issues if a monster is a mat for the same monster repeatedly (gunma, stones)
+        if target_monster not in self.fodder_monster.material_of:
+            self.fodder_monster.material_of.append(target_monster)
+
+
+# monsterAddInfoList
+# {
+#     "EXTRA_VAL1": "1",
+#     "EXTRA_VAL2": "",
+#     "EXTRA_VAL3": "",
+#     "EXTRA_VAL4": "",
+#     "EXTRA_VAL5": "",
+#     "MONSTER_NO": "3329",
+#     "SUB_TYPE": "0",
+#     "TSTAMP": "1480435906788"
+# },
+class PgMonsterAddInfo(PgItem):
+    """Optional extra information for a Monster.
+
+    Data is copied into PgMonster and this is discarded."""
+
+    @staticmethod
+    def file_name():
+        return 'monsterAddInfoList'
+
+    def __init__(self, item):
+        super().__init__()
+        self.monster_no = int(item['MONSTER_NO'])
+        self.sub_type = int(item['SUB_TYPE'])
+        self.extra_val_1 = int_or_none(item['EXTRA_VAL1'])
+
+    def key(self):
+        return self.monster_no
+
+    def load(self, database: PgRawDatabase):
+        pass
+
+
+# monsterInfoList
+# {
+#     "FODDER_EXP": "675.0",
+#     "HISTORY_JP": "[2016-12-16] \u65b0\u898f\u8ffd\u52a0",
+#     "HISTORY_KR": "[2016-12-16] \uc2e0\uaddc\ucd94\uac00",
+#     "HISTORY_US": "[2016-12-16] New Added",
+#     "MONSTER_NO": "3382",
+#     "ON_KR": "1",
+#     "ON_US": "1",
+#     "PAL_EGG": "0",
+#     "RARE_EGG": "0",
+#     "SELL_PRICE": "300.0",
+#     "TSR_SEQ": "86",
+#     "TSTAMP": "1481846935838"
+# },
+class PgMonsterInfo(PgItem):
+    """Extra information for a Monster.
+
+    Data is copied into PgMonster and this is discarded."""
+
+    @staticmethod
+    def file_name():
+        return 'monsterInfoList'
+
+    def __init__(self, item):
+        super().__init__()
+        self.monster_no = int(item['MONSTER_NO'])
+        self.on_na = item['ON_US'] == '1'
+        self.tsr_seq = int_or_none(item['TSR_SEQ'])  # PgSeries id
+        self.in_pem = item['PAL_EGG'] == '1'
+        self.in_rem = item['RARE_EGG'] == '1'
+        self.history_us = item['HISTORY_US']
+
+    def key(self):
+        return self.monster_no
+
+    def load(self, database: PgRawDatabase):
+        self.series = database.getSeries(self.tsr_seq)
+
+
+# monsterList
+# {
+#     "APP_VERSION": "0.0",
+#     "ATK_MAX": "1985",
+#     "ATK_MIN": "695",
+#     "COMMENT_JP": "",
+#     "COMMENT_KR": "\uc77c\ubcf8",
+#     "COMMENT_US": "Japan",
+#     "COST": "60",
+#     "EXP": "10000000",
+#     "HP_MAX": "6258",
+#     "HP_MIN": "3528",
+#     "LEVEL": "99",
+#     "MONSTER_NO": "3646",
+#     "MONSTER_NO_JP": "3646",
+#     "MONSTER_NO_KR": "3646",
+#     "MONSTER_NO_US": "3646",
+#     "PRONUNCIATION_JP": "\u304b\u306a\u305f\u306a\u308b\u3082\u306e\u30fb\u3088\u3050\u305d\u3068\u30fc\u3059",
+#     "RARITY": "7",
+#     "RATIO_ATK": "1.5",
+#     "RATIO_HP": "1.5",
+#     "RATIO_RCV": "1.5",
+#     "RCV_MAX": "233",
+#     "RCV_MIN": "926",
+#     "REG_DATE": "2017-04-27 17:29:48.0",
+#     "TA_SEQ": "4",
+#     "TA_SEQ_SUB": "0",
+#     "TE_SEQ": "14",
+#     "TM_NAME_JP": "\u5f7c\u65b9\u306a\u308b\u3082\u306e\u30fb\u30e8\u30b0\uff1d\u30bd\u30c8\u30fc\u30b9",
+#     "TM_NAME_KR": "\u5f7c\u65b9\u306a\u308b\u3082\u306e\u30fb\u30e8\u30b0\uff1d\u30bd\u30c8\u30fc\u30b9",
+#     "TM_NAME_US": "\u5f7c\u65b9\u306a\u308b\u3082\u306e\u30fb\u30e8\u30b0\uff1d\u30bd\u30c8\u30fc\u30b9",
+#     "TSTAMP": "1494033700775",
+#     "TS_SEQ_LEADER": "12448",
+#     "TS_SEQ_SKILL": "12447",
+#     "TT_SEQ": "10",
+#     "TT_SEQ_SUB": "1"
+# }
+class PgMonster(PgItem):
+    @staticmethod
+    def file_name():
+        return 'monsterList'
+
+    def __init__(self, item):
+        super().__init__()
+        self.monster_no = int(item['MONSTER_NO'])
+        self.monster_no_na = int(item['MONSTER_NO_US'])
+        self.monster_no_jp = int(item['MONSTER_NO_JP'])
+        self.min_hp = int(item['HP_MIN'])
+        self.min_atk = int(item['ATK_MIN'])
+        self.min_rcv = int(item['RCV_MIN'])
+        self.hp = int(item['HP_MAX'])
+        self.atk = int(item['ATK_MAX'])
+        self.rcv = int(item['RCV_MAX'])
+        self.ts_seq_active = int_or_none(item['TS_SEQ_SKILL'])
+        self.ts_seq_leader = int_or_none(item['TS_SEQ_LEADER'])
+        self.rarity = int(item['RARITY'])
+        self.cost = int(item['COST'])
+        self.exp = int(item['EXP'])
+        self.max_level = int(item['LEVEL'])
+        self.name_na = item['TM_NAME_US']
+        self.name_jp = item['TM_NAME_JP']
+        self.ta_seq_1 = int(item['TA_SEQ'])  # PgAttribute id
+        self.ta_seq_2 = int(item['TA_SEQ_SUB'])  # PgAttribute id
+        self.te_seq = int(item['TE_SEQ'])
+        self.tt_seq_1 = int(item['TT_SEQ'])  # PgType id
+        self.tt_seq_2 = int(item['TT_SEQ_SUB'])  # PgType id
+
+        self.debug_info = ''
+        self.weighted_stats = int(self.hp / 10 + self.atk / 5 + self.rcv / 3)
+
+        self.roma_subname = None
+        if self.name_na == self.name_jp:
+            self.roma_subname = make_roma_subname(self.name_jp)
+        else:
+            # Remove annoying stuff from NA names, like Jörmungandr
+            self.name_na = rpadutils.rmdiacritics(self.name_na)
+
+        self.active_skill = None  # type: PgSkill
+        self.leader_skill = None  # type: PgSkill
+
+        # ???
+        self.cur_evo_type = EvoType.Base
+        self.evo_to = []
+        self.evo_from = None
+
+        self.mats_for_evo = []
+        self.material_of = []
+
+        self.awakenings = []  # PgAwakening
+        self.drop_dungeons = []
+
+        self.alt_evos = []  # PgMonster
+
+        # List of PgSkillRotationDated
+        self.rotating_skillups = []
+        self.server_actives = {}  # str(NA, JP) -> PgSkill
+        self.future_skillup_rotation = {}
+
+        self.is_equip = False
+
+        # Monsters start off pointing to themselves as the base, this will
+        # change once the MonsterGroups are computed.
+        self.base_monster = self
+
+        # Data populated via override
+        self.limitbreak_stats = 1 + float(item['LIMIT_MULT']) / 100 if item['LIMIT_MULT'] else None
+        self.superawakening_count = 0
+
+        # Data filled in post-load
+        self.translated_jp_name = None
+
+    def key(self):
+        return self.monster_no
+
+    def load(self, database: PgRawDatabase):
+        self.active_skill = database.getSkill(self.ts_seq_active)
+        if self.active_skill:
+            self.active_skill.monsters_with_active.append(self)
+
+        self.leader_skill = database.getSkill(self.ts_seq_leader)
+        self.leader_skill_data = database.getSkillLeaderData(self.ts_seq_leader)
+        if self.leader_skill:
+            self.leader_skill.monsters_with_leader.append(self)
+
+        self.attr1 = database.getAttributeEnum(self.ta_seq_1)
+        self.attr2 = database.getAttributeEnum(self.ta_seq_2)
+
+        self.type1 = database.getTypeName(self.tt_seq_1)
+        self.type2 = database.getTypeName(self.tt_seq_2)
+        self.type3 = None
+
+        self.assist_setting = None
+        monster_add_info = database.getMonsterAddInfo(self.monster_no)
+        if monster_add_info:
+            self.type3 = database.getTypeName(monster_add_info.sub_type)
+            self.assist_setting = monster_add_info.extra_val_1
+
+        monster_info = database.getMonsterInfo(self.monster_no)
+        self.on_na = monster_info.on_na
+        self.series = database.getSeries(monster_info.tsr_seq)  # PgSeries
+        self.series.monsters.append(self)
+        self.is_gfe = self.series.tsr_seq == 34  # godfest
+        self.in_pem = monster_info.in_pem
+        self.in_rem = monster_info.in_rem
+        self.pem_evo = self.in_pem
+        self.rem_evo = self.in_rem
+        self.history_us = monster_info.history_us
+
+        monster_price = database.getMonsterPrice(self.monster_no)
+        self.sell_mp = monster_price.sell_mp if monster_price else 0
+        self.buy_mp = monster_price.buy_mp if monster_price else 0
+        self.in_mpshop = self.buy_mp > 0
+        self.mp_evo = self.in_mpshop
+
+    def finalize(self):
+        self.farmable = len(self.drop_dungeons) > 0
+        self.farmable_evo = self.farmable
+
+        self.awakenings.sort(key=lambda x: x.order)
+        self.superawakening_count = sum(int(a.is_super) for a in self.awakenings)
+
+        if self.assist_setting == 1:
+            self.is_inheritable = True
+        elif self.assist_setting == 2:
+            self.is_inheritable = False
+        else:
+            has_awakenings = len(self.awakenings) > 0
+            self.is_inheritable = has_awakenings and self.rarity >= 5 and self.sell_mp >= 3000
+
+        self.is_equip = 'Awoken Assist' in [a.get_name() for a in self.awakenings]
+
+        self.types = [t.lower() for t in [self.type1, self.type2, self.type3] if t]
+
+        if self.evo_from is None:
+            def link(m: PgMonster, alt_evos: list):
+                alt_evos.append(m)
+                m.alt_evos = alt_evos
+                for em in m.evo_to:
+                    link(em, alt_evos)
+            link(self, [])
+
+        self.search = MonsterSearchHelper(self)
+
+        # Compute server skill rotations
+        for server, server_tz in {'JP': rpadutils.JP_TZ_OBJ, 'NA': rpadutils.NA_TZ_OBJ}.items():
+            server_now = datetime.now().replace(tzinfo=server_tz).date()
+            server_skillups = list(filter(lambda s: s.skill_rotation.server == server,
+                                          self.rotating_skillups))
+            future_skillup = list(filter(lambda s: server_now < s.rotation_date, server_skillups))
+            if future_skillup:
+                self.future_skillup_rotation[server] = future_skillup[0]
+
+            past_skillups = list(filter(lambda s: server_now >= s.rotation_date, server_skillups))
+            if past_skillups:
+                active_skillup = max(past_skillups, key=lambda s: s.rotation_date)
+                self.server_actives[server] = active_skillup.skill
+                active_skillup.skill.server_skillups[server] = active_skillup.skill_rotation.monster
+
+
+class MonsterSearchHelper(object):
+    def __init__(self, m: PgMonster):
+
+        self.name = '{} {}'.format(m.name_na, m.name_jp).lower()
+        self.leader = m.leader_skill.desc.lower() if m.leader_skill else ''
+        self.active_name = m.active_skill.name.lower() if m.active_skill else ''
+        self.active_desc = m.active_skill.desc.lower() if m.active_skill else ''
+        self.active = '{} {}'.format(self.active_name, self.active_desc)
+        self.active_min = m.active_skill.turn_min if m.active_skill else None
+        self.active_max = m.active_skill.turn_max if m.active_skill else None
+
+        self.color = [m.attr1.name.lower()]
+        self.hascolor = [c.name.lower() for c in [m.attr1, m.attr2] if c]
+
+        self.limitbreak_stats = m.limitbreak_stats or 1
+
+        self.hp = m.hp * self.limitbreak_stats
+        self.atk = m.atk * self.limitbreak_stats
+        self.rcv = m.rcv * self.limitbreak_stats
+        self.weighted_stats = m.weighted_stats * self.limitbreak_stats
+
+        self.types = m.types
+
+        def replace_colors(text: str):
+            return text.replace('red', 'fire').replace('blue', 'water').replace('green', 'wood')
+        self.leader = replace_colors(self.leader)
+        self.active = replace_colors(self.active)
+        self.active_name = replace_colors(self.active_name)
+        self.active_desc = replace_colors(self.active_desc)
+
+        self.board_change = []
+        self.orb_convert = defaultdict(list)
+        self.row_convert = []
+        self.column_convert = []
+
+        def color_txt_to_list(txt):
+            txt = txt.replace('and', ' ')
+            txt = txt.replace(',', ' ')
+            txt = txt.replace('orbs', ' ')
+            txt = txt.replace('orb', ' ')
+            txt = txt.replace('mortal poison', 'mortalpoison')
+            txt = txt.replace('jammers', 'jammer')
+            txt = txt.strip()
+            return txt.split()
+
+        def strip_prev_clause(txt: str, sep: str):
+            prev_clause_start_idx = txt.find(sep)
+            if prev_clause_start_idx >= 0:
+                prev_clause_start_idx += len(sep)
+                txt = txt[prev_clause_start_idx:]
+            return txt
+
+        def strip_next_clause(txt: str, sep: str):
+            next_clause_start_idx = txt.find(sep)
+            if next_clause_start_idx >= 0:
+                txt = txt[:next_clause_start_idx]
+            return txt
+
+        active_desc = self.active_desc
+        active_desc = active_desc.replace(' rows ', ' row ')
+        active_desc = active_desc.replace(' columns ', ' column ')
+        active_desc = active_desc.replace(' into ', ' to ')
+        active_desc = active_desc.replace('changes orbs to', 'all orbs to')
+
+        board_change_txt = 'all orbs to'
+        if board_change_txt in active_desc:
+            txt = strip_prev_clause(active_desc, board_change_txt)
+            txt = strip_next_clause(txt, 'orbs')
+            txt = strip_next_clause(txt, ';')
+            self.board_change = color_txt_to_list(txt)
+
+        txt = active_desc
+        if 'row' in txt:
+            parts = re.split('\Wand\W|;\W', txt)
+            for i in range(0, len(parts)):
+                if 'row' in parts[i]:
+                    self.row_convert.append(strip_next_clause(
+                        strip_prev_clause(parts[i], 'to '), ' orbs'))
+
+        txt = active_desc
+        if 'column' in txt:
+            parts = re.split('\Wand\W|;\W', txt)
+            for i in range(0, len(parts)):
+                if 'column' in parts[i]:
+                    self.column_convert.append(strip_next_clause(
+                        strip_prev_clause(parts[i], 'to '), ' orbs'))
+
+        convert_done = self.board_change or self.row_convert or self.column_convert
+
+        change_txt = 'change '
+        if not convert_done and change_txt in active_desc and 'orb' in active_desc:
+            txt = active_desc
+            parts = re.split('\Wand\W|;\W', txt)
+            for i in range(0, len(parts)):
+                parts[i] = strip_prev_clause(parts[i], change_txt) if change_txt in parts[i] else ''
+
+            for part in parts:
+                sub_parts = part.split(' to ')
+                if len(sub_parts) > 1:
+                    source_orbs = color_txt_to_list(sub_parts[0])
+                    dest_orbs = color_txt_to_list(sub_parts[1])
+                    for so in source_orbs:
+                        for do in dest_orbs:
+                            self.orb_convert[so].append(do)
+
+
+class MonsterGroup(object):
+    """Computes shared values across a tree of monsters and injects them."""
+
+    def __init__(self, base_monster: PgMonster):
+        self.base_monster = base_monster
+        self.members = list()
+        self._recursive_add(base_monster)
+        self._initialize_members()
+
+    def _recursive_add(self, m: PgMonster):
+        m.base_monster = self.base_monster
+        self.members.append(m)
+        for em in m.evo_to:
+            self._recursive_add(em)
+
+    def _initialize_members(self):
+        # Compute tree acquisition status
+        farmable_evo, pem_evo, rem_evo, mp_evo = False, False, False, False
+        for m in self.members:
+            farmable_evo = farmable_evo or m.farmable
+            pem_evo = pem_evo or m.in_pem
+            rem_evo = rem_evo or m.in_rem
+            mp_evo = mp_evo or m.in_mpshop
+
+        # Override tree acquisition status
+        for m in self.members:
+            m.farmable_evo = farmable_evo
+            m.pem_evo = pem_evo
+            m.rem_evo = rem_evo
+            m.mp_evo = mp_evo
+
+
+# monsterPriceList
+# {
+#     "BUY_PRICE": "0",
+#     "MONSTER_NO": "3577",
+#     "SELL_PRICE": "99",
+#     "TSTAMP": "1492101772974"
+# }
+
+
+class PgMonsterPrice(PgItem):
+    @staticmethod
+    def file_name():
+        return 'monsterPriceList'
+
+    def __init__(self, item):
+        super().__init__()
+        self.monster_no = int(item['MONSTER_NO'])
+        self.buy_mp = int(item['BUY_PRICE'])
+        self.sell_mp = int(item['SELL_PRICE'])
+
+    def key(self):
+        return self.monster_no
+
+    def load(self, database: PgRawDatabase):
+        pass
+
+
+# seriesList
+# {
+#     "DEL_YN": "N",
+#     "NAME_JP": "\u308a\u3093",
+#     "NAME_KR": "\uc2ac\ub77c\uc784",
+#     "NAME_US": "Slime",
+#     "SEARCH_DATA": "\u308a\u3093 Slime \uc2ac\ub77c\uc784",
+#     "TSR_SEQ": "3",
+#     "TSTAMP": "1380587210667"
+# },
+class PgSeries(PgItem):
+    @staticmethod
+    def file_name():
+        return 'seriesList'
+
+    def __init__(self, item):
+        super().__init__()
+        self.tsr_seq = int(item['TSR_SEQ'])
+        self.name = item['NAME_US']
+        self.deleted_yn = item['DEL_YN']  # Either Y(discard) or N.
+
+        self.monsters = []
+
+    def key(self):
+        return self.tsr_seq
+
+    def deleted(self):
+        return False
+        # Temporary
+#         return self.deleted_yn == 'Y'
+
+    def load(self, database: PgRawDatabase):
+        pass
+
+
+# skillList
+# {
+#     "MAG_ATK": "0.0",
+#     "MAG_HP": "0.0",
+#     "MAG_RCV": "0.0",
+#     "ORDER_IDX": "3",
+#     "REDUCE_DMG": "0.0",
+#     "RTA_SEQ_1": "0",
+#     "RTA_SEQ_2": "0",
+#     "SEARCH_DATA": "\u6e9c\u3081\u65ac\u308a \u6e9c\u3081\u65ac\u308a \u6e9c\u3081\u65ac\u308a 2\u30bf\u30fc\u30f3\u306e\u9593\u3001\u30c1\u30fc\u30e0\u5185\u306e\u30c9\u30e9\u30b4\u30f3\u30ad\u30e9\u30fc\u306e\u899a\u9192\u6570\u306b\u5fdc\u3058\u3066\u653b\u6483\u529b\u304c\u4e0a\u6607\u3002(1\u500b\u306b\u3064\u304d50%) Increase ATK depending on number of Dragon Killer Awakening Skills on team for 2 turns (50% per each) 2\ud134\uac04 \ud300\ub0b4\uc758 \ub4dc\ub798\uace4 \ud0ac\ub7ec \uac01\uc131 \uac2f\uc218\uc5d0 \ub530\ub77c \uacf5\uaca9\ub825\uc774 \uc0c1\uc2b9 (\uac1c\ub2f9 50%)",
+#     "TA_SEQ_1": "0",
+#     "TA_SEQ_2": "0",
+#     "TSTAMP": "1493861895693",
+#     "TS_DESC_JP": "2\u30bf\u30fc\u30f3\u306e\u9593\u3001\u30c1\u30fc\u30e0\u5185\u306e\u30c9\u30e9\u30b4\u30f3\u30ad\u30e9\u30fc\u306e\u899a\u9192\u6570\u306b\u5fdc\u3058\u3066\u653b\u6483\u529b\u304c\u4e0a\u6607\u3002(1\u500b\u306b\u3064\u304d50%)",
+#     "TS_DESC_KR": "2\ud134\uac04 \ud300\ub0b4\uc758 \ub4dc\ub798\uace4 \ud0ac\ub7ec \uac01\uc131 \uac2f\uc218\uc5d0 \ub530\ub77c \uacf5\uaca9\ub825\uc774 \uc0c1\uc2b9 (\uac1c\ub2f9 50%)",
+#     "TS_DESC_US": "Increase ATK depending on number of Dragon Killer Awakening Skills on team for 2 turns (50% per each)",
+#     "TS_NAME_JP": "\u6e9c\u3081\u65ac\u308a",
+#     "TS_NAME_KR": "\u6e9c\u3081\u65ac\u308a",
+#     "TS_NAME_US": "\u6e9c\u3081\u65ac\u308a",
+#     "TS_SEQ": "12478",
+#     "TT_SEQ_1": "0",
+#     "TT_SEQ_2": "0",
+#     "TURN_MAX": "22",
+#     "TURN_MIN": "14",
+#     "T_CONDITION": "3"
+# }
+class PgSkill(PgItem):
+    @staticmethod
+    def file_name():
+        return 'skillList'
+
+    def __init__(self, item):
+        super().__init__()
+        self.ts_seq = int(item['TS_SEQ'])
+        self.name = item['TS_NAME_US']
+        self.desc = item['TS_DESC_US']
+        self.turn_min = int(item['TURN_MIN'])
+        self.turn_max = int(item['TURN_MAX'])
+
+        self.monsters_with_active = []  # PgMonster
+        self.monsters_with_leader = []  # PgMonster
+        self.monsters_with_awakening = []  # PgMonster
+
+        # str (NA, JP) -> PgMonster
+        self.server_skillups = {}
+
+    def key(self):
+        return self.ts_seq
+
+    def load(self, database: PgRawDatabase):
+        pass
+
+
+# skillLeaderDataList
+#
+# PgSkillLeaderData
+# 4 pipe delimited fields, each field is a condition
+# Slashes separate effects for conditions
+# 1: Code 1=HP, 2=ATK, 3=RCV, 4=Reduction
+# 2: Multiplier
+# 3: Color restriction (coded)
+# 4: Type restriction (coded)
+# 5: Combo restriction
+#
+# Reincarnated Izanagi, 4x + 50% for heal cross, 2x atk 2x rcv for god/dragon/balanced
+# {
+#     "LEADER_DATA": "4/0.5///|2/4///|2/2//6,1,2/|3/2//6,1,2/",
+#     "TSTAMP": "1487553365770",
+#     "TS_SEQ": "11695"
+# },
+# Gold Saint, Shion : 4.5X atk when 3+ light combo
+# {
+#     "LEADER_DATA": "2/4.5///3",
+#     "TSTAMP": "1432940060708",
+#     "TS_SEQ": "6661"
+# },
+# Reincarnated Minerva, 3x damage, 2x damage, color resist
+# {
+#     "LEADER_DATA": "2/3/1//|2/2///|4/0.5/1,4,5//",
+#     "TSTAMP": "1475243514648",
+#     "TS_SEQ": "10835"
+# },
+class PgSkillLeaderData(PgItem):
+    @staticmethod
+    def empty():
+        return PgSkillLeaderData({
+            'TS_SEQ': '-1',
+            'LEADER_DATA': '',
+        })
+
+    @staticmethod
+    def file_name():
+        return 'skillLeaderDataList'
+
+    def __init__(self, item):
+        super().__init__()
+        self.ts_seq = int(item['TS_SEQ'])  # unique id
+        self.leader_data = item['LEADER_DATA']
+
+        hp, atk, rcv, resist = (1.0,) * 4
+        for mod in self.leader_data.split('|'):
+            if not mod.strip():
+                continue
+            items = mod.split('/')
+
+            code = items[0]
+            mult = float(items[1])
+            if code == '1':
+                hp *= mult
+            if code == '2':
+                atk *= mult
+            if code == '3':
+                rcv *= mult
+            if code == '4':
+                resist *= mult
+
+        self.hp = hp
+        self.atk = atk
+        self.rcv = rcv
+        self.resist = resist
+
+    def key(self):
+        return self.ts_seq
+
+    def load(self, database: PgRawDatabase):
+        pass
+
+    def get_data(self):
+        return self.hp, self.atk, self.rcv, self.resist
+
+
+# skillRotationList
+# {
+#     "MONSTER_NO": "915",
+#     "SERVER": "JP",
+#     "STATUS": "0",
+#     "TSR_SEQ": "2",
+#     "TSTAMP": "1481627094573"
+# }
+class PgSkillRotation(PgItem):
+    @staticmethod
+    def file_name():
+        return 'skillRotationList'
+
+    def __init__(self, item):
+        super().__init__()
+        self.tsr_seq = int(item['TSR_SEQ'])  # unique id
+        self.monster_no = int(item['MONSTER_NO'])
+        self.server = normalizeServer(item['SERVER'])  # JP, NA, KR
+        # Status seems to be rarely '2'
+        self.status = int(item['STATUS'])
+
+    def key(self):
+        return self.tsr_seq
+
+    def deleted(self):
+        return self.server == 'KR' or self.status != 0  # We don't do KR
+
+    def load(self, database: PgRawDatabase):
+        self.monster = database.getMonster(self.monster_no)
+
+
+# skillRotationListList
+# {
+#     "ROTATION_DATE": "2016-12-14",
+#     "STATUS": "0",
+#     "TSRL_SEQ": "960",
+#     "TSR_SEQ": "86",
+#     "TSTAMP": "1481627993157",
+#     "TS_SEQ": "9926"
+# }
+class PgSkillRotationDated(PgItem):
+    @staticmethod
+    def file_name():
+        return 'skillRotationListList'
+
+    def __init__(self, item):
+        super().__init__()
+        self.tsrl_seq = int(item['TSRL_SEQ'])  # unique id
+        self.tsr_seq = int(item['TSR_SEQ'])  # PgSkillRotation id - Current skillup monster
+        self.ts_seq = int(item['TS_SEQ'])  # PGSkill id - Current skill
+        self.rotation_date_str = item['ROTATION_DATE']
+
+        self.rotation_date = None
+        if len(self.rotation_date_str):
+            self.rotation_date = datetime.strptime(self.rotation_date_str, "%Y-%m-%d").date()
+
+    def key(self):
+        return self.tsrl_seq
+
+    def load(self, database: PgRawDatabase):
+        self.skill = database.getSkill(self.ts_seq)
+        self.skill_rotation = database.getSkillRotation(self.tsr_seq)
+
+        if self.skill_rotation:
+            self.skill_rotation.monster.rotating_skillups.append(self)
+
+
+# typeList
+# {
+#     "ORDER_IDX": "2",
+#     "TSTAMP": "1375363406092",
+#     "TT_NAME_JP": "\u60aa\u9b54",
+#     "TT_NAME_KR": "\uc545\ub9c8",
+#     "TT_NAME_US": "Devil",
+#     "TT_SEQ": "10"
+# },
+class PgType(PgItem):
+    @staticmethod
+    def file_name():
+        return 'typeList'
+
+    def __init__(self, item):
+        super().__init__()
+        self.tt_seq = int(item['TT_SEQ'])  # unique id
+        self.name = item['TT_NAME_US']
+
+    def key(self):
+        return self.tt_seq
+
+    def load(self, database: PgRawDatabase):
+        pass
+
+
+class PgMonsterDropInfoCombined(object):
+    def __init__(self, monster_id, dungeon_monster_drop, dungeon_monster, dungeon):
+        self.monster_id = monster_id
+        self.dungeon_monster_drop = dungeon_monster_drop
+        self.dungeon_monster = dungeon_monster
+        self.dungeon = dungeon
+
+
+# ================================================================================
+# PadRem items below
+# ================================================================================
+
+class RemType(Enum):
+    godfest = 1
+    rare = 2
+    pal = 3
+    unknown1 = 4
+
+
+class RemRowType(Enum):
+    subsection = 0
+    divider = 1
+
+
+# eggTitleList
+#       {
+#            "DEL_YN": "N",
+#            "END_DATE": "2016-10-24 07:59:00",
+#            "ORDER_IDX": "0",
+#            "SERVER": "US",
+#            "SHOW_YN": "Y",
+#            "START_DATE": "2016-10-17 08:00:00",
+#            "TEC_SEQ": "2",
+#            "TET_SEQ": "64",
+#            "TSTAMP": "1476490114488",
+#            "TYPE": "1"
+#        },
+class PgEggInstance(PgItem):
+    @staticmethod
+    def file_name():
+        return 'eggTitleList'
+
+    def __init__(self, item):
+        super().__init__()
+        self.server = normalizeServer(item['SERVER'])
+        self.deleted_yn = item['DEL_YN']  # Y, N
+        self.show_yn = item['SHOW_YN']  # Y, N
+        self.rem_type = RemType(int(item['TEC_SEQ']))  # matches RemType
+        self.tet_seq = int(item['TET_SEQ'])  # primary key
+        self.row_type = RemRowType(int(item['TYPE']))  # 0-> row with just name, 1-> row with date
+
+        self.order = int(item["ORDER_IDX"])
+        self.start_date_str = item['START_DATE']
+        self.end_date_str = item['END_DATE']
+
+        self.egg_name_us = None
+        self.egg_monsters = []
+
+        tz = pytz.UTC
+        self.start_datetime = None
+        self.end_datetime = None
+        self.open_date_str = None
+
+#         self.pt_date_str = None
+        if len(self.start_date_str):
+            self.start_datetime = datetime.strptime(
+                self.start_date_str, "%Y-%m-%d %H:%M:%S").replace(tzinfo=tz)
+            self.end_datetime = datetime.strptime(
+                self.end_date_str, "%Y-%m-%d %H:%M:%S").replace(tzinfo=tz)
+
+            if self.server == 'NA':
+                pt_tz_obj = pytz.timezone('America/Los_Angeles')
+                self.open_date_str = self.start_datetime.replace(tzinfo=pt_tz_obj).strftime('%m/%d')
+            if self.server == 'JP':
+                jp_tz_obj = pytz.timezone('Asia/Tokyo')
+                self.open_date_str = self.start_datetime.replace(tzinfo=jp_tz_obj).strftime('%m/%d')
+
+    def key(self):
+        return self.tet_seq
+
+    def deleted(self):
+        return (self.deleted_yn == 'Y' or
+                self.show_yn == 'N' or
+                self.server == 'KR' or
+                self.rem_type in (RemType.pal, RemType.unknown1))
+
+    def load(self, database: PgRawDatabase):
+        pass
+#         self.monster = database.getMonster(self.monster_no)
+
+
+# eggMonsterList
+#        {
+#            "DEL_YN": "Y",
+#            "MONSTER_NO": "120",
+#            "ORDER_IDX": "1",
+#            "TEM_SEQ": "1",
+#            "TET_SEQ": "1",
+#            "TSTAMP": "1405245537715"
+#        },
+class PgEggMonster(PgItem):
+    @staticmethod
+    def file_name():
+        return 'eggMonsterList'
+
+    def __init__(self, item):
+        super().__init__()
+        self.deleted_yn = item['DEL_YN']
+        self.monster_no = int(item['MONSTER_NO'])
+        self.tem_seq = int(item['TEM_SEQ'])  # primary key
+        self.tet_seq = int(item['TET_SEQ'])  # fk to PgEggInstance
+
+    def key(self):
+        return self.tem_seq
+
+    def deleted(self):
+        return self.deleted_yn == 'Y' or self.monster_no == 0
+
+    def load(self, database: PgRawDatabase):
+        self.monster = database.getMonster(self.monster_no)
+        self.egg_instance = database.getEggInstance(self.tet_seq)
+        if self.egg_instance:
+            # For KR stuff we clipped out
+            self.egg_instance.egg_monsters.append(self)
+
+
+# eggTitleNameList
+#        {
+#            "DEL_YN": "N",
+#            "LANGUAGE": "US",
+#            "NAME": "Batman Egg",
+#            "TETN_SEQ": "183",
+#            "TET_SEQ": "64",
+#            "TSTAMP": "1441589491425"
+#        },
+class PgEggName(PgItem):
+    @staticmethod
+    def file_name():
+        return 'eggTitleNameList'
+
+    def __init__(self, item):
+        super().__init__()
+        self.name = item['NAME']
+        self.language = item['LANGUAGE']  # US, JP, KR
+        self.deleted_yn = item['DEL_YN']  # Y, N
+        self.tetn_seq = int(item['TETN_SEQ'])  # primary key
+        self.tet_seq = int(item['TET_SEQ'])  # fk to PgEggInstance
+
+    def key(self):
+        return self.tetn_seq
+
+    def deleted(self):
+        return self.deleted_yn == 'Y' or self.language != 'US'
+
+    def load(self, database: PgRawDatabase):
+        self.egg_instance = database.getEggInstance(self.tet_seq)
+        if self.egg_instance:
+            # For KR stuff we clipped out
+            self.egg_instance.egg_name_us = self
+
+
+# ================================================================================
+# PadEvents items below
+# ================================================================================
+
+
+class EventType(Enum):
+    EventTypeWeek = 0
+    EventTypeSpecial = 1
+    EventTypeSpecialWeek = 2
+    EventTypeGuerrilla = 3
+    EventTypeGuerrillaNew = 4
+    EventTypeEtc = -100
+
+
+def normalizeServer(server):
+    server = server.upper()
+    return 'NA' if server == 'US' else server
+
+
+# {
+#     "CLOSE_DATE": "2017-09-01",
+#     "CLOSE_HOUR": "19",
+#     "CLOSE_MINUTE": "59",
+#     "CLOSE_WEEKDAY": "0",
+#     "DUNGEON_SEQ": "31",
+#     "EVENT_SEQ": "25",
+#     "EVENT_TYPE": "-100",
+#     "OPEN_DATE": "2017-09-01",
+#     "OPEN_HOUR": "08",
+#     "OPEN_MINUTE": "00",
+#     "OPEN_WEEKDAY": "0",
+#     "SCHEDULE_SEQ": "235217",
+#     "SERVER": "US",
+#     "SERVER_OPEN_DATE": "2017-09-01",
+#     "SERVER_OPEN_HOUR": "1",
+#     "TEAM_DATA": "0",
+#     "TSTAMP": "1504233623450",
+#     "URL": ""
+# },
+class PgScheduledEvent(PgItem):
+    @staticmethod
+    def file_name():
+        return 'scheduleList'
+
+    def __init__(self, item):
+        super().__init__()
+        self.schedule_seq = int(item['SCHEDULE_SEQ'])
+
+        self.open_timestamp = int(item['OPEN_TIMESTAMP'])
+        self.close_timestamp = int(item['CLOSE_TIMESTAMP'])
+
+        self.dungeon_seq = int(item['DUNGEON_SEQ'])
+        self.event_seq = int(item['EVENT_SEQ'])
+        self.event_type = int(item['EVENT_TYPE'])
+
+        self.server = normalizeServer(item['SERVER'])
+
+        self.team_data = int_or_none(item['TEAM_DATA'])
+        self.url = item['URL']
+
+        self.group = None
+        if self.team_data is not None:
+            if self.event_type == EventType.EventTypeGuerrilla.value:
+                self.group = chr(ord('a') + self.team_data).upper()
+            elif self.event_type == EventType.EventTypeSpecialWeek.value:
+                self.group = ['RED', 'BLUE', 'GREEN'][self.team_data]
+
+        self.open_datetime = datetime.utcfromtimestamp(
+            self.open_timestamp).replace(tzinfo=pytz.UTC)
+        self.close_datetime = datetime.utcfromtimestamp(
+            self.close_timestamp).replace(tzinfo=pytz.UTC)
+
+    def key(self):
+        return self.schedule_seq
+
+    def deleted(self):
+        return self.server == 'KR'
+
+    def load(self, database: PgRawDatabase):
+        self.dungeon = database.getDungeon(self.dungeon_seq)
+        self.event = database.getEvent(self.event_seq) if self.event_seq != '0' else None
+
+
+# {
+#     "EVENT_NAME_JP": "\u30b3\u30a4\u30f3 1.5\u500d!",
+#     "EVENT_NAME_KR": "\ucf54\uc778 1.5\ubc30!",
+#     "EVENT_NAME_US": "Coin x 1.5!",
+#     "EVENT_SEQ": "3",
+#     "TSTAMP": "1370174967128"
+# },
+class PgEvent(PgItem):
+    @staticmethod
+    def file_name():
+        return 'eventList'
+
+    def __init__(self, item):
+        super().__init__()
+        self.event_seq = int(item['EVENT_SEQ'])
+        self.name = item['EVENT_NAME_US']
+
+    def key(self):
+        return self.event_seq
+
+    def load(self, database: PgRawDatabase):
+        pass
+
+
+def make_roma_subname(name_jp):
+    subname = name_jp.replace('＝', '')
+    adjusted_subname = ''
+    for part in subname.split('・'):
+        roma_part = romkan.to_roma(part)
+        if part != roma_part and not rpadutils.containsJp(roma_part):
+            adjusted_subname += ' ' + roma_part.strip('-')
+    return adjusted_subname.strip()
+
+
+def int_or_none(maybe_int: str):
+    return int(maybe_int) if maybe_int else None
+
+
+def float_or_none(maybe_float: str):
+    return float(maybe_float) if maybe_float else None
+
+
+def empty_index():
+    return MonsterIndex(PgRawDatabase(skip_load=True), {}, {})
+
+
+class MonsterIndex(object):
+    def __init__(self, monster_database, nickname_overrides, basename_overrides, accept_filter=None):
+        # Important not to hold onto anything except IDs here so we don't leak memory
+        monster_groups = monster_database.grouped_monsters
+
+        self.attr_short_prefix_map = {
+            Attribute.Fire: ['r'],
+            Attribute.Water: ['b'],
+            Attribute.Wood: ['g'],
+            Attribute.Light: ['l'],
+            Attribute.Dark: ['d'],
+        }
+        self.attr_long_prefix_map = {
+            Attribute.Fire: ['red', 'fire'],
+            Attribute.Water: ['blue', 'water'],
+            Attribute.Wood: ['green', 'wood'],
+            Attribute.Light: ['light'],
+            Attribute.Dark: ['dark'],
+        }
+
+        self.series_to_prefix_map = {
+            130: ['halloween', 'hw', 'h'],
+            136: ['xmas', 'christmas'],
+            125: ['summer', 'beach'],
+            114: ['school', 'academy', 'gakuen'],
+            139: ['new years', 'ny'],
+            149: ['wedding', 'bride'],
+            154: ['padr'],
+            175: ['valentines', 'vday'],
+        }
+
+        monster_no_na_to_nicknames = defaultdict(set)
+        for nickname, monster_no_na in nickname_overrides.items():
+            monster_no_na_to_nicknames[monster_no_na].add(nickname)
+
+        named_monsters = []
+        for mg in monster_groups:
+            group_basename_overrides = basename_overrides.get(mg.base_monster.monster_no_na, [])
+            named_mg = NamedMonsterGroup(mg, group_basename_overrides)
+            for monster in mg.members:
+                if accept_filter and not accept_filter(monster):
+                    continue
+                prefixes = self.compute_prefixes(monster, mg)
+                extra_nicknames = monster_no_na_to_nicknames[monster.monster_no_na]
+                named_monster = NamedMonster(monster, named_mg, prefixes, extra_nicknames)
+                named_monsters.append(named_monster)
+
+        # Sort the NamedMonsters into the opposite order we want to accept their nicknames in
+        # This order is:
+        #  1) High priority first
+        #  2) Larger group sizes
+        #  3) Minimum ID size in the group
+        #  4) Monsters with higher ID values
+        def named_monsters_sort(nm: NamedMonster):
+            return (not nm.is_low_priority, nm.group_size, -1 *
+                    nm.base_monster_no_na, nm.monster_no_na)
+        named_monsters.sort(key=named_monsters_sort)
+
+        self.all_entries = {}
+        self.all_prefixes = set()
+        self.two_word_entries = {}
+        for nm in named_monsters:
+            for prefix in nm.prefixes:
+                self.all_prefixes.add(prefix)
+            for nickname in nm.final_nicknames:
+                self.all_entries[nickname] = nm
+            for nickname in nm.final_two_word_nicknames:
+                self.two_word_entries[nickname] = nm
+
+        self.all_monsters = named_monsters
+        self.all_na_name_to_monsters = {m.name_na.lower(): m for m in named_monsters}
+        self.monster_no_na_to_named_monster = {m.monster_no_na: m for m in named_monsters}
+        self.monster_no_to_named_monster = {m.monster_no: m for m in named_monsters}
+
+        for nickname, monster_no_na in nickname_overrides.items():
+            nm = self.monster_no_na_to_named_monster.get(monster_no_na)
+            if nm:
+                self.all_entries[nickname] = nm
+
+    def init_index(self):
+        pass
+
+    def compute_prefixes(self, m: PgMonster, mg: MonsterGroup):
+        prefixes = set()
+
+        attr1_short_prefixes = self.attr_short_prefix_map[m.attr1]
+        attr1_long_prefixes = self.attr_long_prefix_map[m.attr1]
+        prefixes.update(attr1_short_prefixes)
+        prefixes.update(attr1_long_prefixes)
+
+        # If no 2nd attribute, use x so we can look those monsters up easier
+        attr2_short_prefixes = self.attr_short_prefix_map.get(m.attr2, ['x'])
+        for a1 in attr1_short_prefixes:
+            for a2 in attr2_short_prefixes:
+                prefixes.add(a1 + a2)
+                prefixes.add(a1 + '/' + a2)
+
+        # TODO: add prefixes based on type
+
+        # Chibi monsters have the same NA name, except lowercased
+        if m.name_na != m.name_jp:
+            if m.name_na.lower() == m.name_na:
+                prefixes.add('chibi')
+        elif 'ミニ' in m.name_jp:
+            # Guarding this separately to prevent 'gemini' from triggering (e.g. 2645)
+            prefixes.add('chibi')
+
+        lower_name = m.name_na.lower()
+        awoken = lower_name.startswith('awoken') or '覚醒' in lower_name
+        revo = lower_name.startswith('reincarnated') or '転生' in lower_name
+        mega = lower_name.startswith('mega woken') or '極醒' in lower_name
+        awoken_or_revo_or_equip_or_mega = awoken or revo or m.is_equip or mega
+
+        # These clauses need to be separate to handle things like 'Awoken Thoth' which are
+        # actually Evos but have awoken in the name
+        if awoken:
+            prefixes.add('a')
+            prefixes.add('awoken')
+
+        if revo:
+            prefixes.add('revo')
+            prefixes.add('reincarnated')
+
+        if mega:
+            prefixes.add('mega')
+            prefixes.add('mega awoken')
+            prefixes.add('awoken')
+
+        # Prefixes for evo type
+        if m.cur_evo_type == EvoType.Base:
+            prefixes.add('base')
+        elif m.cur_evo_type == EvoType.Evo:
+            prefixes.add('evo')
+        elif m.cur_evo_type == EvoType.UvoAwoken and not awoken_or_revo_or_equip_or_mega:
+            prefixes.add('uvo')
+            prefixes.add('uevo')
+        elif m.cur_evo_type == EvoType.UuvoReincarnated and not awoken_or_revo_or_equip_or_mega:
+            prefixes.add('uuvo')
+            prefixes.add('uuevo')
+
+        # If any monster in the group is a pixel, add 'nonpixel' to all the versions
+        # without pixel in the name. Add 'pixel' as a prefix to the ones with pixel in the name.
+        def is_pixel(n):
+            n = n.name_na.lower()
+            return n.startswith('pixel') or n.startswith('ドット')
+
+        for gm in mg.members:
+            if is_pixel(gm):
+                prefixes.update(['pixel'] if is_pixel(m) else ['np', 'nonpixel'])
+                break
+
+        if m.is_equip:
+            prefixes.add('assist')
+            prefixes.add('equip')
+
+        # Collab prefixes
+        prefixes.update(self.series_to_prefix_map.get(m.series.tsr_seq, []))
+
+        return prefixes
+
+    def find_monster(self, query):
+        query = rpadutils.rmdiacritics(query).lower().strip()
+
+        # id search
+        if query.isdigit():
+            m = self.monster_no_na_to_named_monster.get(int(query))
+            if m is None:
+                return None, 'Looks like a monster ID but was not found', None
             else:
-                row.append('')
-        tbl.add_row(row)
+                return m, None, "ID lookup"
+            # special handling for na/jp
 
-    return tbl.get_string()
+        # TODO: need to handle na_only?
 
+        # handle exact nickname match
+        if query in self.all_entries:
+            return self.all_entries[query], None, "Exact nickname"
 
-AWAKENING_NAME_MAP_RPAD = {
-    'Enhanced Attack': 'boost_atk',
-    'Enhanced HP': 'boost_hp',
-    'Enhanced Heal': 'boost_rcv',
+        contains_jp = rpadutils.containsJp(query)
+        if len(query) < 2 and contains_jp:
+            return None, 'Japanese queries must be at least 2 characters', None
+        elif len(query) < 4 and not contains_jp:
+            return None, 'Your query must be at least 4 letters', None
 
-    'Enhanced Team HP': 'teamboost_hp',
-    'Enhanced Team Attack': 'teamboost_atk',
-    'Enhanced Team RCV': 'teamboost_rcv',
+        # TODO: this should be a length-limited priority queue
+        matches = set()
+        # prefix search for nicknames, space-preceeded, take max id
+        for nickname, m in self.all_entries.items():
+            if nickname.startswith(query + ' '):
+                matches.add(m)
+        if len(matches):
+            return self.pickBestMonster(matches), None, "Space nickname prefix, max of {}".format(len(matches))
 
-    'God Killer': 'killer_god',
-    'Dragon Killer': 'killer_dragon',
-    'Devil Killer': 'killer_devil',
-    'Machine Killer': 'killer_machine',
-    'Balanced Killer': 'killer_balance',
-    'Attacker Killer': 'killer_attacker',
+        # prefix search for nicknames, take max id
+        for nickname, m in self.all_entries.items():
+            if nickname.startswith(query):
+                matches.add(m)
+        if len(matches):
+            all_names = ",".join(map(lambda x: x.name_na, matches))
+            return self.pickBestMonster(matches), None, "Nickname prefix, max of {}, matches=({})".format(len(matches), all_names)
 
-    'Physical Killer': 'killer_physical',
-    'Healer Killer': 'killer_healer',
-    'Evolve Material Killer': 'killer_evomat',
-    'Awaken Material Killer': 'killer_awoken',
-    'Enhance Material Killer': 'killer_enhancemat',
-    'Vendor Material Killer': 'killer_vendor',
+        # prefix search for full name, take max id
+        for nickname, m in self.all_entries.items():
+            if (m.name_na.lower().startswith(query) or m.name_jp.lower().startswith(query)):
+                matches.add(m)
+        if len(matches):
+            return self.pickBestMonster(matches), None, "Full name, max of {}".format(len(matches))
 
-    'Auto-Recover': 'misc_autoheal',
-    'Recover Bind': 'misc_bindclear',
-    'Enhanced Combo': 'misc_comboboost',
-    'Super Enhanced Combo': 'misc_super_comboboost',
-    'Guard Break': 'misc_guardbreak',
-    'Multi Boost': 'misc_multiboost',
-    'Additional Attack': 'misc_extraattack',
-    'Skill Boost': 'misc_sb',
-    'Extend Time': 'misc_te',
-    'Two-Pronged Attack': 'misc_tpa',
-    'Damage Void Shield Penetration': 'misc_voidshield',
-    'Awoken Assist': 'misc_assist',
+        # for nicknames with 2 names, prefix search 2nd word, take max id
+        if query in self.two_word_entries:
+            return self.two_word_entries[query], None, "Second-word nickname prefix, max of {}".format(len(matches))
 
-    'Enhanced Fire Orbs': 'oe_fire',
-    'Enhanced Water Orbs': 'oe_water',
-    'Enhanced Wood Orbs': 'oe_wood',
-    'Enhanced Light Orbs': 'oe_light',
-    'Enhanced Dark Orbs': 'oe_dark',
-    'Enhanced Heal Orbs': 'oe_heart',
+        # TODO: refactor 2nd search characteristcs for 2nd word
 
-    'Reduce Fire Damage': 'reduce_fire',
-    'Reduce Water Damage': 'reduce_water',
-    'Reduce Wood Damage': 'reduce_wood',
-    'Reduce Light Damage': 'reduce_light',
-    'Reduce Dark Damage': 'reduce_dark',
+        # full name contains on nickname, take max id
+        for nickname, m in self.all_entries.items():
+            if (query in m.name_na.lower() or query in m.name_jp.lower()):
+                matches.add(m)
+        if len(matches):
+            return self.pickBestMonster(matches), None, 'Full name match on nickname, max of {}'.format(len(matches))
 
-    'Resistance-Bind': 'res_bind',
-    'Resistance-Dark': 'res_blind',
-    'Resistance-Jammers': 'res_jammer',
-    'Resistance-Poison': 'res_poison',
-    'Resistance-Skill Bind': 'res_skillbind',
+        # full name contains on full monster list, take max id
 
-    'Enhanced Fire Att.': 'row_fire',
-    'Enhanced Water Att.': 'row_water',
-    'Enhanced Wood Att.': 'row_wood',
-    'Enhanced Light Att.': 'row_light',
-    'Enhanced Dark Att.': 'row_dark',
+        for m in self.all_monsters:
+            if (query in m.name_na.lower() or query in m.name_jp.lower()):
+                matches.add(m)
+        if len(matches):
+            return self.pickBestMonster(matches), None, 'Full name match on full list, max of {}'.format(len(matches))
 
-    'Skill Charge': 'misc_skillcharge',
-    'Super Additional Attack': 'misc_super_extraattack',
-    'Resistance-Bind＋': 'res_bind_super',
-    'Extend Time＋': 'misc_te_super',
-    'Resistance-Cloud': 'res_cloud',
-    'Resistance-Board Restrict': 'res_seal',
-    'Skill Boost＋': 'misc_sb_super',
-    'L-Shape Attack': 'l_attack',
-    'L-Shape Damage Reduction': 'l_shield',
-    'Enhance when HP is below 50%': 'attack_boost_low',
-    'Enhance when HP is above 80%': 'attack_boost_high',
-    'Combo Orb': 'orb_combo',
-    'Skill Voice': 'misc_voice',
-    'Dungeon Bonus': 'misc_dungeonbonus',
-}
+        # No decent matches. Try near hits on nickname instead
+        matches = difflib.get_close_matches(query, self.all_entries.keys(), n=1, cutoff=.8)
+        if len(matches):
+            match = matches[0]
+            return self.all_entries[match], None, 'Close nickname match ({})'.format(match)
 
-AWAKENING_NAME_MAP = {
-    'Enhanced Fire Orbs': 'R-OE',
-    'Enhanced Water Orbs': 'B-OE',
-    'Enhanced Wood Orbs': 'G-OE',
-    'Enhanced Light Orbs': 'L-OE',
-    'Enhanced Dark Orbs': 'D-OE',
-    'Enhanced Heal Orbs': 'H-OE',
+        # Still no decent matches. Try near hits on full name instead
+        matches = difflib.get_close_matches(
+            query, self.all_na_name_to_monsters.keys(), n=1, cutoff=.9)
+        if len(matches):
+            match = matches[0]
+            return self.all_na_name_to_monsters[match], None, 'Close name match ({})'.format(match)
 
-    'Enhanced Fire Att.': 'R-RE',
-    'Enhanced Water Att.': 'B-RE',
-    'Enhanced Wood Att.': 'G-RE',
-    'Enhanced Light Att.': 'L-RE',
-    'Enhanced Dark Att.': 'D-RE',
-
-    'Enhanced HP': 'HP',
-    'Enhanced Attack': 'ATK',
-    'Enhanced Heal': 'RCV',
-
-    'Enhanced Team HP': 'TEAM-HP',
-    'Enhanced Team Attack': 'TEAM-ATK',
-    'Enhanced Team RCV': 'TEAM-RCV',
-
-    'Auto-Recover': 'AUTO-RECOVER',
-    'Skill Boost': 'SB',
-    'Resistance-Skill Bind': 'SBR',
-    'Two-Pronged Attack': 'TPA',
-    'Multi Boost': 'MULTI-BOOST',
-    'Recover Bind': 'RCV-BIND',
-    'Extend Time': 'TE',
-    'Enhanced Combo': 'COMBO-BOOST',
-    'Guard Break': 'DEF-BREAK',
-    'Additional Attack': 'EXTRA-ATK',
-    'Damage Void Shield Penetration': 'VOID-BREAK',
-    'Awoken Assist': 'ASSIST',
-
-    'Resistance-Bind': 'RES-BIND',
-    'Resistance-Dark': 'RES-BLIND',
-    'Resistance-Poison': 'RES-POISON',
-    'Resistance-Jammers': 'RES-JAMMER',
-
-    'Reduce Fire Damage': 'R-RES',
-    'Reduce Water Damage': 'B-RES',
-    'Reduce Wood Damage': 'G-RES',
-    'Reduce Light Damage': 'L-RES',
-    'Reduce Dark Damage': 'D-RES',
-
-    'Healer Killer': 'K-HEALER',
-    'Machine Killer': 'K-MACHINE',
-    'Dragon Killer': 'K-DRAGON',
-    'Attacker Killer': 'K-ATTACKER',
-    'Physical Killer': 'K-PHYSICAL',
-    'God Killer': 'K-GOD',
-    'Devil Killer': 'K-DEVIL',
-    'Balance Killer': 'K-BALANCE',
-}
-
-
-def createMultiplierText(hp1, atk1, rcv1, resist1, hp2=None, atk2=None, rcv2=None, resist2=None):
-    hp2, atk2, rcv2, resist2 = hp2 or hp1, atk2 or atk1, rcv2 or rcv1, resist2 or resist1
-
-    def fmtNum(val):
-        return ('{:.2f}').format(val).strip('0').rstrip('.')
-    text = "{}/{}/{}".format(fmtNum(hp1 * hp2), fmtNum(atk1 * atk2), fmtNum(rcv1 * rcv2))
-    if resist1 * resist2 < 1:
-        resist1 = resist1 if resist1 < 1 else 0
-        resist2 = resist2 if resist2 < 1 else 0
-        text += ' Resist {}%'.format(fmtNum(100 * (1 - (1 - resist1) * (1 - resist2))))
-    return text
+        # couldn't find anything
+        return None, "Could not find a match for: " + query, None
+    
+    def find_monster_multiple_prefixes(self, query):
+        query = rpadutils.rmdiacritics(query).lower().strip()
+        # id search
+        if query.isdigit():
+            m = self.monster_no_na_to_named_monster.get(int(query))
+            if m is None:
+                return None, 'Looks like a monster ID but was not found', None
+            else:
+                return m, None, "ID lookup"
+            # special handling for na/jp
+    
+        # TODO: need to handle na_only?
+    
+        # handle exact nickname match
+        if query in self.all_entries:
+            return self.all_entries[query], None, "Exact nickname"
+    
+        contains_jp = rpadutils.containsJp(query)
+        if len(query) < 2 and contains_jp:
+            return None, 'Japanese queries must be at least 2 characters', None
+        elif len(query) < 4 and not contains_jp:
+            return None, 'Your query must be at least 4 letters', None
+        
+        query_prefixes = []
+        parts_of_query = query.split(' ')
+        parts_of_new_query = []
+        for part in parts_of_query:
+            if part in self.all_prefixes:
+                query_prefixes.append(part)
+            else:
+                parts_of_new_query.append(part)
+                break
+        new_query = ' '.join(parts_of_new_query)
+        
+        # if we don't actually have multiple prefixes, then default to using the regular id lookup
+        if len(query_prefixes) < 2:
+            return self.find_monster(query)
+        
+        matches = set()
+        for nickname, m in self.all_entries.items():
+            if new_query in nickname:
+                matches.add(m)
+        self.check_prefixes_from_potential_matches(matches, query_prefixes)
+        
+        if not len(matches):
+            for nickname, m in self.all_na_name_to_monsters.items():
+                if new_query in m.name_na.lower() or new_query in m.name_jp.lower():
+                    matches.add(m)
+            self.check_prefixes_from_potential_matches(matches, query_prefixes)
+            
+        if len(matches):
+            return self.pickBestMonster(matches), None, None
+        return None, "Could not find a match for: " + query, None
+        
+    
+    def check_prefixes_from_potential_matches(self, matches, query_prefixes):
+        to_remove = set()
+        for m in matches:
+            for prefix in query_prefixes:
+                if prefix not in m.prefixes:
+                    to_remove.add(m)
+                    break
+        for m in to_remove:
+            matches.remove(m)
+    
+    def pickBestMonster(self, named_monster_list):
+        return max(named_monster_list, key=lambda x: (not x.is_low_priority, x.rarity, x.monster_no_na))
 
 
-def _map_awakenings_text(m: padguide2.PgMonster):
-    awakenings_row = ''
-    unique_awakenings = set(m.awakening_names)
-    for a in unique_awakenings:
-        count = m.awakening_names.count(a)
-        awakenings_row += ' {}x{}'.format(AWAKENING_NAME_MAP.get(a, a), count)
-    awakenings_row = awakenings_row.strip()
+class NamedMonsterGroup(object):
+    def __init__(self, monster_group: MonsterGroup, basename_overrides: list):
+        self.is_low_priority = (
+            self._is_low_priority_monster(monster_group.base_monster)
+            or self._is_low_priority_group(monster_group))
 
-    if not len(awakenings_row):
-        awakenings_row = 'No Awakenings'
+        monsters = monster_group.members
+        self.group_size = len(monsters)
+        self.base_monster_no = monster_group.base_monster.monster_no
+        self.base_monster_no_na = monster_group.base_monster.monster_no_na
 
-    return awakenings_row
+        self.monster_no_to_basename = {
+            m.monster_no: self._compute_monster_basename(m) for m in monsters
+        }
+
+        self.computed_basename = self._compute_group_basename(monsters)
+        self.computed_basenames = set([self.computed_basename])
+        if '-' in self.computed_basename:
+            self.computed_basenames.add(self.computed_basename.replace('-', ' '))
+
+        self.basenames = basename_overrides or self.computed_basenames
+
+    def _compute_monster_basename(self, m: PgMonster):
+        basename = m.name_na.lower()
+        if ',' in basename:
+            name_parts = basename.split(',')
+            if name_parts[1].strip().startswith('the '):
+                # handle names like 'xxx, the yyy' where xxx is the name
+                basename = name_parts[0]
+            else:
+                # otherwise, grab the chunk after the last comma
+                basename = name_parts[-1]
+
+        for x in ['awoken', 'reincarnated']:
+            if basename.startswith(x):
+                basename = basename.replace(x, '')
+
+        # Fix for DC collab garbage
+        basename = basename.replace('(comics)', '')
+        basename = basename.replace('(film)', '')
+
+        return basename.strip()
+
+    def _compute_group_basename(self, monsters):
+        """Computes the basename for a group of monsters.
+
+        Prefer a basename with the largest count across the group. If all the
+        groups have equal size, prefer the lowest monster number basename.
+        This monster in general has better names, particularly when all the
+        names are unique, e.g. for male/female hunters."""
+        def count_and_id(): return [0, 0]
+        basename_to_info = defaultdict(count_and_id)
+
+        for m in monsters:
+            basename = self.monster_no_to_basename[m.monster_no]
+            entry = basename_to_info[basename]
+            entry[0] += 1
+            entry[1] = max(entry[1], m.monster_no)
+
+        entries = [[count_id[0], -1 * count_id[1], bn] for bn, count_id in basename_to_info.items()]
+        return max(entries)[2]
+
+    def _is_low_priority_monster(self, m: PgMonster):
+        lp_types = ['evolve', 'enhance', 'protected', 'awoken', 'vendor']
+        lp_substrings = ['tamadra']
+        lp_min_rarity = 2
+        name = m.name_na.lower()
+
+        failed_type = m.type1.lower() in lp_types
+        failed_ss = any([x in name for x in lp_substrings])
+        failed_rarity = m.rarity < lp_min_rarity
+        failed_chibi = name == m.name_na and m.name_na != m.name_jp
+        failed_equip = m.is_equip
+        return failed_type or failed_ss or failed_rarity or failed_chibi or failed_equip
+
+    def _is_low_priority_group(self, mg: MonsterGroup):
+        lp_grp_min_rarity = 5
+        max_rarity = max(m.rarity for m in mg.members)
+        failed_max_rarity = max_rarity < lp_grp_min_rarity
+        return failed_max_rarity
 
 
-# TODO: move to padguide2
+class NamedMonster(object):
+    def __init__(self, monster: PgMonster, monster_group: NamedMonsterGroup, prefixes: set, extra_nicknames: set):
+        # Must not hold onto monster or monster_group!
+
+        # Hold on to the IDs instead
+        self.monster_no = monster.monster_no
+        self.monster_no_na = monster.monster_no_na
+        self.monster_no_jp = monster.monster_no_jp
+
+        # ID of the root of the tree for this monster
+        self.base_monster_no = monster_group.base_monster_no
+        self.base_monster_no_na = monster_group.base_monster_no_na
+
+        # This stuff is important for nickname generation
+        self.group_basenames = monster_group.basenames
+        self.prefixes = prefixes
+
+        # Data used to determine how to rank the nicknames
+        self.is_low_priority = monster_group.is_low_priority or monster.is_equip
+        self.group_size = monster_group.group_size
+        self.rarity = monster.rarity
+
+        # Used in fallback searches
+        self.name_na = monster.name_na
+        self.name_jp = monster.name_jp
+
+        # These are just extra metadata
+        self.monster_basename = monster_group.monster_no_to_basename[self.monster_no]
+        self.group_computed_basename = monster_group.computed_basename
+        self.extra_nicknames = extra_nicknames
+
+        # Compute any extra prefixes
+        if self.monster_basename in ('ana', 'ace'):
+            self.prefixes.add(self.monster_basename)
+
+        # Compute extra basenames by checking for two-word basenames and using the second half
+        self.two_word_basenames = set()
+        for basename in self.group_basenames:
+            basename_words = basename.split(' ')
+            if len(basename_words) == 2:
+                self.two_word_basenames.add(basename_words[1])
+
+        # The primary result nicknames
+        self.final_nicknames = set()
+        # Set the configured override nicknames
+        self.final_nicknames.update(self.extra_nicknames)
+        # Set the roma subname for JP monsters
+        if monster.roma_subname:
+            self.final_nicknames.add(monster.roma_subname)
+
+        # For each basename, add nicknames
+        for basename in self.group_basenames:
+            # Add the basename directly
+            self.final_nicknames.add(basename)
+            # Add the prefix plus basename, and the prefix with a space between basename
+            for prefix in self.prefixes:
+                self.final_nicknames.add(prefix + basename)
+                self.final_nicknames.add(prefix + ' ' + basename)
+
+        self.final_two_word_nicknames = set()
+        # Slightly different process for two-word basenames. Does this make sense? Who knows.
+        for basename in self.two_word_basenames:
+            self.final_two_word_nicknames.add(basename)
+            # Add the prefix plus basename, and the prefix with a space between basename
+            for prefix in self.prefixes:
+                self.final_two_word_nicknames.add(prefix + basename)
+                self.final_two_word_nicknames.add(prefix + ' ' + basename)
+
+
 def compute_killers(*types):
     if 'Balance' in types:
         return ['Any']

--- a/padguide2/padguide2.py
+++ b/padguide2/padguide2.py
@@ -1,2502 +1,1102 @@
-"""
-Provides access to PadGuide data.
-
-Loads every PadGuide related JSON into a simple data structure, and then
-combines them into a an in-memory interconnected database.
-
-Don't hold on to any of the dastructures exported from here, or the
-entire database could be leaked when the module is reloaded.
-"""
-from _collections import defaultdict
 import asyncio
-import csv
-from datetime import datetime
-from datetime import timedelta
-import difflib
-from itertools import groupby
+from builtins import filter, map
+from collections import OrderedDict
+from collections import defaultdict
+import io
 import json
-from operator import itemgetter
-import os
 import re
-import time
 import traceback
 
-import aiohttp
+from dateutil import tz
 import discord
 from discord.ext import commands
 from enum import Enum
-import pytz
-import romkan
+import prettytable
 
-from __main__ import send_cmd_help
+from __main__ import user_allowed, send_cmd_help
 
+from . import padguide2
 from . import rpadutils
+from .rpadutils import *
 from .rpadutils import CogSettings
 from .utils import checks
-from .utils.chat_formatting import box, inline
+from .utils.chat_formatting import *
 from .utils.dataIO import dataIO
 
 
-DUMMY_FILE_PATTERN = 'data/padguide2/{}.dummy'
-JSON_FILE_PATTERN = 'data/padguide2/{}.json'
-CSV_FILE_PATTERN = 'data/padguide2/{}.csv'
-ATTR_EXPORT_PATH = 'data/padguide2/card_data.csv'
-NAMES_EXPORT_PATH = 'data/padguide2/computed_names.json'
-BASENAMES_EXPORT_PATH = 'data/padguide2/base_names.json'
-TRANSLATEDNAMES_EXPORT_PATH = 'data/padguide2/translated_names.json'
+HELP_MSG = """
+^helpid : shows this message
+^id <query> : look up a monster and print a link to puzzledragonx
+^pic <query> : Look up a monster and display its image inline
 
-SHEETS_PATTERN = 'https://docs.google.com/spreadsheets/d/1EoZJ3w5xsXZ67kmarLE4vfrZSIIIAfj04HXeZVST3eY/pub?gid={}&single=true&output=csv'
-GROUP_BASENAMES_OVERRIDES_SHEET = SHEETS_PATTERN.format('2070615818')
-NICKNAME_OVERRIDES_SHEET = SHEETS_PATTERN.format('0')
+Options for <query>
+    <id> : Find a monster by ID
+        ^id 1234 (picks sun quan)
+    <name> : Take the best guess for a monster, picks the most recent monster
+        ^id kali (picks uvo d kali)
+    <prefix> <name> : Limit by element or awoken, e.g.
+        ^id ares  (selects the most recent, awoken ares)
+        ^id aares (explicitly selects awoken ares)
+        ^id a ares (spaces work too)
+        ^id rd ares (select a specific evo for ares, the red/dark one)
+        ^id r/d ares (slashes, spaces work too)
 
-NICKNAME_FILE_PATTERN = CSV_FILE_PATTERN.format('nicknames')
-BASENAME_FILE_PATTERN = CSV_FILE_PATTERN.format('basenames')
+computed nickname list and overrides: https://docs.google.com/spreadsheets/d/1EyzMjvf8ZCQ4K-gJYnNkiZlCEsT9YYI9dUd-T5qCirc/pubhtml
+submit an override suggestion: https://docs.google.com/forms/d/1kJH9Q0S8iqqULwrRqB9dSxMOMebZj6uZjECqi4t9_z0/edit"""
+
+EMBED_NOT_GENERATED = -1
 
 
-class PadGuide2(object):
+INFO_PDX_TEMPLATE = 'http://www.puzzledragonx.com/en/monster.asp?n={}'
+RPAD_PIC_TEMPLATE = 'https://f002.backblazeb2.com/file/miru-data/padimages/{}/full/{}.png'
+RPAD_PORTRAIT_TEMPLATE = 'https://f002.backblazeb2.com/file/miru-data/padimages/{}/portrait/{}.png'
+VIDEO_TEMPLATE = 'https://f002.backblazeb2.com/file/miru-data/padimages/animated/{}.mp4'
+GIF_TEMPLATE = 'https://f002.backblazeb2.com/file/miru-data/padimages/animated/{}.gif'
+
+YT_SEARCH_TEMPLATE = 'https://www.youtube.com/results?search_query={}'
+SKYOZORA_TEMPLATE = 'http://pad.skyozora.com/pets/{}'
+
+
+def get_pdx_url(m):
+    return INFO_PDX_TEMPLATE.format(rpadutils.get_pdx_id(m))
+
+
+def get_portrait_url(m):
+    if int(m.monster_no) != m.monster_no_na:
+        return RPAD_PORTRAIT_TEMPLATE.format('na', m.monster_no_na)
+    else:
+        return RPAD_PORTRAIT_TEMPLATE.format('jp', m.monster_no_jp)
+
+
+def get_pic_url(m):
+    if int(m.monster_no) != m.monster_no_na:
+        return RPAD_PIC_TEMPLATE.format('na', m.monster_no_na)
+    else:
+        return RPAD_PIC_TEMPLATE.format('jp', m.monster_no_jp)
+
+
+class PadInfo:
     def __init__(self, bot):
         self.bot = bot
-        self._is_ready = asyncio.Event(loop=self.bot.loop)
 
-        self.settings = PadGuide2Settings("padguide2")
-        self.reload_task = None
+        self.settings = PadInfoSettings("padinfo")
 
-        self._standard_refresh = [
-            PgAttribute,
-            PgAwakening,
-            PgDungeon,
-            # PgDungeonDamage,
-            PgDungeonMonsterDrop,
-            PgDungeonMonster,
-            # PgDungeonSkill,
-            # PgDungeonType,
-            PgEggInstance,
-            PgEggMonster,
-            PgEggName,
-            PgEvent,
-            PgEvolution,
-            PgEvolutionMaterial,
-            PgMonster,
-            PgMonsterAddInfo,
-            PgMonsterInfo,
-            PgMonsterPrice,
-            PgSeries,
-            PgSkillLeaderData,
-            PgSkill,
-            PgSkillRotation,
-            PgSkillRotationDated,
-            # PgSubDungeon,
-            PgType,
-        ]
+        self.index_all = padguide2.empty_index()
+        self.index_na = padguide2.empty_index()
 
-        self._quick_refresh = [
-            PgScheduledEvent,
-        ]
+        self.menu = Menu(bot)
 
-        # A string -> int mapping, nicknames to monster_id_na
-        self.nickname_overrides = {}
+        # These emojis are the keys into the idmenu submenus
+        self.id_emoji = '\N{INFORMATION SOURCE}'
+        self.evo_emoji = char_to_emoji('e')
+        self.mats_emoji = char_to_emoji('m')
+        self.ls_emoji = '\N{INFORMATION SOURCE}'
+        self.left_emoji = char_to_emoji('l')
+        self.right_emoji = char_to_emoji('r')
+        self.pantheon_emoji = '\N{CLASSICAL BUILDING}'
+        self.skillups_emoji = '\N{MEAT ON BONE}'
+        self.pic_emoji = '\N{FRAME WITH PICTURE}'
+        self.other_info_emoji = '\N{SCROLL}'
 
-        # An int -> set(string), monster_id_na to set of basename overrides
-        self.basename_overrides = defaultdict(set)
+        self.historic_lookups_file_path = "data/padinfo/historic_lookups.json"
+        if not dataIO.is_valid_json(self.historic_lookups_file_path):
+            print("Creating empty historic_lookups.json...")
+            dataIO.save_json(self.historic_lookups_file_path, {})
 
-        self.database = PgRawDatabase(skip_load=True)
-
-        # Map of google-translated JP names to EN names
-        self.translated_names = {}
-
-    @asyncio.coroutine
-    def wait_until_ready(self):
-        """Wait until the PadGuide2 cog is ready.
-
-        Call this from other cogs to wait until PadGuide2 finishes refreshing its database
-        for the first time.
-        """
-        yield from self._is_ready.wait()
-
-    def create_index(self, accept_filter=None):
-        """Exported function that allows a client cog to create a monster index"""
-        return MonsterIndex(self.database, self.nickname_overrides, self.basename_overrides, accept_filter=accept_filter)
-
-    def get_monster_by_no(self, monster_no: int):
-        """Exported function that allows a client cog to get a full PgMonster by monster_no"""
-        return self.database.getMonster(monster_no)
-
-    def get_translated_jp_name(self, jp_name):
-        return self.translate_names.get(jp_name, None)
-
-    def register_tasks(self):
-        self.reload_task = self.bot.loop.create_task(self.reload_data_task())
+        self.historic_lookups = dataIO.load_json(self.historic_lookups_file_path)
 
     def __unload(self):
         # Manually nulling out database because the GC for cogs seems to be pretty shitty
-        self.database = None
-        self._is_ready.clear()
+        self.index_all = padguide2.empty_index()
+        self.index_na = padguide2.empty_index()
+        self.historic_lookups = {}
 
-    async def reload_data_task(self):
+    async def reload_nicknames(self):
         await self.bot.wait_until_ready()
+        while self == self.bot.get_cog('PadInfo'):
+            try:
+                await self.refresh_index()
+                print('Done refreshing PadInfo')
+            except Exception as ex:
+                print("reload padinfo loop caught exception " + str(ex))
+                traceback.print_exc()
+
+            await asyncio.sleep(60 * 60 * 1)
+
+    async def refresh_index(self):
+        """Refresh the monster indexes."""
+        pg_cog = self.bot.get_cog('PadGuide2')
+        await pg_cog.wait_until_ready()
+        self.index_all = pg_cog.create_index()
+        self.index_na = pg_cog.create_index(lambda m: m.on_na)
+
+    def get_monster_by_no(self, monster_no: int):
+        pg_cog = self.bot.get_cog('PadGuide2')
+        return pg_cog.get_monster_by_no(monster_no)
+
+    @commands.command(pass_context=True)
+    async def skillrotation(self, ctx, server: str='NA'):
+        """Print the current rotating skillups for a server (NA/JP)"""
+        server = normalizeServer(server)
+        if server not in ['NA', 'JP']:
+            await self.bot.say(inline('Supported servers are NA, JP'))
+            return
+
+        pg_cog = self.bot.get_cog('PadGuide2')
+        monsters = pg_cog.database.rotating_skillups(server)
+
+        for page in pagify(monsters_to_rotation_list(monsters, server, self.index_all)):
+            await self.bot.say(box(page))
+
+    @commands.command(pass_context=True)
+    async def jpname(self, ctx, *, query: str):
+        """Print the Japanese name of a monster"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self.bot.say(monsterToHeader(m))
+            await self.bot.say(box(m.name_jp))
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+
+    @commands.command(name="id", pass_context=True)
+    async def _do_id_all(self, ctx, *, query: str):
+        """Monster info (main tab)"""
+        await self._do_id(ctx, query)
+
+    @commands.command(name="idna", pass_context=True)
+    async def _do_id_na_multiple_prefixes(self, ctx, *, query: str):
+        """Monster info (limited to NA monsters ONLY)"""
+        await self._do_id(ctx, query, na_only=True)
+
+    @commands.command(name="id2", pass_context=True)
+    async def _do_id_all_multiple_prefixes(self, ctx, *, query: str):
+        """Monster info (main tab)"""
+        await self._do_id(ctx, query, multiple_prefixes=True)
+
+    @commands.command(name="idna2", pass_context=True)
+    async def _do_id_na(self, ctx, *, query: str):
+        """Monster info (limited to NA monsters ONLY)"""
+        await self._do_id(ctx, query, na_only=True, multiple_prefixes=True)
+    
+    async def _do_id(self, ctx, query: str, na_only=False, multiple_prefixes=False):
+        m, err, debug_info = self.findMonster(query, na_only=na_only, multiple_prefixes=multiple_prefixes)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.id_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+
+    @commands.command(name="evos", pass_context=True)
+    async def evos(self, ctx, *, query: str):
+        """Monster info (evolutions tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.evo_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+
+    @commands.command(name="mats", pass_context=True, aliases=['evomats', 'evomat'])
+    async def evomats(self, ctx, *, query: str):
+        """Monster info (evo materials tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.mats_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+
+    @commands.command(pass_context=True)
+    async def pantheon(self, ctx, *, query: str):
+        """Monster info (pantheon tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            menu = await self._do_idmenu(ctx, m, self.pantheon_emoji)
+            if menu == EMBED_NOT_GENERATED:
+                await self.bot.say(inline('Not a pantheon monster'))
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+
+    @commands.command(pass_context=True)
+    async def skillups(self, ctx, *, query: str):
+        """Monster info (evolutions tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            menu = await self._do_idmenu(ctx, m, self.skillups_emoji)
+            if menu == EMBED_NOT_GENERATED:
+                await self.bot.say(inline('No skillups available'))
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+
+    async def _do_idmenu(self, ctx, m, starting_menu_emoji):
+        id_embed = monsterToEmbed(m, self.get_emojis())
+        evo_embed = monsterToEvoEmbed(m)
+        mats_embed = monsterToEvoMatsEmbed(m)
+        animated = self.check_monster_animated(m.monster_no_jp)
+        pic_embed = monsterToPicEmbed(m, animated=animated)
+        other_info_embed = monsterToOtherInfoEmbed(m)
+
+        emoji_to_embed = OrderedDict()
+        emoji_to_embed[self.id_emoji] = id_embed
+        emoji_to_embed[self.evo_emoji] = evo_embed
+        emoji_to_embed[self.mats_emoji] = mats_embed
+        emoji_to_embed[self.pic_emoji] = pic_embed
+
+        pantheon_embed = monsterToPantheonEmbed(m)
+        if pantheon_embed:
+            emoji_to_embed[self.pantheon_emoji] = pantheon_embed
+
+        skillups_embed = monsterToSkillupsEmbed(m)
+        if skillups_embed:
+            emoji_to_embed[self.skillups_emoji] = skillups_embed
+
+        emoji_to_embed[self.other_info_emoji] = other_info_embed
+
+        return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed)
+
+    async def _do_evolistmenu(self, ctx, sm):
+        monsters = sm.alt_evos
+        monsters.sort(key=lambda m: m.monster_no)
+
+        emoji_to_embed = OrderedDict()
+        for idx, m in enumerate(monsters):
+            emoji = char_to_emoji(str(idx))
+            emoji_to_embed[emoji] = monsterToEmbed(m, self.get_emojis())
+            if m == sm:
+                starting_menu_emoji = emoji
+
+        return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed, timeout=60)
+
+    async def _do_menu(self, ctx, starting_menu_emoji, emoji_to_embed, timeout=30):
+        if starting_menu_emoji not in emoji_to_embed:
+            # Selected menu wasn't generated for this monster
+            return EMBED_NOT_GENERATED
+
+        remove_emoji = self.menu.emoji['no']
+        emoji_to_embed[remove_emoji] = self.menu.reaction_delete_message
 
         try:
-            # Try and load the PadGuide database the first time with existing files
-            self.database = PgRawDatabase(data_dir=self.settings.dataDir())
-            self._is_ready.set()
-            print('Finished initial PadGuide2 load with existing database')
+            result_msg, result_embed = await self.menu.custom_menu(ctx, emoji_to_embed, starting_menu_emoji, timeout=timeout)
+            if result_msg and result_embed:
+                # Message is finished but not deleted, clear the footer
+                result_embed.set_footer(text=discord.Embed.Empty)
+                await self.bot.edit_message(result_msg, embed=result_embed)
         except Exception as ex:
-            print(ex)
-            print('Initial PadGuide2 database load failed, waiting for download')
+            print('Menu failure', ex)
 
-        while self == self.bot.get_cog('PadGuide2'):
-            short_wait = False
-            try:
-                await self.download_and_refresh_nicknames()
-                print('Done refreshing PadGuide2, triggering ready')
-                self._is_ready.set()
-            except Exception as ex:
-                short_wait = True
-                print("padguide2 data download/refresh failed", ex)
-                traceback.print_exc()
+    @commands.command(pass_context=True, aliases=['img'])
+    async def pic(self, ctx, *, query: str):
+        """Monster info (full image tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.pic_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
 
-            try:
-                await self.translate_names()
-            except Exception as ex:
-                print("translations failed", ex)
-                traceback.print_exc()
+    @commands.command(pass_context=True, aliases=['stats'])
+    async def otherinfo(self, ctx, *, query: str):
+        """Monster info (misc info tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.other_info_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
 
-            try:
-                wait_time = 60 if short_wait else 60 * 60 * 4
-                await asyncio.sleep(wait_time)
-            except Exception as ex:
-                print("padguide2 data wait loop failed", ex)
-                traceback.print_exc()
-                raise ex
+    @commands.command(pass_context=True)
+    async def lookup(self, ctx, *, query: str):
+        """Short info results for a monster query"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            embed = monsterToHeaderEmbed(m)
+            await self.bot.say(embed=embed)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
 
-    async def reload_config_files(self):
-        os.remove(NICKNAME_FILE_PATTERN)
-        os.remove(BASENAME_FILE_PATTERN)
-        await self.download_and_refresh_nicknames()
+    @commands.command(pass_context=True)
+    async def evolist(self, ctx, *, query):
+        """Monster info (for all monsters in the evo tree)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self._do_evolistmenu(ctx, m)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
 
-    async def translate_names(self):
-        if os.path.exists(TRANSLATEDNAMES_EXPORT_PATH):
-            with open(TRANSLATEDNAMES_EXPORT_PATH) as f:
-                self.translated_names = json.load(f)
+    @commands.command(pass_context=True, aliases=['leaders', 'leaderskills', 'ls'])
+    async def leaderskill(self, ctx, left_query: str, right_query: str=None, *, bad=None):
+        """Display the multiplier and leaderskills for two monsters
 
-        for m in self.database.all_monsters():
-            name_jp = m.name_jp
-            if rpadutils.containsJp(name_jp) and name_jp not in self.translated_names:
-                self.translated_names[name_jp] = await rpadutils.translate_jp_en(self.bot, name_jp)
-            m.translated_jp_name = self.translated_names.get(name_jp, None)
+        If either your left or right query contains spaces, wrap in quotes.
+        e.g.: ^leaderskill "r sonia" "b sonia"
+        """
+        if bad:
+            await self.bot.say(inline('Too many inputs. Try wrapping your queries in quotes.'))
+            return
 
-        with open(TRANSLATEDNAMES_EXPORT_PATH, 'w', encoding='utf-8') as f:
-            json.dump(self.translated_names, f, sort_keys=True, indent=4)
+        # Handle a very specific failure case, user typing something like "uuvo ragdra"
+        if ' ' not in left_query and right_query is not None and ' ' not in right_query and bad is None:
+            combined_query = left_query + ' ' + right_query
+            nm, err, debug_info = self._findMonster(combined_query)
+            if nm and left_query in nm.prefixes:
+                left_query = combined_query
+                right_query = None
 
-    async def download_and_refresh_nicknames(self):
-        if not self.settings.dataDir():
-            await self._download_files()
-        await self._download_override_files()
+        left_m, left_err, _ = self.findMonster(left_query)
+        if right_query:
+            right_m, right_err, _ = self.findMonster(right_query)
+        else:
+            right_m, right_err, = left_m, left_err
 
-        nickname_overrides = self._csv_to_tuples(NICKNAME_FILE_PATTERN)
-        basename_overrides = self._csv_to_tuples(BASENAME_FILE_PATTERN)
+        err_msg = '{} query failed to match a monster: [ {} ]. If your query is multiple words, wrap it in quotes.'
+        if left_err:
+            await self.bot.say(inline(err_msg.format('Left', left_query)))
+            return
+        if right_err:
+            await self.bot.say(inline(err_msg.format('Right', right_query)))
+            return
 
-        self.nickname_overrides = {x[0].lower(): int(x[1])
-                                   for x in nickname_overrides if x[1].isdigit()}
+        emoji_to_embed = OrderedDict()
+        emoji_to_embed[self.ls_emoji] = monstersToLsEmbed(left_m, right_m)
+        emoji_to_embed[self.left_emoji] = monsterToEmbed(left_m, self.get_emojis())
+        emoji_to_embed[self.right_emoji] = monsterToEmbed(right_m, self.get_emojis())
 
-        self.basename_overrides = defaultdict(set)
-        for x in basename_overrides:
-            k, v = x
-            if k.isdigit():
-                self.basename_overrides[int(k)].add(v.lower())
+        await self._do_menu(ctx, self.ls_emoji, emoji_to_embed)
 
-        self.database = PgRawDatabase(data_dir=self.settings.dataDir())
-        self.index = MonsterIndex(self.database, self.nickname_overrides, self.basename_overrides)
+    @commands.command(name="helpid", pass_context=True, aliases=['helppic', 'helpimg'])
+    async def _helpid(self, ctx):
+        """Whispers you info on how to craft monster queries for ^id"""
+        await self.bot.whisper(box(HELP_MSG))
 
-        self.write_monster_attr_data()
-        self.write_monster_computed_names()
+    @commands.command(pass_context=True)
+    async def padsay(self, ctx, server, *, query: str=None):
+        """Speak the voice line of a monster into your current chat"""
+        voice = ctx.message.author.voice
+        channel = voice.voice_channel
+        if channel is None:
+            await self.bot.say(inline('You must be in a voice channel to use this command'))
+            return
 
-    def write_monster_computed_names(self):
-        results = {}
-        for name, nm in self.index.all_entries.items():
-            results[name] = int(rpadutils.get_pdx_id(nm))
+        speech_cog = self.bot.get_cog('Speech')
+        if not speech_cog:
+            await self.bot.say(inline('Speech seems to be offline'))
+            return
 
-        with open(NAMES_EXPORT_PATH, 'w', encoding='utf-8') as f:
-            json.dump(results, f, sort_keys=True)
+        if server.lower() not in ['na', 'jp']:
+            query = server + ' ' + (query or '')
+            server = 'na'
+        query = query.strip().lower()
 
-        results = {}
-        for nm in self.index.all_monsters:
-            entry = {'bn': list(nm.group_basenames)}
-            if nm.extra_nicknames:
-                entry['nn'] = list(nm.extra_nicknames)
-            results[int(rpadutils.get_pdx_id(nm))] = entry
-
-        with open(BASENAMES_EXPORT_PATH, 'w', encoding='utf-8') as f:
-            json.dump(results, f, sort_keys=True)
-
-    def write_monster_attr_data(self):
-        """Write id,server,attr1,attr2 to be used by the portrait generation process."""
-        attr_short_prefix_map = {
-            Attribute.Fire: 'r',
-            Attribute.Water: 'b',
-            Attribute.Wood: 'g',
-            Attribute.Light: 'l',
-            Attribute.Dark: 'd',
-        }
-
-        # Monsters who exist only in na have the same na/jp id but differing monster_no
-        na_only = [x for x in self.database._monster_map.values() if x.monster_no !=
-                   x.monster_no_na and x.monster_no_na == x.monster_no_jp]
-
-        na_only_base_no = [x.monster_no for x in na_only]
-        na_only_server_no = [x.monster_no_na for x in na_only]
-
-        with open(ATTR_EXPORT_PATH, 'w') as csvfile:
-            writer = csv.writer(csvfile, delimiter=',', lineterminator='\n')
-            for m in self.database._monster_map.values():
-                attr1 = attr_short_prefix_map[m.attr1]
-                attr2 = attr_short_prefix_map[m.attr2] if m.attr2 else ''
-                if m.monster_no in na_only_base_no:
-                    # Writes stuff like voltron
-                    writer.writerow([m.monster_no_na, 'na', attr1, attr2])
-                elif m.monster_no_jp in na_only_server_no:
-                    # Writes stuff like crows
-                    writer.writerow([m.monster_no_jp, 'jp', attr1, attr2])
-                else:
-                    # writes everything else
-                    writer.writerow([m.monster_no_na, 'na', attr1, attr2])
-                    writer.writerow([m.monster_no_jp, 'jp', attr1, attr2])
-
-    def _csv_to_tuples(self, file_path: str, cols: int=2):
-        # Loads a two-column CSV into an array of tuples.
-        results = []
-        with open(file_path, encoding='utf-8') as f:
-            file_reader = csv.reader(f, delimiter=',')
-            for row in file_reader:
-                if len(row) < 2:
-                    continue
-
-                data = [None] * cols
-                for i in range(0, min(cols, len(row))):
-                    data[i] = row[i].strip()
-
-                if not len(data[0]):
-                    continue
-
-                results.append(data)
-        return results
-
-    async def _download_files(self):
-        # twelve hours expiry
-        standard_expiry_secs = 12 * 60 * 60
-        # four hours expiry
-        quick_expiry_secs = 4 * 60 * 60
-
-        # Use a dummy file to proxy for the entire database being out of date
-        general_dummy_file = DUMMY_FILE_PATTERN.format('general')
-        download_all = rpadutils.checkPadguideCacheFile(general_dummy_file, quick_expiry_secs)
-
-        async with aiohttp.ClientSession() as client_session:
-            for type in self._standard_refresh:
-                endpoint = type.file_name()
-                result_file = JSON_FILE_PATTERN.format(endpoint)
-                if download_all or rpadutils.should_download(result_file, quick_expiry_secs):
-                    await rpadutils.async_cached_padguide_request(client_session, endpoint, result_file)
-                    # Sleep to avoid overwhelming with requests
-                    await asyncio.sleep(1)
-
-            for type in self._quick_refresh:
-                cur_time = int(round(time.time() * 1000))
-                three_weeks_ago = cur_time - 3 * 7 * 24 * 60 * 60 * 1000
-                endpoint = type.file_name()
-                result_file = JSON_FILE_PATTERN.format(endpoint)
-                if download_all or rpadutils.should_download(result_file, quick_expiry_secs):
-                    await rpadutils.async_cached_padguide_request(client_session, endpoint, result_file, time_ms=three_weeks_ago)
-
-    async def _download_override_files(self):
-        overrides_expiry_secs = 1 * 60 * 60
-        await rpadutils.makeAsyncCachedPlainRequest(
-            NICKNAME_FILE_PATTERN, NICKNAME_OVERRIDES_SHEET, overrides_expiry_secs)
-        await rpadutils.makeAsyncCachedPlainRequest(
-            BASENAME_FILE_PATTERN, GROUP_BASENAMES_OVERRIDES_SHEET, overrides_expiry_secs)
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            base_dir = '/home/tactical0retreat/pad_data/voices/fixed'
+            voice_file = os.path.join(base_dir, server, '{}.wav'.format(m.monster_no_na))
+            header = '{} ({})'.format(monsterToHeader(m), server)
+            if not os.path.exists(voice_file):
+                await self.bot.say(inline('Could not find voice for ' + header))
+                return
+            await self.bot.say('Speaking for ' + header)
+            await speech_cog.play_path(channel, voice_file)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
 
     @commands.group(pass_context=True)
     @checks.is_owner()
-    async def padguide2(self, ctx):
-        """PAD database management"""
+    async def padinfo(self, ctx):
+        """PAD info management"""
         if ctx.invoked_subcommand is None:
             await send_cmd_help(ctx)
 
-    @padguide2.command(pass_context=True)
+    @padinfo.command(pass_context=True)
     @checks.is_owner()
-    async def setdatadir(self, ctx, *, data_dir):
-        """Set a local path to padguide data instead of downloading it."""
-        self.settings.setDataDir(data_dir)
+    async def setemojiservers(self, ctx, *, emoji_servers=''):
+        """Set the emoji servers by ID (csv)"""
+        self.settings.emojiServers().clear()
+        if emoji_servers:
+            self.settings.setEmojiServers(emoji_servers.split(','))
+        await self.bot.say(inline('Set {} servers'.format(len(self.settings.emojiServers()))))
+
+    def get_emojis(self):
+        server_ids = self.settings.emojiServers()
+        return [e for s in self.bot.servers if s.id in server_ids for e in s.emojis]
+
+    def makeFailureMsg(self, err):
+        msg = 'Lookup failed: {}.\n'.format(err)
+        msg += 'Try one of <id>, <name>, [argbld]/[rgbld] <name>. Unexpected results? Use ^helpid for more info.'
+        return box(msg)
+
+    def findMonster(self, query, na_only=False, multiple_prefixes=False):
+        query = rmdiacritics(query)
+        nm, err, debug_info = self._findMonster(query, na_only, multiple_prefixes)
+
+        monster_no = nm.monster_no if nm else -1
+        self.historic_lookups[query] = monster_no
+        dataIO.save_json(self.historic_lookups_file_path, self.historic_lookups)
+
+        m = self.get_monster_by_no(nm.monster_no) if nm else None
+
+        return m, err, debug_info
+
+    def _findMonster(self, query, na_only=False, multiple_prefixes=False):
+        monster_index = self.index_na if na_only else self.index_all
+        if multiple_prefixes:
+            return monster_index.find_monster_multiple_prefixes(query)
+        else:
+            return monster_index.find_monster(query)
+
+    def map_awakenings_text(self, m):
+        """Exported for use in other cogs"""
+        return _map_awakenings_text(m)
+
+    @padinfo.command(pass_context=True)
+    @checks.is_owner()
+    async def setanimationdir(self, ctx, *, animation_dir=''):
+        """Set a directory containing animated images"""
+        self.settings.setAnimationDir(animation_dir)
         await self.bot.say(inline('Done'))
 
+    def check_monster_animated(self, monster_id: int):
+        if not self.settings.animationDir():
+            return False
 
-class PadGuide2Settings(CogSettings):
-    def make_default_settings(self):
-        config = {
-            'data_dir': '',
-        }
-        return config
+        try:
+            animated_ids = set()
+            for f in os.listdir(self.settings.animationDir()):
+                f = f.replace('.mp4', '')
+                if f.isdigit() and int(f) == monster_id:
+                    return True
+        except:
+            pass
 
-    def dataDir(self):
-        return self.bot_settings['data_dir']
-
-    def setDataDir(self, data_dir):
-        self.bot_settings['data_dir'] = data_dir
-        self.save_settings()
+        return False
 
 
 def setup(bot):
-    n = PadGuide2(bot)
+    print('padinfo bot setup')
+    n = PadInfo(bot)
     bot.add_cog(n)
-    n.register_tasks()
+    bot.loop.create_task(n.reload_nicknames())
+    print('done adding padinfo bot')
 
 
-class PgRawDatabase(object):
-    def __init__(self, skip_load=False, data_dir=None):
-        self._skip_load = skip_load
-        self._data_dir = data_dir
-        self._all_pg_items = []
-
-        # Load raw data items into id->value maps
-        self._attribute_map = self._load(PgAttribute)
-        self._awakening_map = self._load(PgAwakening)
-        self._dungeon_map = self._load(PgDungeon)
-        # self._dungeon_damage_map = self._load(PgDungeonDamage)
-        self._dungeon_monster_drop_map = self._load(PgDungeonMonsterDrop)
-        self._dungeon_monster_map = self._load(PgDungeonMonster)
-        # self._dungeon_skill_map = self._load(PgDungeonSkill)
-        # self._dungeon_type_map = self._load(PgDungeonType)
-        self._event_map = self._load(PgEvent)
-        self._evolution_map = self._load(PgEvolution)
-        self._evolution_material_map = self._load(PgEvolutionMaterial)
-        self._monster_map = self._load(PgMonster)
-        self._monster_add_info_map = self._load(PgMonsterAddInfo)
-        self._monster_info_map = self._load(PgMonsterInfo)
-        self._monster_price_map = self._load(PgMonsterPrice)
-        self._series_map = self._load(PgSeries)
-        self._scheduled_event_map = self._load(PgScheduledEvent)
-        self._skill_leader_data_map = self._load(PgSkillLeaderData)
-        self._skill_map = self._load(PgSkill)
-        self._skill_rotation_map = self._load(PgSkillRotation)
-        self._skill_rotation_dated_map = self._load(PgSkillRotationDated)
-        # self._sub_dungeon_map = self._load(PgSubDungeon)
-        self._type_map = self._load(PgType)
-
-        self._egg_instance_map = self._load(PgEggInstance)
-        self._egg_monster_map = self._load(PgEggMonster)
-        self._egg_name_map = self._load(PgEggName)
-
-        # Ensure that every item has loaded its dependencies
-        for i in self._all_pg_items:
-            self._ensure_loaded(i)
-
-        # Finish loading now that all the dependencies are resolved
-        for i in self._all_pg_items:
-            i.finalize()
-
-        # Stick the monsters into groups so that we can calculate info across
-        # the entire group
-        self.grouped_monsters = list()
-        for m in self._monster_map.values():
-            if m.cur_evo_type != EvoType.Base:
-                continue
-            self.grouped_monsters.append(MonsterGroup(m))
-
-        # Used to normalize from monster NA values back to monster number
-        self.monster_no_na_to_monster_no = {
-            m.monster_no_na: m.monster_no for m in self._monster_map.values()}
-
-        # Skill rotation map
-        self._server_to_rotating_skillups = {
-            'NA': [],
-            'JP': [],
+class PadInfoSettings(CogSettings):
+    def make_default_settings(self):
+        config = {
+            'animation_dir': '',
         }
-        for m in self._monster_map.values():
-            for server in m.server_actives:
-                self._server_to_rotating_skillups[server].append(m)
+        return config
 
-    def _load(self, itemtype):
-        if self._skip_load:
-            return {}
+    def emojiServers(self):
+        key = 'emoji_servers'
+        if key not in self.bot_settings:
+            self.bot_settings[key] = []
+        return self.bot_settings[key]
 
-        if self._data_dir:
-            file_path = os.path.join(self._data_dir, '{}.json'.format(itemtype.file_name()))
+    def setEmojiServers(self, emoji_servers):
+        es = self.emojiServers()
+        es.clear()
+        es.extend(emoji_servers)
+        self.save_settings()
+
+    def animationDir(self):
+        return self.bot_settings['animation_dir']
+
+    def setAnimationDir(self, animation_dir):
+        self.bot_settings['animation_dir'] = animation_dir
+        self.save_settings()
+
+
+def monsterToHeader(m: padguide2.PgMonster, link=False):
+    msg = 'No. {} {}'.format(m.monster_no_na, m.name_na)
+    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
+
+
+def monsterToJpSuffix(m: padguide2.PgMonster):
+    suffix = ""
+    if m.roma_subname:
+        suffix += ' [{}]'.format(m.roma_subname)
+    if not m.on_na:
+        suffix += ' (JP only)'
+    return suffix
+
+
+def monsterToLongHeader(m: padguide2.PgMonster, link=False):
+    msg = monsterToHeader(m) + monsterToJpSuffix(m)
+    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
+
+
+def monsterToLongHeaderWithAttr(m: padguide2.PgMonster, link=False):
+    header = 'No. {} {} {}'.format(
+        m.monster_no_na,
+        "({}{})".format(attr_prefix_map[m.attr1], "/" +
+                        attr_prefix_map[m.attr2] if m.attr2 else ""),
+        m.name_na)
+    msg = header + monsterToJpSuffix(m)
+    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
+
+
+def monsterToEvoText(m: padguide2.PgMonster):
+    output = monsterToLongHeader(m)
+    for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
+        output += "\n\t- {}".format(monsterToLongHeader(ae))
+    return output
+
+
+def monsterToThumbnailUrl(m: padguide2.PgMonster):
+    return get_portrait_url(m)
+
+
+def monsterToBaseEmbed(m: padguide2.PgMonster):
+    header = monsterToLongHeader(m)
+    embed = discord.Embed()
+    embed.set_thumbnail(url=monsterToThumbnailUrl(m))
+    embed.title = header
+    embed.url = get_pdx_url(m)
+    embed.set_footer(text='Requester may click the reactions below to switch tabs')
+    return embed
+
+
+def monsterToEvoEmbed(m: padguide2.PgMonster):
+    embed = monsterToBaseEmbed(m)
+
+    if not len(m.alt_evos):
+        embed.description = 'No alternate evos'
+        return embed
+
+    field_name = '{} alternate evos'.format(len(m.alt_evos))
+    field_data = ''
+    for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
+        field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
+
+    embed.add_field(name=field_name, value=field_data)
+
+    return embed
+
+
+def monsterToEvoMatsEmbed(m: padguide2.PgMonster):
+    embed = monsterToBaseEmbed(m)
+
+    mats_for_evo_size = len(m.mats_for_evo)
+    material_of_size = len(m.material_of)
+
+    field_name = 'Evo materials'
+    field_data = ''
+    if mats_for_evo_size:
+        for ae in m.mats_for_evo:
+            field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
+    else:
+        field_data = 'None'
+    embed.add_field(name=field_name, value=field_data)
+
+    if not material_of_size:
+        return embed
+
+    field_name = 'Material for'
+    field_data = ''
+    if material_of_size > 5:
+        field_data = '{} monsters'.format(material_of_size)
+    else:
+        item_count = min(material_of_size, 5)
+        for ae in sorted(m.material_of, key=lambda x: x.monster_no_na, reverse=True)[:item_count]:
+            field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
+    embed.add_field(name=field_name, value=field_data)
+
+    return embed
+
+
+def monsterToPantheonEmbed(m: padguide2.PgMonster):
+    full_pantheon = m.series.monsters
+    pantheon_list = list(filter(lambda x: x.evo_from is None, full_pantheon))
+    if len(pantheon_list) == 0 or len(pantheon_list) > 6:
+        return None
+
+    embed = monsterToBaseEmbed(m)
+
+    field_name = 'Pantheon: ' + m.series.name
+    field_data = ''
+    for monster in sorted(pantheon_list, key=lambda x: x.monster_no_na):
+        field_data += '\n' + monsterToHeader(monster, link=True)
+    embed.add_field(name=field_name, value=field_data)
+
+    return embed
+
+
+def monsterToSkillupsEmbed(m: padguide2.PgMonster):
+    skillups_list = m.active_skill.monsters_with_active if m.active_skill else []
+    skillups_list = list(filter(lambda m: m.sell_mp < 3000, skillups_list))
+    server_skillups = m.active_skill.server_skillups if m.active_skill else []
+
+    if len(skillups_list) + len(server_skillups) == 0:
+        return None
+
+    embed = monsterToBaseEmbed(m)
+
+    skillups_to_skip = []
+    for server, skillup in server_skillups.items():
+        skillup_header = 'Skillup in ' + server
+        skillup_body = monsterToHeader(skillup, link=True)
+        embed.add_field(name=skillup_header, value=skillup_body)
+        skillups_to_skip.append(skillup.monster_no_na)
+
+    field_name = 'Skillups'
+    field_data = ''
+
+    # Prevent huge skillup lists
+    if len(skillups_list) > 8:
+        field_data = '({} skillups omitted)'.format(len(skillups_list) - 8)
+        skillups_list = skillups_list[0:8]
+
+    for monster in sorted(skillups_list, key=lambda x: x.monster_no_na):
+        if monster.monster_no_na in skillups_to_skip:
+            continue
+        field_data += '\n' + monsterToHeader(monster, link=True)
+
+    if len(field_data.strip()):
+        embed.add_field(name=field_name, value=field_data)
+
+    return embed
+
+
+def monsterToPicUrl(m: padguide2.PgMonster):
+    return get_pic_url(m)
+
+
+def monsterToPicEmbed(m: padguide2.PgMonster, animated=False):
+    embed = monsterToBaseEmbed(m)
+    url = monsterToPicUrl(m)
+    embed.set_image(url=url)
+    # Clear the thumbnail, don't need it on pic
+    embed.set_thumbnail(url='')
+    if animated:
+        description = '[{}]({}) –– [{}]({})'.format(
+            'HQ (MP4)', monsterToVideoUrl(m), 'LQ (GIF)', monsterToGifUrl(m))
+        embed.add_field(name='Animated links', value=description)
+
+    return embed
+
+
+def monsterToVideoUrl(m: padguide2.PgMonster):
+    return VIDEO_TEMPLATE.format(m.monster_no_jp)
+
+
+def monsterToGifUrl(m: padguide2.PgMonster):
+    return GIF_TEMPLATE.format(m.monster_no_jp)
+
+
+def monsterToGifEmbed(m: padguide2.PgMonster):
+    embed = monsterToBaseEmbed(m)
+    url = monsterToGifUrl(m)
+    embed.set_image(url=url)
+    # Clear the thumbnail, don't need it on pic
+    embed.set_thumbnail(url='')
+    return embed
+
+
+def monstersToLsEmbed(left_m: padguide2.PgMonster, right_m: padguide2.PgMonster):
+    lhp, latk, lrcv, lresist = left_m.leader_skill_data.get_data()
+    rhp, ratk, rrcv, rresist = right_m.leader_skill_data.get_data()
+    multiplier_text = createMultiplierText(lhp, latk, lrcv, lresist, rhp, ratk, rrcv, rresist)
+
+    embed = discord.Embed()
+    embed.title = 'Multiplier [{}]\n\n'.format(multiplier_text)
+    description = ''
+    description += '\n**{}**\n{}'.format(
+        monsterToHeader(left_m, link=True),
+        left_m.leader_skill.desc if left_m.leader_skill else 'None/Missing')
+    description += '\n**{}**\n{}'.format(
+        monsterToHeader(right_m, link=True),
+        right_m.leader_skill.desc if right_m.leader_skill else 'None/Missing')
+    embed.description = description
+
+    return embed
+
+
+def monsterToHeaderEmbed(m: padguide2.PgMonster):
+    header = monsterToLongHeader(m, link=True)
+    embed = discord.Embed()
+    embed.description = header
+    return embed
+
+
+def monsterToTypeString(m: padguide2.PgMonster):
+    output = m.type1
+    if m.type2:
+        output += '/' + m.type2
+    if m.type3:
+        output += '/' + m.type3
+    return output
+
+
+def monsterToAcquireString(m: padguide2.PgMonster):
+    acquire_text = None
+    if m.farmable and not m.mp_evo:
+        # Some MP shop monsters 'drop' in PADR
+        acquire_text = 'Farmable'
+    elif m.farmable_evo and not m.mp_evo:
+        acquire_text = 'Farmable Evo'
+    elif m.in_pem:
+        acquire_text = 'In PEM'
+    elif m.pem_evo:
+        acquire_text = 'PEM Evo'
+    elif m.in_rem:
+        acquire_text = 'In REM'
+    elif m.rem_evo:
+        acquire_text = 'REM Evo'
+    elif m.in_mpshop:
+        acquire_text = 'MP Shop'
+    elif m.mp_evo:
+        acquire_text = 'MP Shop Evo'
+    return acquire_text
+
+
+def match_emoji(emoji_list, name):
+    for e in emoji_list:
+        if e.name == name:
+            return e
+    return None
+
+
+def monsterToEmbed(m: padguide2.PgMonster, emoji_list):
+    embed = monsterToBaseEmbed(m)
+
+    info_row_1 = monsterToTypeString(m)
+    acquire_text = monsterToAcquireString(m)
+
+    info_row_2 = '**Rarity** {}\n**Cost** {}'.format(m.rarity, m.cost)
+    if acquire_text:
+        info_row_2 += '\n**{}**'.format(acquire_text)
+    if m.is_inheritable:
+        info_row_2 += '\n**Inheritable**'
+    else:
+        info_row_2 += '\n**Not inheritable**'
+
+    embed.add_field(name=info_row_1, value=info_row_2)
+
+    if m.limitbreak_stats and m.limitbreak_stats > 1:
+        def lb(x): return int(round(m.limitbreak_stats * x))
+        stats_row_1 = 'Weighted {} | LB {}'.format(m.weighted_stats, lb(m.weighted_stats))
+        stats_row_2 = '**HP** {} ({})\n**ATK** {} ({})\n**RCV** {} ({})'.format(
+            m.hp, lb(m.hp), m.atk, lb(m.atk), m.rcv, lb(m.rcv))
+    else:
+        stats_row_1 = 'Weighted {}'.format(m.weighted_stats)
+        stats_row_2 = '**HP** {}\n**ATK** {}\n**RCV** {}'.format(m.hp, m.atk, m.rcv)
+    embed.add_field(name=stats_row_1, value=stats_row_2)
+
+    awakenings_row = ''
+    for idx, a in enumerate(m.awakenings):
+        a = a.get_name()
+        mapped_awakening = AWAKENING_NAME_MAP_RPAD.get(a, a)
+        mapped_awakening = match_emoji(emoji_list, mapped_awakening)
+
+        if mapped_awakening is None:
+            mapped_awakening = AWAKENING_NAME_MAP.get(a, a)
+
+        # Wrap superawakenings to the next line
+        if len(m.awakenings) - idx == m.superawakening_count:
+            awakenings_row += '\n{}'.format(mapped_awakening)
         else:
-            file_path = JSON_FILE_PATTERN.format(itemtype.file_name())
-        item_list = []
-
-        if dataIO.is_valid_json(file_path):
-            json_data = dataIO.load_json(file_path)
-            item_list = [itemtype(item) for item in json_data['items']]
-
-        result_map = {item.key(): item for item in item_list if not item.deleted()}
-
-        self._all_pg_items.extend(result_map.values())
-
-        return result_map
-
-    def _ensure_loaded(self, item: 'PgItem'):
-        if item:
-            item.ensure_loaded(self)
-        return item
-
-    def normalize_monster_no_na(self, monster_no_na: int):
-        if monster_no_na > 10000:
-            # Allows crows to be referenced
-            return monster_no_na - 10000
-        return self.monster_no_na_to_monster_no[monster_no_na]
-
-    def all_monsters(self):
-        """Exported for access to the full monster list."""
-        return list(self._monster_map.values())
-
-    def all_dungeons(self):
-        """Exported for access to the full dungeon list."""
-        return list(self._dungeon_map.values())
-
-    def all_egg_instances(self):
-        """Exported for access to the full egg machine list."""
-        return list(self._egg_instance_map.values())
-
-    def all_scheduled_events(self):
-        """Exported for access to event list."""
-        se = list(self._scheduled_event_map.values())
-        return se
-
-    def rotating_skillups(self, server: str):
-        """Gets monsters used as rotating skillups for the specified server"""
-        return list(self._server_to_rotating_skillups[server])
-
-    def getAttributeEnum(self, ta_seq: int):
-        attr = self._ensure_loaded(self._attribute_map.get(ta_seq))
-        return attr.value if attr else None
-
-    def getAwakening(self, tma_seq: int):
-        return self._ensure_loaded(self._awakening_map.get(tma_seq))
-
-    def getDungeon(self, dungeon_seq: int):
-        return self._ensure_loaded(self._dungeon_map.get(dungeon_seq))
-
-#    def getDungeonDamage(self, tds_seq: int):
-#        return self._ensure_loaded(self._dungeon_damage_map.get(tds_seq))
-
-    def getDungeonMonsterDrop(self, tdmd_seq: int):
-        return self._ensure_loaded(self._dungeon_monster_drop_map.get(tdmd_seq))
-
-    def getDungeonMonster(self, tdm_seq: int):
-        return self._ensure_loaded(self._dungeon_monster_map.get(tdm_seq))
-
-#    def getDungeonType(self, tdt_seq: int):
-#        return self._ensure_loaded(self._dungeon_type_map.get(tdt_seq))
-
-    def getEvent(self, event_seq: int):
-        return self._ensure_loaded(self._event_map.get(event_seq))
-
-    def getEvolution(self, tv_seq: int):
-        return self._ensure_loaded(self._evolution_map.get(tv_seq))
-
-    def getEvolutionMaterial(self, tem_seq: int):
-        return self._ensure_loaded(self._evolution_material_map.get(tem_seq))
-
-    def getMonster(self, monster_no: int):
-        return self._ensure_loaded(self._monster_map.get(monster_no))
-
-    def getMonsterAddInfo(self, monster_no: int):
-        return self._ensure_loaded(self._monster_add_info_map.get(monster_no))
-
-    def getMonsterInfo(self, monster_no: int):
-        return self._ensure_loaded(self._monster_info_map.get(monster_no))
-
-    def getMonsterPrice(self, monster_no: int):
-        return self._ensure_loaded(self._monster_price_map.get(monster_no))
-
-    def getSeries(self, tsr_seq: int):
-        return self._ensure_loaded(self._series_map.get(tsr_seq))
-
-    def getScheduledEvent(self, schedule_seq: int):
-        return self._ensure_loaded(self._scheduled_event_map.get(schedule_seq))
-
-    def getSkill(self, ts_seq: int):
-        return self._ensure_loaded(self._skill_map.get(ts_seq))
-
-    def getSkillLeaderData(self, ts_seq: int):
-        skill_leader = self._skill_leader_data_map.get(ts_seq)
-        if skill_leader:
-            return self._ensure_loaded(skill_leader)
-        else:
-            return PgSkillLeaderData.empty()
-
-    def getSkillRotation(self, tsr_seq: int):
-        return self._ensure_loaded(self._skill_rotation_map.get(tsr_seq))
-
-    def getSkillRotationDated(self, tsrl_seq: int):
-        return self._ensure_loaded(self._skill_rotation_dated_map.get(tsrl_seq))
-
-#    def getSubDungeon(self, tsd_seq: int):
-#        return self._ensure_loaded(self._sub_dungeon_map.get(tsd_seq))
-
-    def getTypeName(self, tt_seq: int):
-        type = self._ensure_loaded(self._type_map.get(tt_seq))
-        return type.name if type else None
-
-    def getEggInstance(self, tet_seq: int):
-        return self._ensure_loaded(self._egg_instance_map.get(tet_seq))
-
-    def getEggMonster(self, tem_seq: int):
-        return self._ensure_loaded(self._egg_monster_map.get(tem_seq))
-
-    def getEggName(self, tetn_seq: int):
-        return self._ensure_loaded(self._egg_name_map.get(tetn_seq))
-
-
-class PgItem(object):
-    """Base class for all items loaded from PadGuide.
-
-    You must call super().__init__() in your constructor.
-    You must override key() and load().
-    """
-
-    def __init__(self):
-        self._loaded = False
-
-    def key(self):
-        """Used to look up an item by id."""
-        raise NotImplementedError()
-
-    def deleted(self):
-        """Is this item marked for deletion. Discard if true. Not all items can be deleted."""
-        return False
-
-    def ensure_loaded(self, database: PgRawDatabase):
-        """Ensures that the dependencies have been loaded, or loads them."""
-        if not self._loaded:
-            self._loaded = True
-            self._loading_error = False
-            try:
-                self.load(database)
-            except Exception as ex:
-                self._loading_error = False
-                print('Error occurred while loading item')
-                print(type(self), 'key=', self.key())
-                traceback.print_exc()
-
-        return self
-
-    def load(self, database: PgRawDatabase):
-        """Override to inject dependencies."""
-        raise NotImplementedError()
-
-    def finalize(self):
-        """Finish filling in anything that requires completion but no dependencies."""
-        pass
-
-
-class Attribute(Enum):
-    """Standard 5 PAD colors in enum form. Values correspond to PadGuide values."""
-    Fire = 1
-    Water = 2
-    Wood = 3
-    Light = 4
-    Dark = 5
-
-
-# attributeList
-# {
-#     "ORDER_IDX": "2",
-#     "TA_NAME_JP": "\u6c34",
-#     "TA_NAME_KR": "\ubb3c",
-#     "TA_NAME_US": "Water",
-#     "TA_SEQ": "2",
-#     "TSTAMP": "1372947975226"
-# },
-class PgAttribute(PgItem):
-    @staticmethod
-    def file_name():
-        return 'attributeList'
-
-    def __init__(self, item):
-        super().__init__()
-        self.ta_seq = int(item['TA_SEQ'])  # unique id
-        self.name = item['TA_NAME_US']
-
-        self.value = Attribute(self.ta_seq)
-
-    def key(self):
-        return self.ta_seq
-
-    def load(self, database: PgRawDatabase):
-        pass
-
-
-# awokenSkillList
-# {
-#     "DEL_YN": "N",
-#     "IS_SUPER": "1",
-#     "MONSTER_NO": "661",
-#     "ORDER_IDX": "1",
-#     "TMA_SEQ": "1",
-#     "TSTAMP": "1380587210665",
-#     "TS_SEQ": "2769"
-# },
-class PgAwakening(PgItem):
-    @staticmethod
-    def file_name():
-        return 'awokenSkillList'
-
-    def __init__(self, item):
-        super().__init__()
-        self.tma_seq = int(item['TMA_SEQ'])  # unique id
-        self.ts_seq = int(item['TS_SEQ'])  # PgSkill id - awakening info
-        self.deleted_yn = item['DEL_YN']  # Either Y(discard) or N.
-        self.monster_no = int(item['MONSTER_NO'])  # PgMonster id - monster this belongs to
-        self.order = int(item['ORDER_IDX'])  # display order
-        self.is_super = item.get('IS_SUPER', '0') == '1'
-
-        self.skill = None  # type: PgSkill  # The awakening skill
-        self.monster = None  # type: PgMonster # The monster the awakening belongs to
-
-    def key(self):
-        return self.tma_seq
-
-    def deleted(self):
-        return self.deleted_yn == 'Y'
-
-    def load(self, database: PgRawDatabase):
-        self.skill = database.getSkill(self.ts_seq)
-        self.monster = database.getMonster(self.monster_no)
-
-        self.monster.awakenings.append(self)
-        self.skill.monsters_with_awakening.append(self.monster)
-
-    def get_name(self):
-        return self.skill.name
-
-
-# dungeonList
-# {
-#     "APP_VERSION": "",
-#     "COMMENT_JP": "",
-#     "COMMENT_KR": "",
-#     "COMMENT_US": "",
-#     "DUNGEON_SEQ": "102",
-#     "DUNGEON_TYPE": "1",
-#     "ICON_SEQ": "666",
-#     "NAME_JP": "ECO\u30b3\u30e9\u30dc",
-#     "NAME_KR": "ECO \ucf5c\ub77c\ubcf4",
-#     "NAME_US": "ECO Collab",
-#     "ORDER_IDX": "3",
-#     "SHOW_YN": "1",
-#     "TDT_SEQ": "10",
-#     "TSTAMP": "1373289123410"
-# },
-class PgDungeon(PgItem):
-    @staticmethod
-    def file_name():
-        return 'dungeonList'
-
-    def __init__(self, item):
-        super().__init__()
-        self.dungeon_seq = int(item['DUNGEON_SEQ'])
-        self.dungeon_type = int(item['DUNGEON_TYPE'])
-        # TODO: merge these two, delete DungeonType from padevents
-        self.dungeon_type_value = DungeonType(self.dungeon_type)
-        self.name = item['NAME_US']
-        self.name_jp = item['NAME_JP']
-        # TODO: load tdt type
-        self.tdt_seq = int_or_none(item['TDT_SEQ'])
-        self.show = item['SHOW_YN'] == 1
-        self.icon = int(item['ICON_SEQ'])
-
-        self.tdungeon_type = None
-        self.tdungeon_type_name = 'no_type'
-
-        self.monsters = []
-        self.subdungeons = []
-
-    def key(self):
-        return self.dungeon_seq
-
-    def deleted(self):
-        return False
-#         return not self.show
-
-    def load(self, database: PgRawDatabase):
-        pass
-#        if self.tdt_seq:
-#            self.tdungeon_type = database.getDungeonType(self.tdt_seq)
-#            # Somehow this can still fail
-#            if self.tdungeon_type:
-#                self.tdungeon_type_name = self.tdungeon_type.name
-
-
-class DungeonType(Enum):
-    Unknown = -1
-    Normal = 0
-    CoinDailyOther = 1
-    Technical = 2
-    Etc = 3
-
-
-# {
-#     "COIN_MAX": "2496",
-#     "COIN_MIN": "2496",
-#     "DUNGEON_SEQ": "81",
-#     "EXP_MAX": "2420",
-#     "EXP_MIN": "2420",
-#     "ORDER_IDX": "96",
-#     "STAGE": "5",
-#     "STAMINA": "15",
-#     "TSD_NAME_JP": "\u65ad\u7f6a\u306e\u7114 \u4e2d\u7d1a",
-#     "TSD_NAME_KR": "\ub2e8\uc8c4\uc758 \ubd88\uaf43 \uc911\uae09",
-#     "TSD_NAME_US": "Flame of Conviction - Int",
-#     "TSD_SEQ": "1365",
-#     "TSTAMP": "1373446281337"
-# },
-class PgSubDungeon(PgItem):
-    @staticmethod
-    def file_name():
-        return 'subDungeonList'
-
-    def __init__(self, item):
-        super().__init__()
-        self.dungeon_seq = int(item['DUNGEON_SEQ'])
-        self.exp_max = int(item['EXP_MAX'])
-        self.exp_min = int(item['EXP_MIN'])
-        self.order = int(item['ORDER_IDX'])
-        self.stage = int(item['STAGE'])
-        self.stamina = int(item['STAMINA'])
-        self.name = item['TSD_NAME_US']
-        self.tsd_seq = int(item['TSD_SEQ'])
-
-        self.monsters = []
-        self.floor_to_monsters = defaultdict(list)
-
-    def key(self):
-        return self.tsd_seq
-
-    def load(self, database: PgRawDatabase):
-        self.dungeon = database.getDungeon(self.dungeon_seq)
-        self.dungeon.subdungeons.append(self)
-
-
-# dungeonMonsterDropList.jsp
-# {
-#     "MONSTER_NO": "3427",
-#     "ORDER_IDX": "20",
-#     "STATUS": "0",
-#     "TDMD_SEQ": "967",
-#     "TDM_SEQ": "17816",
-#     "TSTAMP": "1489371218890"
-# },
-# Seems to be dedicated skillups only, like collab drops
-class PgDungeonMonsterDrop(PgItem):
-    @staticmethod
-    def file_name():
-        return 'dungeonMonsterDropList'
-
-    def __init__(self, item):
-        super().__init__()
-        self.tdmd_seq = int(item['TDMD_SEQ'])  # unique id
-        self.monster_no = int(item['MONSTER_NO'])
-        self.status = item['STATUS']  # if 1, good, if 0, bad
-        self.tdm_seq = int(item['TDM_SEQ'])  # PgDungeonMonster id
-
-        self.monster = None  # type: PgMonster
-        self.dungeon_monster = None  # type: PgDungeonMonster
-
-    def key(self):
-        return self.tdmd_seq
-
-    def deleted(self):
-        # TODO: Should we be checking status == 1?
-        return False
-
-    def load(self, database: PgRawDatabase):
-        self.monster = database.getMonster(self.monster_no)
-        self.dungeon_monster = database.getDungeonMonster(self.tdm_seq)
-
-
-# dungeonMonsterList
-# {
-#     "AMOUNT": "1",
-#     "ATK": "9810",
-#     "COMMENT_JP": "",
-#     "COMMENT_KR": "",
-#     "COMMENT_US": "",
-#     "DEF": "340",
-#     "DROP_NO": "2789",
-#     "DUNGEON_SEQ": "150",
-#     "FLOOR": "5",
-#     "HP": "3011250",
-#     "MONSTER_NO": "2789",
-#     "ORDER_IDX": "50",
-#     "TDM_SEQ": "53122",
-#     "TSD_SEQ": "4564",
-#     "TSTAMP": "1480298353178",
-#     "TURN": "1"
-# },
-class PgDungeonMonster(PgItem):
-    @staticmethod
-    def file_name():
-        return 'dungeonMonsterList'
-
-    def __init__(self, item):
-        super().__init__()
-        self.tdm_seq = int(item['TDM_SEQ'])  # unique id
-        self.amount = int(item['AMOUNT'])
-        self.atk = int(item['ATK'])
-        self.defence = int(item['DEF'])
-        self.drop_monster_no = int(item['DROP_NO'])  # PgMonster unique id
-        self.dungeon_seq = int(item['DUNGEON_SEQ'])  # PgDungeon uniqueId
-        self.floor = int(item['FLOOR'])
-        self.hp = int(item['HP'])
-        self.monster_no = int(item['MONSTER_NO'])  # PgMonster unique id
-        self.order = int(item['ORDER_IDX'])
-        self.tsd_seq = int(item['TSD_SEQ'])  # Sub Dungeon ID
-        self.turn = int(item['TURN'])
-
-        self.skills = []
-
-    def key(self):
-        return self.tdm_seq
-
-    def load(self, database: PgRawDatabase):
-        self.monster = database.getMonster(self.monster_no)
-
-        self.dungeon = database.getDungeon(self.dungeon_seq)
-        if self.dungeon:
-            self.dungeon.monsters.append(self)
-
-#         self.sub_dungeon = database.getSubDungeon(self.tsd_seq)
-#         self.sub_dungeon.monsters.append(self)
-#         self.sub_dungeon.floor_to_monsters[self.floor].append(self)
-
-        self.drop_monster = database.getMonster(self.drop_monster_no)
-        if self.drop_monster and self.dungeon:
-            self.drop_monster.drop_dungeons.append(self.dungeon)
-
-
-# {
-#     "TDM_SEQ": "15044", # dungeon monster
-#     "TDS_SEQ": "8934", # damage
-#     "TSTAMP": "100",
-#     "TS_SEQ": "2190" # skill
-# },
-class PgDungeonSkill(PgItem):
-    @staticmethod
-    def file_name():
-        return 'dungeonSkillList'
-
-    def __init__(self, item):
-        super().__init__()
-        self.tdm_seq = int(item['TDM_SEQ'])
-        self.tds_seq = int(item['TDS_SEQ'])
-        self.ts_seq = int(item['TS_SEQ'])
-
-    def key(self):
-        return '{},{},{}'.format(self.tdm_seq, self.tds_seq, self.ts_seq)
-
-    def load(self, database: PgRawDatabase):
-        self.dungeon_monster = database.getDungeonMonster(self.tdm_seq)
-        if self.dungeon_monster:
-            self.dungeon_monster.skills.append(self)
-        self.damage = database.getDungeonDamage(self.tds_seq)
-        self.skill = database.getSkill(self.ts_seq)
-
-
-# {
-#     "DAMAGE": "16538.0",
-#     "TDS_SEQ": "14631",
-#     "TSTAMP": "1401764306350"
-# },
-class PgDungeonDamage(PgItem):
-    @staticmethod
-    def file_name():
-        return 'dungeonSkillDamageList'
-
-    def __init__(self, item):
-        super().__init__()
-        self.tds_seq = int(item['TDS_SEQ'])
-        self.amount = float(item['DAMAGE'])
-
-        self.monsters = []
-        self.floor_to_monsters = defaultdict(list)
-
-    def key(self):
-        return self.tds_seq
-
-    def load(self, database: PgRawDatabase):
-        pass
-
-
-# {
-#     "ORDER_IDX": "120",
-#     "TDT_NAME_JP": "\u30a2\u30f3\u30b1\u30fc\u30c8",
-#     "TDT_NAME_KR": "\uc559\ucf00\uc774\ud2b8",
-#     "TDT_NAME_US": "Survey",
-#     "TDT_SEQ": "9",
-#     "TSTAMP": "1388128221704"
-# },
-class PgDungeonType(PgItem):
-    @staticmethod
-    def file_name():
-        return 'dungeonTypeList'
-
-    def __init__(self, item):
-        super().__init__()
-        self.name = item['TDT_NAME_US']
-        self.tdt_seq = int(item['TDT_SEQ'])
-
-    def key(self):
-        return self.tdt_seq
-
-    def load(self, database: PgRawDatabase):
-        pass
-
-
-class EvoType(Enum):
-    """Evo types supported by PadGuide. Numbers correspond to their id values."""
-    Base = -1  # Represents monsters who didn't require evo
-    Evo = 0
-    UvoAwoken = 1
-    UuvoReincarnated = 2
-
-
-# evolutionList
-# {
-#     "APP_VERSION": "",
-#     "COMMENT_JP": "",
-#     "COMMENT_KR": "",
-#     "COMMENT_US": "",
-#     "MONSTER_NO": "1",
-#     "TO_NO": "2",
-#     "TSTAMP": "1371788673999",
-#     "TV_SEQ": "331",
-#     "TV_TYPE": "0"
-# },
-class PgEvolution(PgItem):
-    @staticmethod
-    def file_name():
-        return 'evolutionList'
-
-    def __init__(self, item):
-        super().__init__()
-        self.tv_seq = int(item['TV_SEQ'])  # unique id
-        self.from_monster_no = int(item['MONSTER_NO'])  # PgMonster id - base monster
-        self.to_monster_no = int(item['TO_NO'])  # PgMonster id - target monster
-        self.tv_type = int(item['TV_TYPE'])
-        self.evo_type = EvoType(self.tv_type)
-
-    def key(self):
-        return self.tv_seq
-
-    def deleted(self):
-        # Really rare and unusual bug
-        return self.from_monster_no == 0 or self.to_monster_no == 0
-
-    def load(self, database: PgRawDatabase):
-        self.from_monster = database.getMonster(self.from_monster_no)
-        self.to_monster = database.getMonster(self.to_monster_no)
-
-        if self.to_monster:
-            self.to_monster.cur_evo_type = self.evo_type
-            if self.from_monster:
-                self.to_monster.evo_from = self.from_monster
-                self.from_monster.evo_to.append(self.to_monster)
-
-
-# evoMaterialList
-# {
-#     "MONSTER_NO": "153",
-#     "ORDER_IDX": "1",
-#     "TEM_SEQ": "1429",
-#     "TSTAMP": "1371788674011",
-#     "TV_SEQ": "332"
-# },
-class PgEvolutionMaterial(PgItem):
-    @staticmethod
-    def file_name():
-        return 'evoMaterialList'
-
-    def __init__(self, item):
-        super().__init__()
-        self.tem_seq = int(item['TEM_SEQ'])  # unique id
-        self.tv_seq = int(item['TV_SEQ'])  # evo id
-        self.fodder_monster_no = int(item['MONSTER_NO'])  # material monster
-        self.order = int(item['ORDER_IDX'])  # display order
-
-        self.evolution = None  # type: PgEvolution
-        self.fodder_monster = None  # type: PgMonster
-
-    def key(self):
-        return self.tem_seq
-
-    def load(self, database: PgRawDatabase):
-        self.evolution = database.getEvolution(self.tv_seq)
-        self.fodder_monster = database.getMonster(self.fodder_monster_no)
-
-        if self.evolution is None or self.evolution.to_monster is None:
-            # Really rare and unusual bug
-            return
-
-        target_monster = self.evolution.to_monster
-        # TODO: this is unsorted
-        target_monster.mats_for_evo.append(self.fodder_monster)
-
-        # Prevent issues if a monster is a mat for the same monster repeatedly (gunma, stones)
-        if target_monster not in self.fodder_monster.material_of:
-            self.fodder_monster.material_of.append(target_monster)
-
-
-# monsterAddInfoList
-# {
-#     "EXTRA_VAL1": "1",
-#     "EXTRA_VAL2": "",
-#     "EXTRA_VAL3": "",
-#     "EXTRA_VAL4": "",
-#     "EXTRA_VAL5": "",
-#     "MONSTER_NO": "3329",
-#     "SUB_TYPE": "0",
-#     "TSTAMP": "1480435906788"
-# },
-class PgMonsterAddInfo(PgItem):
-    """Optional extra information for a Monster.
-
-    Data is copied into PgMonster and this is discarded."""
-
-    @staticmethod
-    def file_name():
-        return 'monsterAddInfoList'
-
-    def __init__(self, item):
-        super().__init__()
-        self.monster_no = int(item['MONSTER_NO'])
-        self.sub_type = int(item['SUB_TYPE'])
-        self.extra_val_1 = int_or_none(item['EXTRA_VAL1'])
-
-    def key(self):
-        return self.monster_no
-
-    def load(self, database: PgRawDatabase):
-        pass
-
-
-# monsterInfoList
-# {
-#     "FODDER_EXP": "675.0",
-#     "HISTORY_JP": "[2016-12-16] \u65b0\u898f\u8ffd\u52a0",
-#     "HISTORY_KR": "[2016-12-16] \uc2e0\uaddc\ucd94\uac00",
-#     "HISTORY_US": "[2016-12-16] New Added",
-#     "MONSTER_NO": "3382",
-#     "ON_KR": "1",
-#     "ON_US": "1",
-#     "PAL_EGG": "0",
-#     "RARE_EGG": "0",
-#     "SELL_PRICE": "300.0",
-#     "TSR_SEQ": "86",
-#     "TSTAMP": "1481846935838"
-# },
-class PgMonsterInfo(PgItem):
-    """Extra information for a Monster.
-
-    Data is copied into PgMonster and this is discarded."""
-
-    @staticmethod
-    def file_name():
-        return 'monsterInfoList'
-
-    def __init__(self, item):
-        super().__init__()
-        self.monster_no = int(item['MONSTER_NO'])
-        self.on_na = item['ON_US'] == '1'
-        self.tsr_seq = int_or_none(item['TSR_SEQ'])  # PgSeries id
-        self.in_pem = item['PAL_EGG'] == '1'
-        self.in_rem = item['RARE_EGG'] == '1'
-        self.history_us = item['HISTORY_US']
-
-    def key(self):
-        return self.monster_no
-
-    def load(self, database: PgRawDatabase):
-        self.series = database.getSeries(self.tsr_seq)
-
-
-# monsterList
-# {
-#     "APP_VERSION": "0.0",
-#     "ATK_MAX": "1985",
-#     "ATK_MIN": "695",
-#     "COMMENT_JP": "",
-#     "COMMENT_KR": "\uc77c\ubcf8",
-#     "COMMENT_US": "Japan",
-#     "COST": "60",
-#     "EXP": "10000000",
-#     "HP_MAX": "6258",
-#     "HP_MIN": "3528",
-#     "LEVEL": "99",
-#     "MONSTER_NO": "3646",
-#     "MONSTER_NO_JP": "3646",
-#     "MONSTER_NO_KR": "3646",
-#     "MONSTER_NO_US": "3646",
-#     "PRONUNCIATION_JP": "\u304b\u306a\u305f\u306a\u308b\u3082\u306e\u30fb\u3088\u3050\u305d\u3068\u30fc\u3059",
-#     "RARITY": "7",
-#     "RATIO_ATK": "1.5",
-#     "RATIO_HP": "1.5",
-#     "RATIO_RCV": "1.5",
-#     "RCV_MAX": "233",
-#     "RCV_MIN": "926",
-#     "REG_DATE": "2017-04-27 17:29:48.0",
-#     "TA_SEQ": "4",
-#     "TA_SEQ_SUB": "0",
-#     "TE_SEQ": "14",
-#     "TM_NAME_JP": "\u5f7c\u65b9\u306a\u308b\u3082\u306e\u30fb\u30e8\u30b0\uff1d\u30bd\u30c8\u30fc\u30b9",
-#     "TM_NAME_KR": "\u5f7c\u65b9\u306a\u308b\u3082\u306e\u30fb\u30e8\u30b0\uff1d\u30bd\u30c8\u30fc\u30b9",
-#     "TM_NAME_US": "\u5f7c\u65b9\u306a\u308b\u3082\u306e\u30fb\u30e8\u30b0\uff1d\u30bd\u30c8\u30fc\u30b9",
-#     "TSTAMP": "1494033700775",
-#     "TS_SEQ_LEADER": "12448",
-#     "TS_SEQ_SKILL": "12447",
-#     "TT_SEQ": "10",
-#     "TT_SEQ_SUB": "1"
-# }
-class PgMonster(PgItem):
-    @staticmethod
-    def file_name():
-        return 'monsterList'
-
-    def __init__(self, item):
-        super().__init__()
-        self.monster_no = int(item['MONSTER_NO'])
-        self.monster_no_na = int(item['MONSTER_NO_US'])
-        self.monster_no_jp = int(item['MONSTER_NO_JP'])
-        self.min_hp = int(item['HP_MIN'])
-        self.min_atk = int(item['ATK_MIN'])
-        self.min_rcv = int(item['RCV_MIN'])
-        self.hp = int(item['HP_MAX'])
-        self.atk = int(item['ATK_MAX'])
-        self.rcv = int(item['RCV_MAX'])
-        self.ts_seq_active = int_or_none(item['TS_SEQ_SKILL'])
-        self.ts_seq_leader = int_or_none(item['TS_SEQ_LEADER'])
-        self.rarity = int(item['RARITY'])
-        self.cost = int(item['COST'])
-        self.exp = int(item['EXP'])
-        self.max_level = int(item['LEVEL'])
-        self.name_na = item['TM_NAME_US']
-        self.name_jp = item['TM_NAME_JP']
-        self.ta_seq_1 = int(item['TA_SEQ'])  # PgAttribute id
-        self.ta_seq_2 = int(item['TA_SEQ_SUB'])  # PgAttribute id
-        self.te_seq = int(item['TE_SEQ'])
-        self.tt_seq_1 = int(item['TT_SEQ'])  # PgType id
-        self.tt_seq_2 = int(item['TT_SEQ_SUB'])  # PgType id
-
-        self.debug_info = ''
-        self.weighted_stats = int(self.hp / 10 + self.atk / 5 + self.rcv / 3)
-
-        self.roma_subname = None
-        if self.name_na == self.name_jp:
-            self.roma_subname = make_roma_subname(self.name_jp)
-        else:
-            # Remove annoying stuff from NA names, like Jörmungandr
-            self.name_na = rpadutils.rmdiacritics(self.name_na)
-
-        self.active_skill = None  # type: PgSkill
-        self.leader_skill = None  # type: PgSkill
-
-        # ???
-        self.cur_evo_type = EvoType.Base
-        self.evo_to = []
-        self.evo_from = None
-
-        self.mats_for_evo = []
-        self.material_of = []
-
-        self.awakenings = []  # PgAwakening
-        self.drop_dungeons = []
-
-        self.alt_evos = []  # PgMonster
-
-        # List of PgSkillRotationDated
-        self.rotating_skillups = []
-        self.server_actives = {}  # str(NA, JP) -> PgSkill
-        self.future_skillup_rotation = {}
-
-        self.is_equip = False
-
-        # Monsters start off pointing to themselves as the base, this will
-        # change once the MonsterGroups are computed.
-        self.base_monster = self
-
-        # Data populated via override
-        self.limitbreak_stats = 1 + float(item['LIMIT_MULT']) / 100 if item['LIMIT_MULT'] else None
-        self.superawakening_count = 0
-
-        # Data filled in post-load
-        self.translated_jp_name = None
-
-    def key(self):
-        return self.monster_no
-
-    def load(self, database: PgRawDatabase):
-        self.active_skill = database.getSkill(self.ts_seq_active)
-        if self.active_skill:
-            self.active_skill.monsters_with_active.append(self)
-
-        self.leader_skill = database.getSkill(self.ts_seq_leader)
-        self.leader_skill_data = database.getSkillLeaderData(self.ts_seq_leader)
-        if self.leader_skill:
-            self.leader_skill.monsters_with_leader.append(self)
-
-        self.attr1 = database.getAttributeEnum(self.ta_seq_1)
-        self.attr2 = database.getAttributeEnum(self.ta_seq_2)
-
-        self.type1 = database.getTypeName(self.tt_seq_1)
-        self.type2 = database.getTypeName(self.tt_seq_2)
-        self.type3 = None
-
-        self.assist_setting = None
-        monster_add_info = database.getMonsterAddInfo(self.monster_no)
-        if monster_add_info:
-            self.type3 = database.getTypeName(monster_add_info.sub_type)
-            self.assist_setting = monster_add_info.extra_val_1
-
-        monster_info = database.getMonsterInfo(self.monster_no)
-        self.on_na = monster_info.on_na
-        self.series = database.getSeries(monster_info.tsr_seq)  # PgSeries
-        self.series.monsters.append(self)
-        self.is_gfe = self.series.tsr_seq == 34  # godfest
-        self.in_pem = monster_info.in_pem
-        self.in_rem = monster_info.in_rem
-        self.pem_evo = self.in_pem
-        self.rem_evo = self.in_rem
-        self.history_us = monster_info.history_us
-
-        monster_price = database.getMonsterPrice(self.monster_no)
-        self.sell_mp = monster_price.sell_mp if monster_price else 0
-        self.buy_mp = monster_price.buy_mp if monster_price else 0
-        self.in_mpshop = self.buy_mp > 0
-        self.mp_evo = self.in_mpshop
-
-    def finalize(self):
-        self.farmable = len(self.drop_dungeons) > 0
-        self.farmable_evo = self.farmable
-
-        self.awakenings.sort(key=lambda x: x.order)
-        self.superawakening_count = sum(int(a.is_super) for a in self.awakenings)
-
-        if self.assist_setting == 1:
-            self.is_inheritable = True
-        elif self.assist_setting == 2:
-            self.is_inheritable = False
-        else:
-            has_awakenings = len(self.awakenings) > 0
-            self.is_inheritable = has_awakenings and self.rarity >= 5 and self.sell_mp >= 3000
-
-        self.is_equip = 'Awoken Assist' in [a.get_name() for a in self.awakenings]
-
-        self.types = [t.lower() for t in [self.type1, self.type2, self.type3] if t]
-
-        if self.evo_from is None:
-            def link(m: PgMonster, alt_evos: list):
-                alt_evos.append(m)
-                m.alt_evos = alt_evos
-                for em in m.evo_to:
-                    link(em, alt_evos)
-            link(self, [])
-
-        self.search = MonsterSearchHelper(self)
-
-        # Compute server skill rotations
-        for server, server_tz in {'JP': rpadutils.JP_TZ_OBJ, 'NA': rpadutils.NA_TZ_OBJ}.items():
-            server_now = datetime.now().replace(tzinfo=server_tz).date()
-            server_skillups = list(filter(lambda s: s.skill_rotation.server == server,
-                                          self.rotating_skillups))
-            future_skillup = list(filter(lambda s: server_now < s.rotation_date, server_skillups))
-            if future_skillup:
-                self.future_skillup_rotation[server] = future_skillup[0]
-
-            past_skillups = list(filter(lambda s: server_now >= s.rotation_date, server_skillups))
-            if past_skillups:
-                active_skillup = max(past_skillups, key=lambda s: s.rotation_date)
-                self.server_actives[server] = active_skillup.skill
-                active_skillup.skill.server_skillups[server] = active_skillup.skill_rotation.monster
-
-
-class MonsterSearchHelper(object):
-    def __init__(self, m: PgMonster):
-
-        self.name = '{} {}'.format(m.name_na, m.name_jp).lower()
-        self.leader = m.leader_skill.desc.lower() if m.leader_skill else ''
-        self.active_name = m.active_skill.name.lower() if m.active_skill else ''
-        self.active_desc = m.active_skill.desc.lower() if m.active_skill else ''
-        self.active = '{} {}'.format(self.active_name, self.active_desc)
-        self.active_min = m.active_skill.turn_min if m.active_skill else None
-        self.active_max = m.active_skill.turn_max if m.active_skill else None
-
-        self.color = [m.attr1.name.lower()]
-        self.hascolor = [c.name.lower() for c in [m.attr1, m.attr2] if c]
-
-        self.limitbreak_stats = m.limitbreak_stats or 1
-
-        self.hp = m.hp * self.limitbreak_stats
-        self.atk = m.atk * self.limitbreak_stats
-        self.rcv = m.rcv * self.limitbreak_stats
-        self.weighted_stats = m.weighted_stats * self.limitbreak_stats
-
-        self.types = m.types
-
-        def replace_colors(text: str):
-            return text.replace('red', 'fire').replace('blue', 'water').replace('green', 'wood')
-        self.leader = replace_colors(self.leader)
-        self.active = replace_colors(self.active)
-        self.active_name = replace_colors(self.active_name)
-        self.active_desc = replace_colors(self.active_desc)
-
-        self.board_change = []
-        self.orb_convert = defaultdict(list)
-        self.row_convert = []
-        self.column_convert = []
-
-        def color_txt_to_list(txt):
-            txt = txt.replace('and', ' ')
-            txt = txt.replace(',', ' ')
-            txt = txt.replace('orbs', ' ')
-            txt = txt.replace('orb', ' ')
-            txt = txt.replace('mortal poison', 'mortalpoison')
-            txt = txt.replace('jammers', 'jammer')
-            txt = txt.strip()
-            return txt.split()
-
-        def strip_prev_clause(txt: str, sep: str):
-            prev_clause_start_idx = txt.find(sep)
-            if prev_clause_start_idx >= 0:
-                prev_clause_start_idx += len(sep)
-                txt = txt[prev_clause_start_idx:]
-            return txt
-
-        def strip_next_clause(txt: str, sep: str):
-            next_clause_start_idx = txt.find(sep)
-            if next_clause_start_idx >= 0:
-                txt = txt[:next_clause_start_idx]
-            return txt
-
-        active_desc = self.active_desc
-        active_desc = active_desc.replace(' rows ', ' row ')
-        active_desc = active_desc.replace(' columns ', ' column ')
-        active_desc = active_desc.replace(' into ', ' to ')
-        active_desc = active_desc.replace('changes orbs to', 'all orbs to')
-
-        board_change_txt = 'all orbs to'
-        if board_change_txt in active_desc:
-            txt = strip_prev_clause(active_desc, board_change_txt)
-            txt = strip_next_clause(txt, 'orbs')
-            txt = strip_next_clause(txt, ';')
-            self.board_change = color_txt_to_list(txt)
-
-        txt = active_desc
-        if 'row' in txt:
-            parts = re.split('\Wand\W|;\W', txt)
-            for i in range(0, len(parts)):
-                if 'row' in parts[i]:
-                    self.row_convert.append(strip_next_clause(
-                        strip_prev_clause(parts[i], 'to '), ' orbs'))
-
-        txt = active_desc
-        if 'column' in txt:
-            parts = re.split('\Wand\W|;\W', txt)
-            for i in range(0, len(parts)):
-                if 'column' in parts[i]:
-                    self.column_convert.append(strip_next_clause(
-                        strip_prev_clause(parts[i], 'to '), ' orbs'))
-
-        convert_done = self.board_change or self.row_convert or self.column_convert
-
-        change_txt = 'change '
-        if not convert_done and change_txt in active_desc and 'orb' in active_desc:
-            txt = active_desc
-            parts = re.split('\Wand\W|;\W', txt)
-            for i in range(0, len(parts)):
-                parts[i] = strip_prev_clause(parts[i], change_txt) if change_txt in parts[i] else ''
-
-            for part in parts:
-                sub_parts = part.split(' to ')
-                if len(sub_parts) > 1:
-                    source_orbs = color_txt_to_list(sub_parts[0])
-                    dest_orbs = color_txt_to_list(sub_parts[1])
-                    for so in source_orbs:
-                        for do in dest_orbs:
-                            self.orb_convert[so].append(do)
-
-
-class MonsterGroup(object):
-    """Computes shared values across a tree of monsters and injects them."""
-
-    def __init__(self, base_monster: PgMonster):
-        self.base_monster = base_monster
-        self.members = list()
-        self._recursive_add(base_monster)
-        self._initialize_members()
-
-    def _recursive_add(self, m: PgMonster):
-        m.base_monster = self.base_monster
-        self.members.append(m)
-        for em in m.evo_to:
-            self._recursive_add(em)
-
-    def _initialize_members(self):
-        # Compute tree acquisition status
-        farmable_evo, pem_evo, rem_evo, mp_evo = False, False, False, False
-        for m in self.members:
-            farmable_evo = farmable_evo or m.farmable
-            pem_evo = pem_evo or m.in_pem
-            rem_evo = rem_evo or m.in_rem
-            mp_evo = mp_evo or m.in_mpshop
-
-        # Override tree acquisition status
-        for m in self.members:
-            m.farmable_evo = farmable_evo
-            m.pem_evo = pem_evo
-            m.rem_evo = rem_evo
-            m.mp_evo = mp_evo
-
-
-# monsterPriceList
-# {
-#     "BUY_PRICE": "0",
-#     "MONSTER_NO": "3577",
-#     "SELL_PRICE": "99",
-#     "TSTAMP": "1492101772974"
-# }
-
-
-class PgMonsterPrice(PgItem):
-    @staticmethod
-    def file_name():
-        return 'monsterPriceList'
-
-    def __init__(self, item):
-        super().__init__()
-        self.monster_no = int(item['MONSTER_NO'])
-        self.buy_mp = int(item['BUY_PRICE'])
-        self.sell_mp = int(item['SELL_PRICE'])
-
-    def key(self):
-        return self.monster_no
-
-    def load(self, database: PgRawDatabase):
-        pass
-
-
-# seriesList
-# {
-#     "DEL_YN": "N",
-#     "NAME_JP": "\u308a\u3093",
-#     "NAME_KR": "\uc2ac\ub77c\uc784",
-#     "NAME_US": "Slime",
-#     "SEARCH_DATA": "\u308a\u3093 Slime \uc2ac\ub77c\uc784",
-#     "TSR_SEQ": "3",
-#     "TSTAMP": "1380587210667"
-# },
-class PgSeries(PgItem):
-    @staticmethod
-    def file_name():
-        return 'seriesList'
-
-    def __init__(self, item):
-        super().__init__()
-        self.tsr_seq = int(item['TSR_SEQ'])
-        self.name = item['NAME_US']
-        self.deleted_yn = item['DEL_YN']  # Either Y(discard) or N.
-
-        self.monsters = []
-
-    def key(self):
-        return self.tsr_seq
-
-    def deleted(self):
-        return False
-        # Temporary
-#         return self.deleted_yn == 'Y'
-
-    def load(self, database: PgRawDatabase):
-        pass
-
-
-# skillList
-# {
-#     "MAG_ATK": "0.0",
-#     "MAG_HP": "0.0",
-#     "MAG_RCV": "0.0",
-#     "ORDER_IDX": "3",
-#     "REDUCE_DMG": "0.0",
-#     "RTA_SEQ_1": "0",
-#     "RTA_SEQ_2": "0",
-#     "SEARCH_DATA": "\u6e9c\u3081\u65ac\u308a \u6e9c\u3081\u65ac\u308a \u6e9c\u3081\u65ac\u308a 2\u30bf\u30fc\u30f3\u306e\u9593\u3001\u30c1\u30fc\u30e0\u5185\u306e\u30c9\u30e9\u30b4\u30f3\u30ad\u30e9\u30fc\u306e\u899a\u9192\u6570\u306b\u5fdc\u3058\u3066\u653b\u6483\u529b\u304c\u4e0a\u6607\u3002(1\u500b\u306b\u3064\u304d50%) Increase ATK depending on number of Dragon Killer Awakening Skills on team for 2 turns (50% per each) 2\ud134\uac04 \ud300\ub0b4\uc758 \ub4dc\ub798\uace4 \ud0ac\ub7ec \uac01\uc131 \uac2f\uc218\uc5d0 \ub530\ub77c \uacf5\uaca9\ub825\uc774 \uc0c1\uc2b9 (\uac1c\ub2f9 50%)",
-#     "TA_SEQ_1": "0",
-#     "TA_SEQ_2": "0",
-#     "TSTAMP": "1493861895693",
-#     "TS_DESC_JP": "2\u30bf\u30fc\u30f3\u306e\u9593\u3001\u30c1\u30fc\u30e0\u5185\u306e\u30c9\u30e9\u30b4\u30f3\u30ad\u30e9\u30fc\u306e\u899a\u9192\u6570\u306b\u5fdc\u3058\u3066\u653b\u6483\u529b\u304c\u4e0a\u6607\u3002(1\u500b\u306b\u3064\u304d50%)",
-#     "TS_DESC_KR": "2\ud134\uac04 \ud300\ub0b4\uc758 \ub4dc\ub798\uace4 \ud0ac\ub7ec \uac01\uc131 \uac2f\uc218\uc5d0 \ub530\ub77c \uacf5\uaca9\ub825\uc774 \uc0c1\uc2b9 (\uac1c\ub2f9 50%)",
-#     "TS_DESC_US": "Increase ATK depending on number of Dragon Killer Awakening Skills on team for 2 turns (50% per each)",
-#     "TS_NAME_JP": "\u6e9c\u3081\u65ac\u308a",
-#     "TS_NAME_KR": "\u6e9c\u3081\u65ac\u308a",
-#     "TS_NAME_US": "\u6e9c\u3081\u65ac\u308a",
-#     "TS_SEQ": "12478",
-#     "TT_SEQ_1": "0",
-#     "TT_SEQ_2": "0",
-#     "TURN_MAX": "22",
-#     "TURN_MIN": "14",
-#     "T_CONDITION": "3"
-# }
-class PgSkill(PgItem):
-    @staticmethod
-    def file_name():
-        return 'skillList'
-
-    def __init__(self, item):
-        super().__init__()
-        self.ts_seq = int(item['TS_SEQ'])
-        self.name = item['TS_NAME_US']
-        self.desc = item['TS_DESC_US']
-        self.turn_min = int(item['TURN_MIN'])
-        self.turn_max = int(item['TURN_MAX'])
-
-        self.monsters_with_active = []  # PgMonster
-        self.monsters_with_leader = []  # PgMonster
-        self.monsters_with_awakening = []  # PgMonster
-
-        # str (NA, JP) -> PgMonster
-        self.server_skillups = {}
-
-    def key(self):
-        return self.ts_seq
-
-    def load(self, database: PgRawDatabase):
-        pass
-
-
-# skillLeaderDataList
-#
-# PgSkillLeaderData
-# 4 pipe delimited fields, each field is a condition
-# Slashes separate effects for conditions
-# 1: Code 1=HP, 2=ATK, 3=RCV, 4=Reduction
-# 2: Multiplier
-# 3: Color restriction (coded)
-# 4: Type restriction (coded)
-# 5: Combo restriction
-#
-# Reincarnated Izanagi, 4x + 50% for heal cross, 2x atk 2x rcv for god/dragon/balanced
-# {
-#     "LEADER_DATA": "4/0.5///|2/4///|2/2//6,1,2/|3/2//6,1,2/",
-#     "TSTAMP": "1487553365770",
-#     "TS_SEQ": "11695"
-# },
-# Gold Saint, Shion : 4.5X atk when 3+ light combo
-# {
-#     "LEADER_DATA": "2/4.5///3",
-#     "TSTAMP": "1432940060708",
-#     "TS_SEQ": "6661"
-# },
-# Reincarnated Minerva, 3x damage, 2x damage, color resist
-# {
-#     "LEADER_DATA": "2/3/1//|2/2///|4/0.5/1,4,5//",
-#     "TSTAMP": "1475243514648",
-#     "TS_SEQ": "10835"
-# },
-class PgSkillLeaderData(PgItem):
-    @staticmethod
-    def empty():
-        return PgSkillLeaderData({
-            'TS_SEQ': '-1',
-            'LEADER_DATA': '',
-        })
-
-    @staticmethod
-    def file_name():
-        return 'skillLeaderDataList'
-
-    def __init__(self, item):
-        super().__init__()
-        self.ts_seq = int(item['TS_SEQ'])  # unique id
-        self.leader_data = item['LEADER_DATA']
-
-        hp, atk, rcv, resist = (1.0,) * 4
-        for mod in self.leader_data.split('|'):
-            if not mod.strip():
-                continue
-            items = mod.split('/')
-
-            code = items[0]
-            mult = float(items[1])
-            if code == '1':
-                hp *= mult
-            if code == '2':
-                atk *= mult
-            if code == '3':
-                rcv *= mult
-            if code == '4':
-                resist *= mult
-
-        self.hp = hp
-        self.atk = atk
-        self.rcv = rcv
-        self.resist = resist
-
-    def key(self):
-        return self.ts_seq
-
-    def load(self, database: PgRawDatabase):
-        pass
-
-    def get_data(self):
-        return self.hp, self.atk, self.rcv, self.resist
-
-
-# skillRotationList
-# {
-#     "MONSTER_NO": "915",
-#     "SERVER": "JP",
-#     "STATUS": "0",
-#     "TSR_SEQ": "2",
-#     "TSTAMP": "1481627094573"
-# }
-class PgSkillRotation(PgItem):
-    @staticmethod
-    def file_name():
-        return 'skillRotationList'
-
-    def __init__(self, item):
-        super().__init__()
-        self.tsr_seq = int(item['TSR_SEQ'])  # unique id
-        self.monster_no = int(item['MONSTER_NO'])
-        self.server = normalizeServer(item['SERVER'])  # JP, NA, KR
-        # Status seems to be rarely '2'
-        self.status = int(item['STATUS'])
-
-    def key(self):
-        return self.tsr_seq
-
-    def deleted(self):
-        return self.server == 'KR' or self.status != 0  # We don't do KR
-
-    def load(self, database: PgRawDatabase):
-        self.monster = database.getMonster(self.monster_no)
-
-
-# skillRotationListList
-# {
-#     "ROTATION_DATE": "2016-12-14",
-#     "STATUS": "0",
-#     "TSRL_SEQ": "960",
-#     "TSR_SEQ": "86",
-#     "TSTAMP": "1481627993157",
-#     "TS_SEQ": "9926"
-# }
-class PgSkillRotationDated(PgItem):
-    @staticmethod
-    def file_name():
-        return 'skillRotationListList'
-
-    def __init__(self, item):
-        super().__init__()
-        self.tsrl_seq = int(item['TSRL_SEQ'])  # unique id
-        self.tsr_seq = int(item['TSR_SEQ'])  # PgSkillRotation id - Current skillup monster
-        self.ts_seq = int(item['TS_SEQ'])  # PGSkill id - Current skill
-        self.rotation_date_str = item['ROTATION_DATE']
-
-        self.rotation_date = None
-        if len(self.rotation_date_str):
-            self.rotation_date = datetime.strptime(self.rotation_date_str, "%Y-%m-%d").date()
-
-    def key(self):
-        return self.tsrl_seq
-
-    def load(self, database: PgRawDatabase):
-        self.skill = database.getSkill(self.ts_seq)
-        self.skill_rotation = database.getSkillRotation(self.tsr_seq)
-
-        if self.skill_rotation:
-            self.skill_rotation.monster.rotating_skillups.append(self)
-
-
-# typeList
-# {
-#     "ORDER_IDX": "2",
-#     "TSTAMP": "1375363406092",
-#     "TT_NAME_JP": "\u60aa\u9b54",
-#     "TT_NAME_KR": "\uc545\ub9c8",
-#     "TT_NAME_US": "Devil",
-#     "TT_SEQ": "10"
-# },
-class PgType(PgItem):
-    @staticmethod
-    def file_name():
-        return 'typeList'
-
-    def __init__(self, item):
-        super().__init__()
-        self.tt_seq = int(item['TT_SEQ'])  # unique id
-        self.name = item['TT_NAME_US']
-
-    def key(self):
-        return self.tt_seq
-
-    def load(self, database: PgRawDatabase):
-        pass
-
-
-class PgMonsterDropInfoCombined(object):
-    def __init__(self, monster_id, dungeon_monster_drop, dungeon_monster, dungeon):
-        self.monster_id = monster_id
-        self.dungeon_monster_drop = dungeon_monster_drop
-        self.dungeon_monster = dungeon_monster
-        self.dungeon = dungeon
-
-
-# ================================================================================
-# PadRem items below
-# ================================================================================
-
-class RemType(Enum):
-    godfest = 1
-    rare = 2
-    pal = 3
-    unknown1 = 4
-
-
-class RemRowType(Enum):
-    subsection = 0
-    divider = 1
-
-
-# eggTitleList
-#       {
-#            "DEL_YN": "N",
-#            "END_DATE": "2016-10-24 07:59:00",
-#            "ORDER_IDX": "0",
-#            "SERVER": "US",
-#            "SHOW_YN": "Y",
-#            "START_DATE": "2016-10-17 08:00:00",
-#            "TEC_SEQ": "2",
-#            "TET_SEQ": "64",
-#            "TSTAMP": "1476490114488",
-#            "TYPE": "1"
-#        },
-class PgEggInstance(PgItem):
-    @staticmethod
-    def file_name():
-        return 'eggTitleList'
-
-    def __init__(self, item):
-        super().__init__()
-        self.server = normalizeServer(item['SERVER'])
-        self.deleted_yn = item['DEL_YN']  # Y, N
-        self.show_yn = item['SHOW_YN']  # Y, N
-        self.rem_type = RemType(int(item['TEC_SEQ']))  # matches RemType
-        self.tet_seq = int(item['TET_SEQ'])  # primary key
-        self.row_type = RemRowType(int(item['TYPE']))  # 0-> row with just name, 1-> row with date
-
-        self.order = int(item["ORDER_IDX"])
-        self.start_date_str = item['START_DATE']
-        self.end_date_str = item['END_DATE']
-
-        self.egg_name_us = None
-        self.egg_monsters = []
-
-        tz = pytz.UTC
-        self.start_datetime = None
-        self.end_datetime = None
-        self.open_date_str = None
-
-#         self.pt_date_str = None
-        if len(self.start_date_str):
-            self.start_datetime = datetime.strptime(
-                self.start_date_str, "%Y-%m-%d %H:%M:%S").replace(tzinfo=tz)
-            self.end_datetime = datetime.strptime(
-                self.end_date_str, "%Y-%m-%d %H:%M:%S").replace(tzinfo=tz)
-
-            if self.server == 'NA':
-                pt_tz_obj = pytz.timezone('America/Los_Angeles')
-                self.open_date_str = self.start_datetime.replace(tzinfo=pt_tz_obj).strftime('%m/%d')
-            if self.server == 'JP':
-                jp_tz_obj = pytz.timezone('Asia/Tokyo')
-                self.open_date_str = self.start_datetime.replace(tzinfo=jp_tz_obj).strftime('%m/%d')
-
-    def key(self):
-        return self.tet_seq
-
-    def deleted(self):
-        return (self.deleted_yn == 'Y' or
-                self.show_yn == 'N' or
-                self.server == 'KR' or
-                self.rem_type in (RemType.pal, RemType.unknown1))
-
-    def load(self, database: PgRawDatabase):
-        pass
-#         self.monster = database.getMonster(self.monster_no)
-
-
-# eggMonsterList
-#        {
-#            "DEL_YN": "Y",
-#            "MONSTER_NO": "120",
-#            "ORDER_IDX": "1",
-#            "TEM_SEQ": "1",
-#            "TET_SEQ": "1",
-#            "TSTAMP": "1405245537715"
-#        },
-class PgEggMonster(PgItem):
-    @staticmethod
-    def file_name():
-        return 'eggMonsterList'
-
-    def __init__(self, item):
-        super().__init__()
-        self.deleted_yn = item['DEL_YN']
-        self.monster_no = int(item['MONSTER_NO'])
-        self.tem_seq = int(item['TEM_SEQ'])  # primary key
-        self.tet_seq = int(item['TET_SEQ'])  # fk to PgEggInstance
-
-    def key(self):
-        return self.tem_seq
-
-    def deleted(self):
-        return self.deleted_yn == 'Y' or self.monster_no == 0
-
-    def load(self, database: PgRawDatabase):
-        self.monster = database.getMonster(self.monster_no)
-        self.egg_instance = database.getEggInstance(self.tet_seq)
-        if self.egg_instance:
-            # For KR stuff we clipped out
-            self.egg_instance.egg_monsters.append(self)
-
-
-# eggTitleNameList
-#        {
-#            "DEL_YN": "N",
-#            "LANGUAGE": "US",
-#            "NAME": "Batman Egg",
-#            "TETN_SEQ": "183",
-#            "TET_SEQ": "64",
-#            "TSTAMP": "1441589491425"
-#        },
-class PgEggName(PgItem):
-    @staticmethod
-    def file_name():
-        return 'eggTitleNameList'
-
-    def __init__(self, item):
-        super().__init__()
-        self.name = item['NAME']
-        self.language = item['LANGUAGE']  # US, JP, KR
-        self.deleted_yn = item['DEL_YN']  # Y, N
-        self.tetn_seq = int(item['TETN_SEQ'])  # primary key
-        self.tet_seq = int(item['TET_SEQ'])  # fk to PgEggInstance
-
-    def key(self):
-        return self.tetn_seq
-
-    def deleted(self):
-        return self.deleted_yn == 'Y' or self.language != 'US'
-
-    def load(self, database: PgRawDatabase):
-        self.egg_instance = database.getEggInstance(self.tet_seq)
-        if self.egg_instance:
-            # For KR stuff we clipped out
-            self.egg_instance.egg_name_us = self
-
-
-# ================================================================================
-# PadEvents items below
-# ================================================================================
-
-
-class EventType(Enum):
-    EventTypeWeek = 0
-    EventTypeSpecial = 1
-    EventTypeSpecialWeek = 2
-    EventTypeGuerrilla = 3
-    EventTypeGuerrillaNew = 4
-    EventTypeEtc = -100
-
-
-def normalizeServer(server):
-    server = server.upper()
-    return 'NA' if server == 'US' else server
-
-
-# {
-#     "CLOSE_DATE": "2017-09-01",
-#     "CLOSE_HOUR": "19",
-#     "CLOSE_MINUTE": "59",
-#     "CLOSE_WEEKDAY": "0",
-#     "DUNGEON_SEQ": "31",
-#     "EVENT_SEQ": "25",
-#     "EVENT_TYPE": "-100",
-#     "OPEN_DATE": "2017-09-01",
-#     "OPEN_HOUR": "08",
-#     "OPEN_MINUTE": "00",
-#     "OPEN_WEEKDAY": "0",
-#     "SCHEDULE_SEQ": "235217",
-#     "SERVER": "US",
-#     "SERVER_OPEN_DATE": "2017-09-01",
-#     "SERVER_OPEN_HOUR": "1",
-#     "TEAM_DATA": "0",
-#     "TSTAMP": "1504233623450",
-#     "URL": ""
-# },
-class PgScheduledEvent(PgItem):
-    @staticmethod
-    def file_name():
-        return 'scheduleList'
-
-    def __init__(self, item):
-        super().__init__()
-        self.schedule_seq = int(item['SCHEDULE_SEQ'])
-
-        self.open_timestamp = int(item['OPEN_TIMESTAMP'])
-        self.close_timestamp = int(item['CLOSE_TIMESTAMP'])
-
-        self.dungeon_seq = int(item['DUNGEON_SEQ'])
-        self.event_seq = int(item['EVENT_SEQ'])
-        self.event_type = int(item['EVENT_TYPE'])
-
-        self.server = normalizeServer(item['SERVER'])
-
-        self.team_data = int_or_none(item['TEAM_DATA'])
-        self.url = item['URL']
-
-        self.group = None
-        if self.team_data is not None:
-            if self.event_type == EventType.EventTypeGuerrilla.value:
-                self.group = chr(ord('a') + self.team_data).upper()
-            elif self.event_type == EventType.EventTypeSpecialWeek.value:
-                self.group = ['RED', 'BLUE', 'GREEN'][self.team_data]
-
-        self.open_datetime = datetime.utcfromtimestamp(
-            self.open_timestamp).replace(tzinfo=pytz.UTC)
-        self.close_datetime = datetime.utcfromtimestamp(
-            self.close_timestamp).replace(tzinfo=pytz.UTC)
-
-    def key(self):
-        return self.schedule_seq
-
-    def deleted(self):
-        return self.server == 'KR'
-
-    def load(self, database: PgRawDatabase):
-        self.dungeon = database.getDungeon(self.dungeon_seq)
-        self.event = database.getEvent(self.event_seq) if self.event_seq != '0' else None
-
-
-# {
-#     "EVENT_NAME_JP": "\u30b3\u30a4\u30f3 1.5\u500d!",
-#     "EVENT_NAME_KR": "\ucf54\uc778 1.5\ubc30!",
-#     "EVENT_NAME_US": "Coin x 1.5!",
-#     "EVENT_SEQ": "3",
-#     "TSTAMP": "1370174967128"
-# },
-class PgEvent(PgItem):
-    @staticmethod
-    def file_name():
-        return 'eventList'
-
-    def __init__(self, item):
-        super().__init__()
-        self.event_seq = int(item['EVENT_SEQ'])
-        self.name = item['EVENT_NAME_US']
-
-    def key(self):
-        return self.event_seq
-
-    def load(self, database: PgRawDatabase):
-        pass
-
-
-def make_roma_subname(name_jp):
-    subname = name_jp.replace('＝', '')
-    adjusted_subname = ''
-    for part in subname.split('・'):
-        roma_part = romkan.to_roma(part)
-        if part != roma_part and not rpadutils.containsJp(roma_part):
-            adjusted_subname += ' ' + roma_part.strip('-')
-    return adjusted_subname.strip()
-
-
-def int_or_none(maybe_int: str):
-    return int(maybe_int) if maybe_int else None
-
-
-def float_or_none(maybe_float: str):
-    return float(maybe_float) if maybe_float else None
-
-
-def empty_index():
-    return MonsterIndex(PgRawDatabase(skip_load=True), {}, {})
-
-
-class MonsterIndex(object):
-    def __init__(self, monster_database, nickname_overrides, basename_overrides, accept_filter=None):
-        # Important not to hold onto anything except IDs here so we don't leak memory
-        monster_groups = monster_database.grouped_monsters
-
-        self.attr_short_prefix_map = {
-            Attribute.Fire: ['r'],
-            Attribute.Water: ['b'],
-            Attribute.Wood: ['g'],
-            Attribute.Light: ['l'],
-            Attribute.Dark: ['d'],
-        }
-        self.attr_long_prefix_map = {
-            Attribute.Fire: ['red', 'fire'],
-            Attribute.Water: ['blue', 'water'],
-            Attribute.Wood: ['green', 'wood'],
-            Attribute.Light: ['light'],
-            Attribute.Dark: ['dark'],
-        }
-
-        self.series_to_prefix_map = {
-            130: ['halloween', 'hw', 'h'],
-            136: ['xmas', 'christmas'],
-            125: ['summer', 'beach'],
-            114: ['school', 'academy', 'gakuen'],
-            139: ['new years', 'ny'],
-            149: ['wedding', 'bride'],
-            154: ['padr'],
-            175: ['valentines', 'vday'],
-        }
-
-        monster_no_na_to_nicknames = defaultdict(set)
-        for nickname, monster_no_na in nickname_overrides.items():
-            monster_no_na_to_nicknames[monster_no_na].add(nickname)
-
-        named_monsters = []
-        for mg in monster_groups:
-            group_basename_overrides = basename_overrides.get(mg.base_monster.monster_no_na, [])
-            named_mg = NamedMonsterGroup(mg, group_basename_overrides)
-            for monster in mg.members:
-                if accept_filter and not accept_filter(monster):
-                    continue
-                prefixes = self.compute_prefixes(monster, mg)
-                extra_nicknames = monster_no_na_to_nicknames[monster.monster_no_na]
-                named_monster = NamedMonster(monster, named_mg, prefixes, extra_nicknames)
-                named_monsters.append(named_monster)
-
-        # Sort the NamedMonsters into the opposite order we want to accept their nicknames in
-        # This order is:
-        #  1) High priority first
-        #  2) Larger group sizes
-        #  3) Minimum ID size in the group
-        #  4) Monsters with higher ID values
-        def named_monsters_sort(nm: NamedMonster):
-            return (not nm.is_low_priority, nm.group_size, -1 *
-                    nm.base_monster_no_na, nm.monster_no_na)
-        named_monsters.sort(key=named_monsters_sort)
-
-        self.all_entries = {}
-        self.all_prefixes = set()
-        self.two_word_entries = {}
-        for nm in named_monsters:
-            for prefix in nm.prefixes:
-                self.all_prefixes.add(prefix)
-            for nickname in nm.final_nicknames:
-                self.all_entries[nickname] = nm
-            for nickname in nm.final_two_word_nicknames:
-                self.two_word_entries[nickname] = nm
-
-        self.all_monsters = named_monsters
-        self.all_na_name_to_monsters = {m.name_na.lower(): m for m in named_monsters}
-        self.monster_no_na_to_named_monster = {m.monster_no_na: m for m in named_monsters}
-        self.monster_no_to_named_monster = {m.monster_no: m for m in named_monsters}
-
-        for nickname, monster_no_na in nickname_overrides.items():
-            nm = self.monster_no_na_to_named_monster.get(monster_no_na)
-            if nm:
-                self.all_entries[nickname] = nm
-
-    def init_index(self):
-        pass
-
-    def compute_prefixes(self, m: PgMonster, mg: MonsterGroup):
-        prefixes = set()
-
-        attr1_short_prefixes = self.attr_short_prefix_map[m.attr1]
-        attr1_long_prefixes = self.attr_long_prefix_map[m.attr1]
-        prefixes.update(attr1_short_prefixes)
-        prefixes.update(attr1_long_prefixes)
-
-        # If no 2nd attribute, use x so we can look those monsters up easier
-        attr2_short_prefixes = self.attr_short_prefix_map.get(m.attr2, ['x'])
-        for a1 in attr1_short_prefixes:
-            for a2 in attr2_short_prefixes:
-                prefixes.add(a1 + a2)
-                prefixes.add(a1 + '/' + a2)
-
-        # TODO: add prefixes based on type
-
-        # Chibi monsters have the same NA name, except lowercased
-        if m.name_na != m.name_jp:
-            if m.name_na.lower() == m.name_na:
-                prefixes.add('chibi')
-        elif 'ミニ' in m.name_jp:
-            # Guarding this separately to prevent 'gemini' from triggering (e.g. 2645)
-            prefixes.add('chibi')
-
-        lower_name = m.name_na.lower()
-        awoken = lower_name.startswith('awoken') or '覚醒' in lower_name
-        revo = lower_name.startswith('reincarnated') or '転生' in lower_name
-        mega = lower_name.startswith('mega woken') or '極醒' in lower_name
-        awoken_or_revo_or_equip_or_mega = awoken or revo or m.is_equip or mega
-
-        # These clauses need to be separate to handle things like 'Awoken Thoth' which are
-        # actually Evos but have awoken in the name
-        if awoken:
-            prefixes.add('a')
-            prefixes.add('awoken')
-
-        if revo:
-            prefixes.add('revo')
-            prefixes.add('reincarnated')
-
-        if mega:
-            prefixes.add('mega')
-            prefixes.add('mega awoken')
-            prefixes.add('awoken')
-
-        # Prefixes for evo type
-        if m.cur_evo_type == EvoType.Base:
-            prefixes.add('base')
-        elif m.cur_evo_type == EvoType.Evo:
-            prefixes.add('evo')
-        elif m.cur_evo_type == EvoType.UvoAwoken and not awoken_or_revo_or_equip_or_mega:
-            prefixes.add('uvo')
-            prefixes.add('uevo')
-        elif m.cur_evo_type == EvoType.UuvoReincarnated and not awoken_or_revo_or_equip_or_mega:
-            prefixes.add('uuvo')
-            prefixes.add('uuevo')
-
-        # If any monster in the group is a pixel, add 'nonpixel' to all the versions
-        # without pixel in the name. Add 'pixel' as a prefix to the ones with pixel in the name.
-        def is_pixel(n):
-            n = n.name_na.lower()
-            return n.startswith('pixel') or n.startswith('ドット')
-
-        for gm in mg.members:
-            if is_pixel(gm):
-                prefixes.update(['pixel'] if is_pixel(m) else ['np', 'nonpixel'])
-                break
-
-        if m.is_equip:
-            prefixes.add('assist')
-            prefixes.add('equip')
-
-        # Collab prefixes
-        prefixes.update(self.series_to_prefix_map.get(m.series.tsr_seq, []))
-
-        return prefixes
-
-    def find_monster(self, query, multiple_prefixes=False):
-        query = rpadutils.rmdiacritics(query).lower().strip()
-
-        # id search
-        if query.isdigit():
-            m = self.monster_no_na_to_named_monster.get(int(query))
-            if m is None:
-                return None, 'Looks like a monster ID but was not found', None
+            awakenings_row += ' {}'.format(mapped_awakening)
+
+    awakenings_row = awakenings_row.strip()
+
+    if not len(awakenings_row):
+        awakenings_row = 'No Awakenings'
+
+    killers = compute_killers(m.type1, m.type2, m.type3)
+    killers_row = '**Available Killers:** {}'.format(' '.join(killers))
+
+    embed.description = '{}\n{}'.format(awakenings_row, killers_row)
+
+    if len(m.server_actives) >= 2:
+        for server, active in m.server_actives.items():
+            active_header = '({} Server) Active Skill ({} -> {})'.format(server,
+                                                                         active.turn_max, active.turn_min)
+            active_body = active.desc
+            embed.add_field(name=active_header, value=active_body, inline=False)
+    else:
+        active_header = 'Active Skill'
+        active_body = 'None/Missing'
+        if m.active_skill:
+            active_header = 'Active Skill ({} -> {})'.format(m.active_skill.turn_max,
+                                                             m.active_skill.turn_min)
+            active_body = m.active_skill.desc
+        embed.add_field(name=active_header, value=active_body, inline=False)
+
+    ls_row = m.leader_skill.desc if m.leader_skill else 'None/Missing'
+    ls_header = 'Leader Skill'
+    if m.leader_skill_data:
+        hp, atk, rcv, resist = m.leader_skill_data.get_data()
+        multiplier_text = createMultiplierText(hp, atk, rcv, resist)
+        ls_header += " [ {} ]".format(multiplier_text)
+    embed.add_field(name=ls_header, value=ls_row, inline=False)
+
+    return embed
+
+
+def monsterToOtherInfoEmbed(m: padguide2.PgMonster):
+    embed = monsterToBaseEmbed(m)
+    # Clear the thumbnail, takes up too much space
+    embed.set_thumbnail(url='')
+
+    stat_cols = ['', 'Max', 'M297', 'Inh', 'I297']
+    tbl = prettytable.PrettyTable(stat_cols)
+    tbl.hrules = prettytable.NONE
+    tbl.vrules = prettytable.NONE
+    tbl.align = "r"
+    hhp = m.hp + 99 * 10
+    hatk = m.atk + 99 * 5
+    hrcv = m.rcv + 99 * 3
+    tbl.add_row(['HP', m.hp, hhp, int(m.hp * .1), int(hhp * .1)])
+    tbl.add_row(['ATK', m.atk, hatk, int(m.atk * .05), int(hatk * .05)])
+    tbl.add_row(['RCV', m.rcv, hrcv, int(m.rcv * .15), int(hrcv * .15)])
+
+    body_text = box(tbl.get_string())
+
+    search_text = YT_SEARCH_TEMPLATE.format(m.name_jp)
+    skyozora_text = SKYOZORA_TEMPLATE.format(m.monster_no_jp)
+    body_text += "\n**JP Name**: {} | [YouTube]({}) | [Skyozora]({})".format(
+        m.name_jp, search_text, skyozora_text)
+
+    if m.history_us:
+        body_text += '\n**History:** {}'.format(m.history_us)
+
+    body_text += '\n**Series:** {}'.format(m.series.name)
+    body_text += '\n**Sell MP:** {:,}'.format(m.sell_mp)
+    if m.buy_mp > 0:
+        body_text += "  **Buy MP:** {:,}".format(m.buy_mp)
+
+    if m.exp < 1000000:
+        xp_text = '{:,}'.format(m.exp)
+    else:
+        xp_text = '{:.1f}'.format(m.exp / 1000000).rstrip('0').rstrip('.') + 'M'
+    body_text += '\n**XP to Max:** {}'.format(xp_text)
+    body_text += '  **Max Level:**: {}'.format(m.max_level)
+    body_text += '\n**Rarity:** {} **Cost:** {}'.format(m.rarity, m.cost)
+
+    if m.translated_jp_name:
+        body_text += '\n**Google Translated:** {}'.format(m.translated_jp_name)
+
+    embed.description = body_text
+
+    return embed
+
+
+def monsters_to_rotation_list(monster_list, server: str, index_all: padguide2.MonsterIndex):
+    # Shorten some of the longer names
+    name_remap = {
+        'Extreme King Metal Tamadra': 'Fat Tama',
+        'Extreme King Metal Dragon': 'EKMD',
+        'Ancient Green Sacred Mask': 'Green Mask',
+        'Ancient Blue Sacred Mask': 'Blue Mask',
+    }
+    ignore_monsters = [
+        'Ancient Draggie Knight',
+    ]
+
+    monster_list.sort(key=lambda m: m.monster_no, reverse=True)
+    next_rotation_date = None
+    for m in monster_list:
+        if server in m.future_skillup_rotation:
+            next_rotation_date = m.future_skillup_rotation[server].rotation_date_str
+            break
+
+    cols = [server + ' Skillup', 'Current']
+    if next_rotation_date:
+        cols.append(next_rotation_date)
+    tbl = prettytable.PrettyTable(cols)
+    tbl.hrules = prettytable.HEADER
+    tbl.vrules = prettytable.NONE
+    tbl.align = "l"
+
+    def cell_name(m: padguide2.PgMonster):
+        nm = index_all.monster_no_to_named_monster[m.monster_no]
+        name = nm.group_computed_basename.title()
+        return name_remap.get(name, name)
+
+    for m in monster_list:
+        skill = m.server_actives[server]
+
+        sm = skill.monsters_with_active
+        # Since some newer monsters like jewel of creation are being used as
+        # skillups, exclude them from the list of skillup targets.
+
+        def is_bad_type(m):
+            return set(['enhance', 'evolve', 'vendor']).intersection(set(m.types))
+        sm = max(sm, key=lambda x: (not is_bad_type(x), x.monster_no))
+
+        skillup_name = cell_name(m)
+        if skillup_name in ignore_monsters:
+            continue
+        row = [skillup_name, cell_name(sm)]
+        if next_rotation_date:
+            if server in m.future_skillup_rotation:
+                next_skill = m.future_skillup_rotation[server].skill
+                nm = max(next_skill.monsters_with_active, key=lambda x: x.monster_no)
+                row.append(cell_name(nm))
             else:
-                return m, None, "ID lookup"
-            # special handling for na/jp
+                row.append('')
+        tbl.add_row(row)
 
-        # TODO: need to handle na_only?
-
-        # handle exact nickname match
-        if query in self.all_entries:
-            return self.all_entries[query], None, "Exact nickname"
-
-        contains_jp = rpadutils.containsJp(query)
-        if len(query) < 2 and contains_jp:
-            return None, 'Japanese queries must be at least 2 characters', None
-        elif len(query) < 4 and not contains_jp:
-            return None, 'Your query must be at least 4 letters', None
-        
-        matches, err, debug_info = self.find_matches_multiple_prefixes(query) if multiple_prefixes else self.find_matches(query)
-        
-        if len(matches):
-            return self.pickBestMonster(matches), err, debug_info
-        
-        # couldn't find anything
-        return None, "Could not find a match for: " + query, None
-
-    def find_matches(self, query):
-        print('starting query: %s' % query)
-        # TODO: this should be a length-limited priority queue
-        matches = set()
-        # prefix search for nicknames, space-preceeded, take max id
-        for nickname, m in self.all_entries.items():
-            if nickname.startswith(query + ' '):
-                matches.add(m)
-        if len(matches):
-            print('case 1')
-            return matches, None, "Space nickname prefix, max of {}".format(len(matches))
-    
-        # prefix search for nicknames, take max id
-        for nickname, m in self.all_entries.items():
-            if nickname.startswith(query):
-                matches.add(m)
-        if len(matches):
-            all_names = ",".join(map(lambda x: x.name_na, matches))
-            print('case 2')
-            return matches, None, "Nickname prefix, max of {}, matches=({})".format(len(matches),
-                                                                                                          all_names)
-    
-        # prefix search for full name, take max id
-        for nickname, m in self.all_entries.items():
-            if (m.name_na.lower().startswith(query) or m.name_jp.lower().startswith(query)):
-                matches.add(m)
-        if len(matches):
-            print('case 3')
-            return matches, None, "Full name, max of {}".format(len(matches))
-    
-        # for nicknames with 2 names, prefix search 2nd word, take max id
-        if query in self.two_word_entries:
-            match_as_set_to_return = set()
-            match_as_set_to_return.add(self.two_word_entries[query])
-            print('case 4')
-            return match_as_set_to_return, None, "Second-word nickname prefix, max of {}".format(len(matches))
-    
-        # TODO: refactor 2nd search characteristcs for 2nd word
-    
-        # full name contains on nickname, take max id
-        for nickname, m in self.all_entries.items():
-            if (query in m.name_na.lower() or query in m.name_jp.lower()):
-                matches.add(m)
-        if len(matches):
-            print('case 5')
-            return matches, None, 'Full name match on nickname, max of {}'.format(len(matches))
-    
-        # full name contains on full monster list, take max id
-    
-        for m in self.all_monsters:
-            if (query in m.name_na.lower() or query in m.name_jp.lower()):
-                matches.add(m)
-        if len(matches):
-            print('case 6')
-            return matches, None, 'Full name match on full list, max of {}'.format(len(matches))
-    
-        # No decent matches. Try near hits on nickname instead
-        matches = difflib.get_close_matches(query, self.all_entries.keys(), n=1, cutoff=.8)
-        if len(matches):
-            match = matches[0]
-            match_as_set_to_return = set()
-            match_as_set_to_return.add(self.all_entries[match])
-            print('case 7')
-            return match_as_set_to_return, None, 'Close nickname match ({})'.format(match)
-    
-        # Still no decent matches. Try near hits on full name instead
-        matches = difflib.get_close_matches(
-            query, self.all_na_name_to_monsters.keys(), n=1, cutoff=.9)
-        if len(matches):
-            match = matches[0]
-            match_as_set_to_return = set()
-            match_as_set_to_return.add(self.all_na_name_to_monsters[match])
-            print('case 8')
-            return match_as_set_to_return, None, 'Close name match ({})'.format(match)
-    
-        # couldn't find anything
-        print('case failure')
-        return None, "Could not find a match for: " + query, None
-    
-    def find_matches_multiple_prefixes(self, query):
-        query_prefixes = []
-        parts_of_query = query.split(' ')
-        parts_of_new_query = []
-        for part in parts_of_query:
-            if part in self.all_prefixes:
-                query_prefixes.append(part)
-            else:
-                parts_of_new_query.append(part)
-                break
-        new_query = ' '.join(parts_of_new_query)
-        for prefix in query_prefixes:
-            print('hi ' + prefix)
-        matches = set()
-        for nickname, m in self.all_entries.items():
-            if new_query in nickname:
-                matches.add(m)
-        if not len(matches):
-            matches = difflib.get_close_matches(new_query, self.all_entries.keys(), n=1, cutoff=.8)
-        new_matches = set()
-        for m in matches:
-            keep = True
-            print('Match: %s' % m.name_na)
-            print('Printing match prefixes')
-            for this_prefix in m.prefixes:
-                print(this_prefix)
-            print('Done printing match prefixes')
-            for prefix in query_prefixes:
-                print(prefix)
-                if prefix not in m.prefixes:
-                    keep = False
-                    print('removing %s' % m.name_na)
-                    break
-            if keep:
-                new_matches.add(m)
-                print('keeping %s' % m.name_na)
-        return new_matches, None, None
-    
-    def pickBestMonster(self, named_monster_list):
-        return max(named_monster_list, key=lambda x: (not x.is_low_priority, x.rarity, x.monster_no_na))
-
-class NamedMonsterGroup(object):
-    def __init__(self, monster_group: MonsterGroup, basename_overrides: list):
-        self.is_low_priority = (
-            self._is_low_priority_monster(monster_group.base_monster)
-            or self._is_low_priority_group(monster_group))
-
-        monsters = monster_group.members
-        self.group_size = len(monsters)
-        self.base_monster_no = monster_group.base_monster.monster_no
-        self.base_monster_no_na = monster_group.base_monster.monster_no_na
-
-        self.monster_no_to_basename = {
-            m.monster_no: self._compute_monster_basename(m) for m in monsters
-        }
-
-        self.computed_basename = self._compute_group_basename(monsters)
-        self.computed_basenames = set([self.computed_basename])
-        if '-' in self.computed_basename:
-            self.computed_basenames.add(self.computed_basename.replace('-', ' '))
-
-        self.basenames = basename_overrides or self.computed_basenames
-
-    def _compute_monster_basename(self, m: PgMonster):
-        basename = m.name_na.lower()
-        if ',' in basename:
-            name_parts = basename.split(',')
-            if name_parts[1].strip().startswith('the '):
-                # handle names like 'xxx, the yyy' where xxx is the name
-                basename = name_parts[0]
-            else:
-                # otherwise, grab the chunk after the last comma
-                basename = name_parts[-1]
-
-        for x in ['awoken', 'reincarnated']:
-            if basename.startswith(x):
-                basename = basename.replace(x, '')
-
-        # Fix for DC collab garbage
-        basename = basename.replace('(comics)', '')
-        basename = basename.replace('(film)', '')
-
-        return basename.strip()
-
-    def _compute_group_basename(self, monsters):
-        """Computes the basename for a group of monsters.
-
-        Prefer a basename with the largest count across the group. If all the
-        groups have equal size, prefer the lowest monster number basename.
-        This monster in general has better names, particularly when all the
-        names are unique, e.g. for male/female hunters."""
-        def count_and_id(): return [0, 0]
-        basename_to_info = defaultdict(count_and_id)
-
-        for m in monsters:
-            basename = self.monster_no_to_basename[m.monster_no]
-            entry = basename_to_info[basename]
-            entry[0] += 1
-            entry[1] = max(entry[1], m.monster_no)
-
-        entries = [[count_id[0], -1 * count_id[1], bn] for bn, count_id in basename_to_info.items()]
-        return max(entries)[2]
-
-    def _is_low_priority_monster(self, m: PgMonster):
-        lp_types = ['evolve', 'enhance', 'protected', 'awoken', 'vendor']
-        lp_substrings = ['tamadra']
-        lp_min_rarity = 2
-        name = m.name_na.lower()
-
-        failed_type = m.type1.lower() in lp_types
-        failed_ss = any([x in name for x in lp_substrings])
-        failed_rarity = m.rarity < lp_min_rarity
-        failed_chibi = name == m.name_na and m.name_na != m.name_jp
-        failed_equip = m.is_equip
-        return failed_type or failed_ss or failed_rarity or failed_chibi or failed_equip
-
-    def _is_low_priority_group(self, mg: MonsterGroup):
-        lp_grp_min_rarity = 5
-        max_rarity = max(m.rarity for m in mg.members)
-        failed_max_rarity = max_rarity < lp_grp_min_rarity
-        return failed_max_rarity
+    return tbl.get_string()
 
 
-class NamedMonster(object):
-    def __init__(self, monster: PgMonster, monster_group: NamedMonsterGroup, prefixes: set, extra_nicknames: set):
-        # Must not hold onto monster or monster_group!
+AWAKENING_NAME_MAP_RPAD = {
+    'Enhanced Attack': 'boost_atk',
+    'Enhanced HP': 'boost_hp',
+    'Enhanced Heal': 'boost_rcv',
 
-        # Hold on to the IDs instead
-        self.monster_no = monster.monster_no
-        self.monster_no_na = monster.monster_no_na
-        self.monster_no_jp = monster.monster_no_jp
-        
-        # ID of the root of the tree for this monster
-        self.base_monster_no = monster_group.base_monster_no
-        self.base_monster_no_na = monster_group.base_monster_no_na
+    'Enhanced Team HP': 'teamboost_hp',
+    'Enhanced Team Attack': 'teamboost_atk',
+    'Enhanced Team RCV': 'teamboost_rcv',
 
-        # This stuff is important for nickname generation
-        self.group_basenames = monster_group.basenames
-        self.prefixes = prefixes
+    'God Killer': 'killer_god',
+    'Dragon Killer': 'killer_dragon',
+    'Devil Killer': 'killer_devil',
+    'Machine Killer': 'killer_machine',
+    'Balanced Killer': 'killer_balance',
+    'Attacker Killer': 'killer_attacker',
 
-        # Data used to determine how to rank the nicknames
-        self.is_low_priority = monster_group.is_low_priority or monster.is_equip
-        self.group_size = monster_group.group_size
-        self.rarity = monster.rarity
+    'Physical Killer': 'killer_physical',
+    'Healer Killer': 'killer_healer',
+    'Evolve Material Killer': 'killer_evomat',
+    'Awaken Material Killer': 'killer_awoken',
+    'Enhance Material Killer': 'killer_enhancemat',
+    'Vendor Material Killer': 'killer_vendor',
 
-        # Used in fallback searches
-        self.name_na = monster.name_na
-        self.name_jp = monster.name_jp
+    'Auto-Recover': 'misc_autoheal',
+    'Recover Bind': 'misc_bindclear',
+    'Enhanced Combo': 'misc_comboboost',
+    'Super Enhanced Combo': 'misc_super_comboboost',
+    'Guard Break': 'misc_guardbreak',
+    'Multi Boost': 'misc_multiboost',
+    'Additional Attack': 'misc_extraattack',
+    'Skill Boost': 'misc_sb',
+    'Extend Time': 'misc_te',
+    'Two-Pronged Attack': 'misc_tpa',
+    'Damage Void Shield Penetration': 'misc_voidshield',
+    'Awoken Assist': 'misc_assist',
 
-        # These are just extra metadata
-        self.monster_basename = monster_group.monster_no_to_basename[self.monster_no]
-        self.group_computed_basename = monster_group.computed_basename
-        self.extra_nicknames = extra_nicknames
+    'Enhanced Fire Orbs': 'oe_fire',
+    'Enhanced Water Orbs': 'oe_water',
+    'Enhanced Wood Orbs': 'oe_wood',
+    'Enhanced Light Orbs': 'oe_light',
+    'Enhanced Dark Orbs': 'oe_dark',
+    'Enhanced Heal Orbs': 'oe_heart',
 
-        # Compute any extra prefixes
-        if self.monster_basename in ('ana', 'ace'):
-            self.prefixes.add(self.monster_basename)
+    'Reduce Fire Damage': 'reduce_fire',
+    'Reduce Water Damage': 'reduce_water',
+    'Reduce Wood Damage': 'reduce_wood',
+    'Reduce Light Damage': 'reduce_light',
+    'Reduce Dark Damage': 'reduce_dark',
 
-        # Compute extra basenames by checking for two-word basenames and using the second half
-        self.two_word_basenames = set()
-        for basename in self.group_basenames:
-            basename_words = basename.split(' ')
-            if len(basename_words) == 2:
-                self.two_word_basenames.add(basename_words[1])
+    'Resistance-Bind': 'res_bind',
+    'Resistance-Dark': 'res_blind',
+    'Resistance-Jammers': 'res_jammer',
+    'Resistance-Poison': 'res_poison',
+    'Resistance-Skill Bind': 'res_skillbind',
 
-        # The primary result nicknames
-        self.final_nicknames = set()
-        # Set the configured override nicknames
-        self.final_nicknames.update(self.extra_nicknames)
-        # Set the roma subname for JP monsters
-        if monster.roma_subname:
-            self.final_nicknames.add(monster.roma_subname)
+    'Enhanced Fire Att.': 'row_fire',
+    'Enhanced Water Att.': 'row_water',
+    'Enhanced Wood Att.': 'row_wood',
+    'Enhanced Light Att.': 'row_light',
+    'Enhanced Dark Att.': 'row_dark',
 
-        # For each basename, add nicknames
-        for basename in self.group_basenames:
-            # Add the basename directly
-            self.final_nicknames.add(basename)
-            # Add the prefix plus basename, and the prefix with a space between basename
-            for prefix in self.prefixes:
-                self.final_nicknames.add(prefix + basename)
-                self.final_nicknames.add(prefix + ' ' + basename)
+    'Skill Charge': 'misc_skillcharge',
+    'Super Additional Attack': 'misc_super_extraattack',
+    'Resistance-Bind＋': 'res_bind_super',
+    'Extend Time＋': 'misc_te_super',
+    'Resistance-Cloud': 'res_cloud',
+    'Resistance-Board Restrict': 'res_seal',
+    'Skill Boost＋': 'misc_sb_super',
+    'L-Shape Attack': 'l_attack',
+    'L-Shape Damage Reduction': 'l_shield',
+    'Enhance when HP is below 50%': 'attack_boost_low',
+    'Enhance when HP is above 80%': 'attack_boost_high',
+    'Combo Orb': 'orb_combo',
+    'Skill Voice': 'misc_voice',
+    'Dungeon Bonus': 'misc_dungeonbonus',
+}
 
-        self.final_two_word_nicknames = set()
-        # Slightly different process for two-word basenames. Does this make sense? Who knows.
-        for basename in self.two_word_basenames:
-            self.final_two_word_nicknames.add(basename)
-            # Add the prefix plus basename, and the prefix with a space between basename
-            for prefix in self.prefixes:
-                self.final_two_word_nicknames.add(prefix + basename)
-                self.final_two_word_nicknames.add(prefix + ' ' + basename)
+AWAKENING_NAME_MAP = {
+    'Enhanced Fire Orbs': 'R-OE',
+    'Enhanced Water Orbs': 'B-OE',
+    'Enhanced Wood Orbs': 'G-OE',
+    'Enhanced Light Orbs': 'L-OE',
+    'Enhanced Dark Orbs': 'D-OE',
+    'Enhanced Heal Orbs': 'H-OE',
+
+    'Enhanced Fire Att.': 'R-RE',
+    'Enhanced Water Att.': 'B-RE',
+    'Enhanced Wood Att.': 'G-RE',
+    'Enhanced Light Att.': 'L-RE',
+    'Enhanced Dark Att.': 'D-RE',
+
+    'Enhanced HP': 'HP',
+    'Enhanced Attack': 'ATK',
+    'Enhanced Heal': 'RCV',
+
+    'Enhanced Team HP': 'TEAM-HP',
+    'Enhanced Team Attack': 'TEAM-ATK',
+    'Enhanced Team RCV': 'TEAM-RCV',
+
+    'Auto-Recover': 'AUTO-RECOVER',
+    'Skill Boost': 'SB',
+    'Resistance-Skill Bind': 'SBR',
+    'Two-Pronged Attack': 'TPA',
+    'Multi Boost': 'MULTI-BOOST',
+    'Recover Bind': 'RCV-BIND',
+    'Extend Time': 'TE',
+    'Enhanced Combo': 'COMBO-BOOST',
+    'Guard Break': 'DEF-BREAK',
+    'Additional Attack': 'EXTRA-ATK',
+    'Damage Void Shield Penetration': 'VOID-BREAK',
+    'Awoken Assist': 'ASSIST',
+
+    'Resistance-Bind': 'RES-BIND',
+    'Resistance-Dark': 'RES-BLIND',
+    'Resistance-Poison': 'RES-POISON',
+    'Resistance-Jammers': 'RES-JAMMER',
+
+    'Reduce Fire Damage': 'R-RES',
+    'Reduce Water Damage': 'B-RES',
+    'Reduce Wood Damage': 'G-RES',
+    'Reduce Light Damage': 'L-RES',
+    'Reduce Dark Damage': 'D-RES',
+
+    'Healer Killer': 'K-HEALER',
+    'Machine Killer': 'K-MACHINE',
+    'Dragon Killer': 'K-DRAGON',
+    'Attacker Killer': 'K-ATTACKER',
+    'Physical Killer': 'K-PHYSICAL',
+    'God Killer': 'K-GOD',
+    'Devil Killer': 'K-DEVIL',
+    'Balance Killer': 'K-BALANCE',
+}
 
 
+def createMultiplierText(hp1, atk1, rcv1, resist1, hp2=None, atk2=None, rcv2=None, resist2=None):
+    hp2, atk2, rcv2, resist2 = hp2 or hp1, atk2 or atk1, rcv2 or rcv1, resist2 or resist1
+
+    def fmtNum(val):
+        return ('{:.2f}').format(val).strip('0').rstrip('.')
+    text = "{}/{}/{}".format(fmtNum(hp1 * hp2), fmtNum(atk1 * atk2), fmtNum(rcv1 * rcv2))
+    if resist1 * resist2 < 1:
+        resist1 = resist1 if resist1 < 1 else 0
+        resist2 = resist2 if resist2 < 1 else 0
+        text += ' Resist {}%'.format(fmtNum(100 * (1 - (1 - resist1) * (1 - resist2))))
+    return text
+
+
+def _map_awakenings_text(m: padguide2.PgMonster):
+    awakenings_row = ''
+    unique_awakenings = set(m.awakening_names)
+    for a in unique_awakenings:
+        count = m.awakening_names.count(a)
+        awakenings_row += ' {}x{}'.format(AWAKENING_NAME_MAP.get(a, a), count)
+    awakenings_row = awakenings_row.strip()
+
+    if not len(awakenings_row):
+        awakenings_row = 'No Awakenings'
+
+    return awakenings_row
+
+
+# TODO: move to padguide2
 def compute_killers(*types):
     if 'Balance' in types:
         return ['Any']

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -54,1096 +54,1061 @@ GIF_TEMPLATE = 'https://f002.backblazeb2.com/file/miru-data/padimages/animated/{
 YT_SEARCH_TEMPLATE = 'https://www.youtube.com/results?search_query={}'
 SKYOZORA_TEMPLATE = 'http://pad.skyozora.com/pets/{}'
 
-
 def get_pdx_url(m):
-    return INFO_PDX_TEMPLATE.format(rpadutils.get_pdx_id(m))
-
+	return INFO_PDX_TEMPLATE.format(rpadutils.get_pdx_id(m))
 
 def get_portrait_url(m):
-    if int(m.monster_no) != m.monster_no_na:
-        return RPAD_PORTRAIT_TEMPLATE.format('na', m.monster_no_na)
-    else:
-        return RPAD_PORTRAIT_TEMPLATE.format('jp', m.monster_no_jp)
-
+	if int(m.monster_no) != m.monster_no_na:
+		return RPAD_PORTRAIT_TEMPLATE.format('na', m.monster_no_na)
+	else:
+		return RPAD_PORTRAIT_TEMPLATE.format('jp', m.monster_no_jp)
 
 def get_pic_url(m):
-    if int(m.monster_no) != m.monster_no_na:
-        return RPAD_PIC_TEMPLATE.format('na', m.monster_no_na)
-    else:
-        return RPAD_PIC_TEMPLATE.format('jp', m.monster_no_jp)
-
+	if int(m.monster_no) != m.monster_no_na:
+		return RPAD_PIC_TEMPLATE.format('na', m.monster_no_na)
+	else:
+		return RPAD_PIC_TEMPLATE.format('jp', m.monster_no_jp)
 
 class PadInfo:
-    def __init__(self, bot):
-        self.bot = bot
-        
-        self.settings = PadInfoSettings("padinfo")
-        
-        self.index_all = padguide2.empty_index()
-        self.index_na = padguide2.empty_index()
-        
-        self.menu = Menu(bot)
-        
-        # These emojis are the keys into the idmenu submenus
-        self.id_emoji = '\N{INFORMATION SOURCE}'
-        self.evo_emoji = char_to_emoji('e')
-        self.mats_emoji = char_to_emoji('m')
-        self.ls_emoji = '\N{INFORMATION SOURCE}'
-        self.left_emoji = char_to_emoji('l')
-        self.right_emoji = char_to_emoji('r')
-        self.pantheon_emoji = '\N{CLASSICAL BUILDING}'
-        self.skillups_emoji = '\N{MEAT ON BONE}'
-        self.pic_emoji = '\N{FRAME WITH PICTURE}'
-        self.other_info_emoji = '\N{SCROLL}'
-        
-        self.historic_lookups_file_path = "data/padinfo/historic_lookups.json"
-        self.historic_lookups_file_path_id2 = "data/padinfo/historic_lookups_id2.json"
-  
-        if not dataIO.is_valid_json(self.historic_lookups_file_path):
-            print("Creating empty historic_lookups.json...")
-            dataIO.save_json(self.historic_lookups_file_path, {})
-
-        if not dataIO.is_valid_json(self.historic_lookups_file_path_id2):
-            print("Creating empty historic_lookups_id2.json...")
-            dataIO.save_json(self.historic_lookups_file_path_id2, {})
-
-        self.historic_lookups = dataIO.load_json(self.historic_lookups_file_path)
-        self.historic_lookups_id2 = dataIO.load_json(self.historic_lookups_file_path_id2)
-    
-    def __unload(self):
-        # Manually nulling out database because the GC for cogs seems to be pretty shitty
-        self.index_all = padguide2.empty_index()
-        self.index_na = padguide2.empty_index()
-        self.historic_lookups = {}
-        self.historic_lookups_id2 = {}
-    
-    async def reload_nicknames(self):
-        await self.bot.wait_until_ready()
-        while self == self.bot.get_cog('PadInfo'):
-            try:
-                await self.refresh_index()
-                print('Done refreshing PadInfo')
-            except Exception as ex:
-                print("reload padinfo loop caught exception " + str(ex))
-                traceback.print_exc()
-            
-            await asyncio.sleep(60 * 60 * 1)
-    
-    async def refresh_index(self):
-        """Refresh the monster indexes."""
-        pg_cog = self.bot.get_cog('PadGuide2')
-        await pg_cog.wait_until_ready()
-        self.index_all = pg_cog.create_index()
-        self.index_na = pg_cog.create_index(lambda m: m.on_na)
-    
-    def get_monster_by_no(self, monster_no: int):
-        pg_cog = self.bot.get_cog('PadGuide2')
-        return pg_cog.get_monster_by_no(monster_no)
-    
-    @commands.command(pass_context=True)
-    async def skillrotation(self, ctx, server: str = 'NA'):
-        """Print the current rotating skillups for a server (NA/JP)"""
-        server = normalizeServer(server)
-        if server not in ['NA', 'JP']:
-            await self.bot.say(inline('Supported servers are NA, JP'))
-            return
-        
-        pg_cog = self.bot.get_cog('PadGuide2')
-        monsters = pg_cog.database.rotating_skillups(server)
-        
-        for page in pagify(monsters_to_rotation_list(monsters, server, self.index_all)):
-            await self.bot.say(box(page))
-    
-    @commands.command(pass_context=True)
-    async def jpname(self, ctx, *, query: str):
-        """Print the Japanese name of a monster"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self.bot.say(monsterToHeader(m))
-            await self.bot.say(box(m.name_jp))
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-    
-    @commands.command(name="id", pass_context=True)
-    async def _do_id_all(self, ctx, *, query: str):
-        """Monster info (main tab)"""
-        await self._do_id(ctx, query)
-    
-    @commands.command(name="idna", pass_context=True)
-    async def _do_id_na(self, ctx, *, query: str):
-        """Monster info (limited to NA monsters ONLY)"""
-        await self._do_id(ctx, query, na_only=True)
-    
-    async def _do_id(self, ctx, query: str, na_only=False):
-        m, err, debug_info = self.findMonster(query, na_only=na_only)
-        if m is not None:
-            await self._do_idmenu(ctx, m, self.id_emoji)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-    
-    @commands.command(name="id2", pass_context=True)
-    async def _do_id2_all(self, ctx, *, query: str):
-        """Monster info (main tab)"""
-        await self._do_id2(ctx, query)
-    
-    @commands.command(name="id2na", pass_context=True)
-    async def _do_id2_na(self, ctx, *, query: str):
-        """Monster info (limited to NA monsters ONLY)"""
-        await self._do_id2(ctx, query, na_only=True)
-    
-    async def _do_id2(self, ctx, query: str, na_only=False):
-        m, err, debug_info = self.findMonster2(query, na_only=na_only)
-        if m is not None:
-            await self._do_idmenu(ctx, m, self.id_emoji)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-    
-    @commands.command(name="evos", pass_context=True)
-    async def evos(self, ctx, *, query: str):
-        """Monster info (evolutions tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self._do_idmenu(ctx, m, self.evo_emoji)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-    
-    @commands.command(name="mats", pass_context=True, aliases=['evomats', 'evomat'])
-    async def evomats(self, ctx, *, query: str):
-        """Monster info (evo materials tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self._do_idmenu(ctx, m, self.mats_emoji)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-    
-    @commands.command(pass_context=True)
-    async def pantheon(self, ctx, *, query: str):
-        """Monster info (pantheon tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            menu = await self._do_idmenu(ctx, m, self.pantheon_emoji)
-            if menu == EMBED_NOT_GENERATED:
-                await self.bot.say(inline('Not a pantheon monster'))
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-    
-    @commands.command(pass_context=True)
-    async def skillups(self, ctx, *, query: str):
-        """Monster info (evolutions tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            menu = await self._do_idmenu(ctx, m, self.skillups_emoji)
-            if menu == EMBED_NOT_GENERATED:
-                await self.bot.say(inline('No skillups available'))
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-    
-    async def _do_idmenu(self, ctx, m, starting_menu_emoji):
-        id_embed = monsterToEmbed(m, self.get_emojis())
-        evo_embed = monsterToEvoEmbed(m)
-        mats_embed = monsterToEvoMatsEmbed(m)
-        animated = self.check_monster_animated(m.monster_no_jp)
-        pic_embed = monsterToPicEmbed(m, animated=animated)
-        other_info_embed = monsterToOtherInfoEmbed(m)
-        
-        emoji_to_embed = OrderedDict()
-        emoji_to_embed[self.id_emoji] = id_embed
-        emoji_to_embed[self.evo_emoji] = evo_embed
-        emoji_to_embed[self.mats_emoji] = mats_embed
-        emoji_to_embed[self.pic_emoji] = pic_embed
-        
-        pantheon_embed = monsterToPantheonEmbed(m)
-        if pantheon_embed:
-            emoji_to_embed[self.pantheon_emoji] = pantheon_embed
-        
-        skillups_embed = monsterToSkillupsEmbed(m)
-        if skillups_embed:
-            emoji_to_embed[self.skillups_emoji] = skillups_embed
-        
-        emoji_to_embed[self.other_info_emoji] = other_info_embed
-        
-        return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed)
-    
-    async def _do_evolistmenu(self, ctx, sm):
-        monsters = sm.alt_evos
-        monsters.sort(key=lambda m: m.monster_no)
-        
-        emoji_to_embed = OrderedDict()
-        for idx, m in enumerate(monsters):
-            emoji = char_to_emoji(str(idx))
-            emoji_to_embed[emoji] = monsterToEmbed(m, self.get_emojis())
-            if m == sm:
-                starting_menu_emoji = emoji
-        
-        return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed, timeout=60)
-    
-    async def _do_menu(self, ctx, starting_menu_emoji, emoji_to_embed, timeout=30):
-        if starting_menu_emoji not in emoji_to_embed:
-            # Selected menu wasn't generated for this monster
-            return EMBED_NOT_GENERATED
-        
-        remove_emoji = self.menu.emoji['no']
-        emoji_to_embed[remove_emoji] = self.menu.reaction_delete_message
-        
-        try:
-            result_msg, result_embed = await self.menu.custom_menu(ctx, emoji_to_embed, starting_menu_emoji,
-                                                                   timeout=timeout)
-            if result_msg and result_embed:
-                # Message is finished but not deleted, clear the footer
-                result_embed.set_footer(text=discord.Embed.Empty)
-                await self.bot.edit_message(result_msg, embed=result_embed)
-        except Exception as ex:
-            print('Menu failure', ex)
-    
-    @commands.command(pass_context=True, aliases=['img'])
-    async def pic(self, ctx, *, query: str):
-        """Monster info (full image tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self._do_idmenu(ctx, m, self.pic_emoji)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-    
-    @commands.command(pass_context=True, aliases=['stats'])
-    async def otherinfo(self, ctx, *, query: str):
-        """Monster info (misc info tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self._do_idmenu(ctx, m, self.other_info_emoji)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-    
-    @commands.command(pass_context=True)
-    async def lookup(self, ctx, *, query: str):
-        """Short info results for a monster query"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            embed = monsterToHeaderEmbed(m)
-            await self.bot.say(embed=embed)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-    
-    @commands.command(pass_context=True)
-    async def evolist(self, ctx, *, query):
-        """Monster info (for all monsters in the evo tree)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self._do_evolistmenu(ctx, m)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-    
-    @commands.command(pass_context=True, aliases=['leaders', 'leaderskills', 'ls'])
-    async def leaderskill(self, ctx, left_query: str, right_query: str = None, *, bad=None):
-        """Display the multiplier and leaderskills for two monsters
+	def __init__(self, bot):
+		self.bot = bot
+		
+		self.settings = PadInfoSettings("padinfo")
+		
+		self.index_all = padguide2.empty_index()
+		self.index_na = padguide2.empty_index()
+		
+		self.menu = Menu(bot)
+		
+		# These emojis are the keys into the idmenu submenus
+		self.id_emoji = '\N{INFORMATION SOURCE}'
+		self.evo_emoji = char_to_emoji('e')
+		self.mats_emoji = char_to_emoji('m')
+		self.ls_emoji = '\N{INFORMATION SOURCE}'
+		self.left_emoji = char_to_emoji('l')
+		self.right_emoji = char_to_emoji('r')
+		self.pantheon_emoji = '\N{CLASSICAL BUILDING}'
+		self.skillups_emoji = '\N{MEAT ON BONE}'
+		self.pic_emoji = '\N{FRAME WITH PICTURE}'
+		self.other_info_emoji = '\N{SCROLL}'
+		
+		self.historic_lookups_file_path = "data/padinfo/historic_lookups.json"
+		self.historic_lookups_file_path_id2 = "data/padinfo/historic_lookups_id2.json"
+		
+		if not dataIO.is_valid_json(self.historic_lookups_file_path):
+			print("Creating empty historic_lookups.json...")
+			dataIO.save_json(self.historic_lookups_file_path, {})
+		
+		if not dataIO.is_valid_json(self.historic_lookups_file_path_id2):
+			print("Creating empty historic_lookups_id2.json...")
+			dataIO.save_json(self.historic_lookups_file_path_id2, {})
+		
+		self.historic_lookups = dataIO.load_json(self.historic_lookups_file_path)
+		self.historic_lookups_id2 = dataIO.load_json(self.historic_lookups_file_path_id2)
+	
+	def __unload(self):
+		# Manually nulling out database because the GC for cogs seems to be pretty shitty
+		self.index_all = padguide2.empty_index()
+		self.index_na = padguide2.empty_index()
+		self.historic_lookups = {}
+		self.historic_lookups_id2 = {}
+	
+	async def reload_nicknames(self):
+		await self.bot.wait_until_ready()
+		while self == self.bot.get_cog('PadInfo'):
+			try:
+				await self.refresh_index()
+				print('Done refreshing PadInfo')
+			except Exception as ex:
+				print("reload padinfo loop caught exception " + str(ex))
+				traceback.print_exc()
+			
+			await asyncio.sleep(60 * 60 * 1)
+	
+	async def refresh_index(self):
+		"""Refresh the monster indexes."""
+		pg_cog = self.bot.get_cog('PadGuide2')
+		await pg_cog.wait_until_ready()
+		self.index_all = pg_cog.create_index()
+		self.index_na = pg_cog.create_index(lambda m: m.on_na)
+	
+	def get_monster_by_no(self, monster_no: int):
+		pg_cog = self.bot.get_cog('PadGuide2')
+		return pg_cog.get_monster_by_no(monster_no)
+	
+	@commands.command(pass_context=True)
+	async def skillrotation(self, ctx, server: str = 'NA'):
+		"""Print the current rotating skillups for a server (NA/JP)"""
+		server = normalizeServer(server)
+		if server not in ['NA', 'JP']:
+			await self.bot.say(inline('Supported servers are NA, JP'))
+			return
+		
+		pg_cog = self.bot.get_cog('PadGuide2')
+		monsters = pg_cog.database.rotating_skillups(server)
+		
+		for page in pagify(monsters_to_rotation_list(monsters, server, self.index_all)):
+			await self.bot.say(box(page))
+	
+	@commands.command(pass_context=True)
+	async def jpname(self, ctx, *, query: str):
+		"""Print the Japanese name of a monster"""
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			await self.bot.say(monsterToHeader(m))
+			await self.bot.say(box(m.name_jp))
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(name="id", pass_context=True)
+	async def _do_id_all(self, ctx, *, query: str):
+		"""Monster info (main tab)"""
+		await self._do_id(ctx, query)
+	
+	@commands.command(name="idna", pass_context=True)
+	async def _do_id_na(self, ctx, *, query: str):
+		"""Monster info (limited to NA monsters ONLY)"""
+		await self._do_id(ctx, query, na_only=True)
+	
+	async def _do_id(self, ctx, query: str, na_only=False):
+		m, err, debug_info = self.findMonster(query, na_only=na_only)
+		if m is not None:
+			await self._do_idmenu(ctx, m, self.id_emoji)
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(name="id2", pass_context=True)
+	async def _do_id2_all(self, ctx, *, query: str):
+		"""Monster info (main tab)"""
+		await self._do_id2(ctx, query)
+	
+	@commands.command(name="id2na", pass_context=True)
+	async def _do_id2_na(self, ctx, *, query: str):
+		"""Monster info (limited to NA monsters ONLY)"""
+		await self._do_id2(ctx, query, na_only=True)
+	
+	async def _do_id2(self, ctx, query: str, na_only=False):
+		m, err, debug_info = self.findMonster2(query, na_only=na_only)
+		if m is not None:
+			await self._do_idmenu(ctx, m, self.id_emoji)
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(name="evos", pass_context=True)
+	async def evos(self, ctx, *, query: str):
+		"""Monster info (evolutions tab)"""
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			await self._do_idmenu(ctx, m, self.evo_emoji)
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(name="mats", pass_context=True, aliases=['evomats', 'evomat'])
+	async def evomats(self, ctx, *, query: str):
+		"""Monster info (evo materials tab)"""
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			await self._do_idmenu(ctx, m, self.mats_emoji)
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(pass_context=True)
+	async def pantheon(self, ctx, *, query: str):
+		"""Monster info (pantheon tab)"""
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			menu = await self._do_idmenu(ctx, m, self.pantheon_emoji)
+			if menu == EMBED_NOT_GENERATED:
+				await self.bot.say(inline('Not a pantheon monster'))
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(pass_context=True)
+	async def skillups(self, ctx, *, query: str):
+		"""Monster info (evolutions tab)"""
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			menu = await self._do_idmenu(ctx, m, self.skillups_emoji)
+			if menu == EMBED_NOT_GENERATED:
+				await self.bot.say(inline('No skillups available'))
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	async def _do_idmenu(self, ctx, m, starting_menu_emoji):
+		id_embed = monsterToEmbed(m, self.get_emojis())
+		evo_embed = monsterToEvoEmbed(m)
+		mats_embed = monsterToEvoMatsEmbed(m)
+		animated = self.check_monster_animated(m.monster_no_jp)
+		pic_embed = monsterToPicEmbed(m, animated=animated)
+		other_info_embed = monsterToOtherInfoEmbed(m)
+		
+		emoji_to_embed = OrderedDict()
+		emoji_to_embed[self.id_emoji] = id_embed
+		emoji_to_embed[self.evo_emoji] = evo_embed
+		emoji_to_embed[self.mats_emoji] = mats_embed
+		emoji_to_embed[self.pic_emoji] = pic_embed
+		
+		pantheon_embed = monsterToPantheonEmbed(m)
+		if pantheon_embed:
+			emoji_to_embed[self.pantheon_emoji] = pantheon_embed
+		
+		skillups_embed = monsterToSkillupsEmbed(m)
+		if skillups_embed:
+			emoji_to_embed[self.skillups_emoji] = skillups_embed
+		
+		emoji_to_embed[self.other_info_emoji] = other_info_embed
+		
+		return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed)
+	
+	async def _do_evolistmenu(self, ctx, sm):
+		monsters = sm.alt_evos
+		monsters.sort(key=lambda m: m.monster_no)
+		
+		emoji_to_embed = OrderedDict()
+		for idx, m in enumerate(monsters):
+			emoji = char_to_emoji(str(idx))
+			emoji_to_embed[emoji] = monsterToEmbed(m, self.get_emojis())
+			if m == sm:
+				starting_menu_emoji = emoji
+		
+		return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed, timeout=60)
+	
+	async def _do_menu(self, ctx, starting_menu_emoji, emoji_to_embed, timeout=30):
+		if starting_menu_emoji not in emoji_to_embed:
+			# Selected menu wasn't generated for this monster
+			return EMBED_NOT_GENERATED
+		
+		remove_emoji = self.menu.emoji['no']
+		emoji_to_embed[remove_emoji] = self.menu.reaction_delete_message
+		
+		try:
+			result_msg, result_embed = await self.menu.custom_menu(ctx, emoji_to_embed, starting_menu_emoji,
+																   timeout=timeout)
+			if result_msg and result_embed:
+				# Message is finished but not deleted, clear the footer
+				result_embed.set_footer(text=discord.Embed.Empty)
+				await self.bot.edit_message(result_msg, embed=result_embed)
+		except Exception as ex:
+			print('Menu failure', ex)
+	
+	@commands.command(pass_context=True, aliases=['img'])
+	async def pic(self, ctx, *, query: str):
+		"""Monster info (full image tab)"""
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			await self._do_idmenu(ctx, m, self.pic_emoji)
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(pass_context=True, aliases=['stats'])
+	async def otherinfo(self, ctx, *, query: str):
+		"""Monster info (misc info tab)"""
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			await self._do_idmenu(ctx, m, self.other_info_emoji)
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(pass_context=True)
+	async def lookup(self, ctx, *, query: str):
+		"""Short info results for a monster query"""
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			embed = monsterToHeaderEmbed(m)
+			await self.bot.say(embed=embed)
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(pass_context=True)
+	async def evolist(self, ctx, *, query):
+		"""Monster info (for all monsters in the evo tree)"""
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			await self._do_evolistmenu(ctx, m)
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(pass_context=True, aliases=['leaders', 'leaderskills', 'ls'])
+	async def leaderskill(self, ctx, left_query: str, right_query: str = None, *, bad=None):
+		"""Display the multiplier and leaderskills for two monsters
 
         If either your left or right query contains spaces, wrap in quotes.
         e.g.: ^leaderskill "r sonia" "b sonia"
         """
-        if bad:
-            await self.bot.say(inline('Too many inputs. Try wrapping your queries in quotes.'))
-            return
-        
-        # Handle a very specific failure case, user typing something like "uuvo ragdra"
-        if ' ' not in left_query and right_query is not None and ' ' not in right_query and bad is None:
-            combined_query = left_query + ' ' + right_query
-            nm, err, debug_info = self._findMonster(combined_query)
-            if nm and left_query in nm.prefixes:
-                left_query = combined_query
-                right_query = None
-        
-        left_m, left_err, _ = self.findMonster(left_query)
-        if right_query:
-            right_m, right_err, _ = self.findMonster(right_query)
-        else:
-            right_m, right_err, = left_m, left_err
-        
-        err_msg = '{} query failed to match a monster: [ {} ]. If your query is multiple words, wrap it in quotes.'
-        if left_err:
-            await self.bot.say(inline(err_msg.format('Left', left_query)))
-            return
-        if right_err:
-            await self.bot.say(inline(err_msg.format('Right', right_query)))
-            return
-        
-        emoji_to_embed = OrderedDict()
-        emoji_to_embed[self.ls_emoji] = monstersToLsEmbed(left_m, right_m)
-        emoji_to_embed[self.left_emoji] = monsterToEmbed(left_m, self.get_emojis())
-        emoji_to_embed[self.right_emoji] = monsterToEmbed(right_m, self.get_emojis())
-        
-        await self._do_menu(ctx, self.ls_emoji, emoji_to_embed)
-    
-    @commands.command(name="helpid", pass_context=True, aliases=['helppic', 'helpimg'])
-    async def _helpid(self, ctx):
-        """Whispers you info on how to craft monster queries for ^id"""
-        await self.bot.whisper(box(HELP_MSG))
-    
-    @commands.command(pass_context=True)
-    async def padsay(self, ctx, server, *, query: str = None):
-        """Speak the voice line of a monster into your current chat"""
-        voice = ctx.message.author.voice
-        channel = voice.voice_channel
-        if channel is None:
-            await self.bot.say(inline('You must be in a voice channel to use this command'))
-            return
-        
-        speech_cog = self.bot.get_cog('Speech')
-        if not speech_cog:
-            await self.bot.say(inline('Speech seems to be offline'))
-            return
-        
-        if server.lower() not in ['na', 'jp']:
-            query = server + ' ' + (query or '')
-            server = 'na'
-        query = query.strip().lower()
-        
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            base_dir = '/home/tactical0retreat/pad_data/voices/fixed'
-            voice_file = os.path.join(base_dir, server, '{}.wav'.format(m.monster_no_na))
-            header = '{} ({})'.format(monsterToHeader(m), server)
-            if not os.path.exists(voice_file):
-                await self.bot.say(inline('Could not find voice for ' + header))
-                return
-            await self.bot.say('Speaking for ' + header)
-            await speech_cog.play_path(channel, voice_file)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-    
-    @commands.group(pass_context=True)
-    @checks.is_owner()
-    async def padinfo(self, ctx):
-        """PAD info management"""
-        if ctx.invoked_subcommand is None:
-            await send_cmd_help(ctx)
-    
-    @padinfo.command(pass_context=True)
-    @checks.is_owner()
-    async def setemojiservers(self, ctx, *, emoji_servers=''):
-        """Set the emoji servers by ID (csv)"""
-        self.settings.emojiServers().clear()
-        if emoji_servers:
-            self.settings.setEmojiServers(emoji_servers.split(','))
-        await self.bot.say(inline('Set {} servers'.format(len(self.settings.emojiServers()))))
-    
-    def get_emojis(self):
-        server_ids = self.settings.emojiServers()
-        return [e for s in self.bot.servers if s.id in server_ids for e in s.emojis]
-    
-    def makeFailureMsg(self, err):
-        msg = 'Lookup failed: {}.\n'.format(err)
-        msg += 'Try one of <id>, <name>, [argbld]/[rgbld] <name>. Unexpected results? Use ^helpid for more info.'
-        return box(msg)
-    
-    def findMonster(self, query, na_only=False):
-        query = rmdiacritics(query)
-        nm, err, debug_info = self._findMonster(query, na_only)
-        
-        monster_no = nm.monster_no if nm else -1
-        self.historic_lookups[query] = monster_no
-        dataIO.save_json(self.historic_lookups_file_path, self.historic_lookups)
-        
-        m = self.get_monster_by_no(nm.monster_no) if nm else None
-        
-        return m, err, debug_info
-    
-    def _findMonster(self, query, na_only=False):
-        monster_index = self.index_na if na_only else self.index_all
-        return monster_index.find_monster(query)
-    
-    def findMonster2(self, query, na_only=False):
-        query = rmdiacritics(query)
-        nm, err, debug_info = self._findMonster2(query, na_only)
-        
-        monster_no = nm.monster_no if nm else -1
-        self.historic_lookups_id2[query] = monster_no
-        dataIO.save_json(self.historic_lookups_file_path_id2, self.historic_lookups_id2)
-        
-        m = self.get_monster_by_no(nm.monster_no) if nm else None
-        
-        return m, err, debug_info
-    
-    def _findMonster2(self, query, na_only=False):
-        monster_index = self.index_na if na_only else self.index_all
-        return monster_index.find_monster2(query)
-    
-    def map_awakenings_text(self, m):
-        """Exported for use in other cogs"""
-        return _map_awakenings_text(m)
-    
-    @padinfo.command(pass_context=True)
-    @checks.is_owner()
-    async def setanimationdir(self, ctx, *, animation_dir=''):
-        """Set a directory containing animated images"""
-        self.settings.setAnimationDir(animation_dir)
-        await self.bot.say(inline('Done'))
-    
-    def check_monster_animated(self, monster_id: int):
-        if not self.settings.animationDir():
-            return False
-        
-        try:
-            animated_ids = set()
-            for f in os.listdir(self.settings.animationDir()):
-                f = f.replace('.mp4', '')
-                if f.isdigit() and int(f) == monster_id:
-                    return True
-        except:
-            pass
-        
-        return False
-
+		if bad:
+			await self.bot.say(inline('Too many inputs. Try wrapping your queries in quotes.'))
+			return
+		
+		# Handle a very specific failure case, user typing something like "uuvo ragdra"
+		if ' ' not in left_query and right_query is not None and ' ' not in right_query and bad is None:
+			combined_query = left_query + ' ' + right_query
+			nm, err, debug_info = self._findMonster(combined_query)
+			if nm and left_query in nm.prefixes:
+				left_query = combined_query
+				right_query = None
+		
+		left_m, left_err, _ = self.findMonster(left_query)
+		if right_query:
+			right_m, right_err, _ = self.findMonster(right_query)
+		else:
+			right_m, right_err, = left_m, left_err
+		
+		err_msg = '{} query failed to match a monster: [ {} ]. If your query is multiple words, wrap it in quotes.'
+		if left_err:
+			await self.bot.say(inline(err_msg.format('Left', left_query)))
+			return
+		if right_err:
+			await self.bot.say(inline(err_msg.format('Right', right_query)))
+			return
+		
+		emoji_to_embed = OrderedDict()
+		emoji_to_embed[self.ls_emoji] = monstersToLsEmbed(left_m, right_m)
+		emoji_to_embed[self.left_emoji] = monsterToEmbed(left_m, self.get_emojis())
+		emoji_to_embed[self.right_emoji] = monsterToEmbed(right_m, self.get_emojis())
+		
+		await self._do_menu(ctx, self.ls_emoji, emoji_to_embed)
+	
+	@commands.command(name="helpid", pass_context=True, aliases=['helppic', 'helpimg'])
+	async def _helpid(self, ctx):
+		"""Whispers you info on how to craft monster queries for ^id"""
+		await self.bot.whisper(box(HELP_MSG))
+	
+	@commands.command(pass_context=True)
+	async def padsay(self, ctx, server, *, query: str = None):
+		"""Speak the voice line of a monster into your current chat"""
+		voice = ctx.message.author.voice
+		channel = voice.voice_channel
+		if channel is None:
+			await self.bot.say(inline('You must be in a voice channel to use this command'))
+			return
+		
+		speech_cog = self.bot.get_cog('Speech')
+		if not speech_cog:
+			await self.bot.say(inline('Speech seems to be offline'))
+			return
+		
+		if server.lower() not in ['na', 'jp']:
+			query = server + ' ' + (query or '')
+			server = 'na'
+		query = query.strip().lower()
+		
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			base_dir = '/home/tactical0retreat/pad_data/voices/fixed'
+			voice_file = os.path.join(base_dir, server, '{}.wav'.format(m.monster_no_na))
+			header = '{} ({})'.format(monsterToHeader(m), server)
+			if not os.path.exists(voice_file):
+				await self.bot.say(inline('Could not find voice for ' + header))
+				return
+			await self.bot.say('Speaking for ' + header)
+			await speech_cog.play_path(channel, voice_file)
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.group(pass_context=True)
+	@checks.is_owner()
+	async def padinfo(self, ctx):
+		"""PAD info management"""
+		if ctx.invoked_subcommand is None:
+			await send_cmd_help(ctx)
+	
+	@padinfo.command(pass_context=True)
+	@checks.is_owner()
+	async def setemojiservers(self, ctx, *, emoji_servers=''):
+		"""Set the emoji servers by ID (csv)"""
+		self.settings.emojiServers().clear()
+		if emoji_servers:
+			self.settings.setEmojiServers(emoji_servers.split(','))
+		await self.bot.say(inline('Set {} servers'.format(len(self.settings.emojiServers()))))
+	
+	def get_emojis(self):
+		server_ids = self.settings.emojiServers()
+		return [e for s in self.bot.servers if s.id in server_ids for e in s.emojis]
+	
+	def makeFailureMsg(self, err):
+		msg = 'Lookup failed: {}.\n'.format(err)
+		msg += 'Try one of <id>, <name>, [argbld]/[rgbld] <name>. Unexpected results? Use ^helpid for more info.'
+		return box(msg)
+	
+	def findMonster(self, query, na_only=False):
+		query = rmdiacritics(query)
+		nm, err, debug_info = self._findMonster(query, na_only)
+		
+		monster_no = nm.monster_no if nm else -1
+		self.historic_lookups[query] = monster_no
+		dataIO.save_json(self.historic_lookups_file_path, self.historic_lookups)
+		
+		m = self.get_monster_by_no(nm.monster_no) if nm else None
+		
+		return m, err, debug_info
+	
+	def _findMonster(self, query, na_only=False):
+		monster_index = self.index_na if na_only else self.index_all
+		return monster_index.find_monster(query)
+	
+	def findMonster2(self, query, na_only=False):
+		query = rmdiacritics(query)
+		nm, err, debug_info = self._findMonster2(query, na_only)
+		
+		monster_no = nm.monster_no if nm else -1
+		self.historic_lookups_id2[query] = monster_no
+		dataIO.save_json(self.historic_lookups_file_path_id2, self.historic_lookups_id2)
+		
+		m = self.get_monster_by_no(nm.monster_no) if nm else None
+		
+		return m, err, debug_info
+	
+	def _findMonster2(self, query, na_only=False):
+		monster_index = self.index_na if na_only else self.index_all
+		return monster_index.find_monster2(query)
+	
+	def map_awakenings_text(self, m):
+		"""Exported for use in other cogs"""
+		return _map_awakenings_text(m)
+	
+	@padinfo.command(pass_context=True)
+	@checks.is_owner()
+	async def setanimationdir(self, ctx, *, animation_dir=''):
+		"""Set a directory containing animated images"""
+		self.settings.setAnimationDir(animation_dir)
+		await self.bot.say(inline('Done'))
+	
+	def check_monster_animated(self, monster_id: int):
+		if not self.settings.animationDir():
+			return False
+		
+		try:
+			animated_ids = set()
+			for f in os.listdir(self.settings.animationDir()):
+				f = f.replace('.mp4', '')
+				if f.isdigit() and int(f) == monster_id:
+					return True
+		except:
+			pass
+		
+		return False
 
 def setup(bot):
-    print('padinfo bot setup')
-    n = PadInfo(bot)
-    bot.add_cog(n)
-    bot.loop.create_task(n.reload_nicknames())
-    print('done adding padinfo bot')
-
+	print('padinfo bot setup')
+	n = PadInfo(bot)
+	bot.add_cog(n)
+	bot.loop.create_task(n.reload_nicknames())
+	print('done adding padinfo bot')
 
 class PadInfoSettings(CogSettings):
-    def make_default_settings(self):
-        config = {
-            'animation_dir': '',
-        }
-        return config
-    
-    def emojiServers(self):
-        key = 'emoji_servers'
-        if key not in self.bot_settings:
-            self.bot_settings[key] = []
-        return self.bot_settings[key]
-    
-    def setEmojiServers(self, emoji_servers):
-        es = self.emojiServers()
-        es.clear()
-        es.extend(emoji_servers)
-        self.save_settings()
-    
-    def animationDir(self):
-        return self.bot_settings['animation_dir']
-    
-    def setAnimationDir(self, animation_dir):
-        self.bot_settings['animation_dir'] = animation_dir
-        self.save_settings()
-
+	def make_default_settings(self):
+		config = {
+			'animation_dir': '',
+		}
+		return config
+	
+	def emojiServers(self):
+		key = 'emoji_servers'
+		if key not in self.bot_settings:
+			self.bot_settings[key] = []
+		return self.bot_settings[key]
+	
+	def setEmojiServers(self, emoji_servers):
+		es = self.emojiServers()
+		es.clear()
+		es.extend(emoji_servers)
+		self.save_settings()
+	
+	def animationDir(self):
+		return self.bot_settings['animation_dir']
+	
+	def setAnimationDir(self, animation_dir):
+		self.bot_settings['animation_dir'] = animation_dir
+		self.save_settings()
 
 def monsterToHeader(m: padguide2.PgMonster, link=False):
-    msg = 'No. {} {}'.format(m.monster_no_na, m.name_na)
-    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
-
+	msg = 'No. {} {}'.format(m.monster_no_na, m.name_na)
+	return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
 
 def monsterToJpSuffix(m: padguide2.PgMonster):
-    suffix = ""
-    if m.roma_subname:
-        suffix += ' [{}]'.format(m.roma_subname)
-    if not m.on_na:
-        suffix += ' (JP only)'
-    return suffix
-
+	suffix = ""
+	if m.roma_subname:
+		suffix += ' [{}]'.format(m.roma_subname)
+	if not m.on_na:
+		suffix += ' (JP only)'
+	return suffix
 
 def monsterToLongHeader(m: padguide2.PgMonster, link=False):
-    msg = monsterToHeader(m) + monsterToJpSuffix(m)
-    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
-
+	msg = monsterToHeader(m) + monsterToJpSuffix(m)
+	return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
 
 def monsterToLongHeaderWithAttr(m: padguide2.PgMonster, link=False):
-    header = 'No. {} {} {}'.format(
-        m.monster_no_na,
-        "({}{})".format(attr_prefix_map[m.attr1], "/" +
-                                                  attr_prefix_map[m.attr2] if m.attr2 else ""),
-        m.name_na)
-    msg = header + monsterToJpSuffix(m)
-    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
-
+	header = 'No. {} {} {}'.format(
+		m.monster_no_na,
+		"({}{})".format(attr_prefix_map[m.attr1], "/" +
+												  attr_prefix_map[m.attr2] if m.attr2 else ""),
+		m.name_na)
+	msg = header + monsterToJpSuffix(m)
+	return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
 
 def monsterToEvoText(m: padguide2.PgMonster):
-    output = monsterToLongHeader(m)
-    for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
-        output += "\n\t- {}".format(monsterToLongHeader(ae))
-    return output
-
+	output = monsterToLongHeader(m)
+	for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
+		output += "\n\t- {}".format(monsterToLongHeader(ae))
+	return output
 
 def monsterToThumbnailUrl(m: padguide2.PgMonster):
-    return get_portrait_url(m)
-
+	return get_portrait_url(m)
 
 def monsterToBaseEmbed(m: padguide2.PgMonster):
-    header = monsterToLongHeader(m)
-    embed = discord.Embed()
-    embed.set_thumbnail(url=monsterToThumbnailUrl(m))
-    embed.title = header
-    embed.url = get_pdx_url(m)
-    embed.set_footer(text='Requester may click the reactions below to switch tabs')
-    return embed
-
+	header = monsterToLongHeader(m)
+	embed = discord.Embed()
+	embed.set_thumbnail(url=monsterToThumbnailUrl(m))
+	embed.title = header
+	embed.url = get_pdx_url(m)
+	embed.set_footer(text='Requester may click the reactions below to switch tabs')
+	return embed
 
 def monsterToEvoEmbed(m: padguide2.PgMonster):
-    embed = monsterToBaseEmbed(m)
-    
-    if not len(m.alt_evos):
-        embed.description = 'No alternate evos'
-        return embed
-    
-    field_name = '{} alternate evos'.format(len(m.alt_evos))
-    field_data = ''
-    for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
-        field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
-    
-    embed.add_field(name=field_name, value=field_data)
-    
-    return embed
-
+	embed = monsterToBaseEmbed(m)
+	
+	if not len(m.alt_evos):
+		embed.description = 'No alternate evos'
+		return embed
+	
+	field_name = '{} alternate evos'.format(len(m.alt_evos))
+	field_data = ''
+	for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
+		field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
+	
+	embed.add_field(name=field_name, value=field_data)
+	
+	return embed
 
 def monsterToEvoMatsEmbed(m: padguide2.PgMonster):
-    embed = monsterToBaseEmbed(m)
-    
-    mats_for_evo_size = len(m.mats_for_evo)
-    material_of_size = len(m.material_of)
-    
-    field_name = 'Evo materials'
-    field_data = ''
-    if mats_for_evo_size:
-        for ae in m.mats_for_evo:
-            field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
-    else:
-        field_data = 'None'
-    embed.add_field(name=field_name, value=field_data)
-    
-    if not material_of_size:
-        return embed
-    
-    field_name = 'Material for'
-    field_data = ''
-    if material_of_size > 5:
-        field_data = '{} monsters'.format(material_of_size)
-    else:
-        item_count = min(material_of_size, 5)
-        for ae in sorted(m.material_of, key=lambda x: x.monster_no_na, reverse=True)[:item_count]:
-            field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
-    embed.add_field(name=field_name, value=field_data)
-    
-    return embed
-
+	embed = monsterToBaseEmbed(m)
+	
+	mats_for_evo_size = len(m.mats_for_evo)
+	material_of_size = len(m.material_of)
+	
+	field_name = 'Evo materials'
+	field_data = ''
+	if mats_for_evo_size:
+		for ae in m.mats_for_evo:
+			field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
+	else:
+		field_data = 'None'
+	embed.add_field(name=field_name, value=field_data)
+	
+	if not material_of_size:
+		return embed
+	
+	field_name = 'Material for'
+	field_data = ''
+	if material_of_size > 5:
+		field_data = '{} monsters'.format(material_of_size)
+	else:
+		item_count = min(material_of_size, 5)
+		for ae in sorted(m.material_of, key=lambda x: x.monster_no_na, reverse=True)[:item_count]:
+			field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
+	embed.add_field(name=field_name, value=field_data)
+	
+	return embed
 
 def monsterToPantheonEmbed(m: padguide2.PgMonster):
-    full_pantheon = m.series.monsters
-    pantheon_list = list(filter(lambda x: x.evo_from is None, full_pantheon))
-    if len(pantheon_list) == 0 or len(pantheon_list) > 6:
-        return None
-    
-    embed = monsterToBaseEmbed(m)
-    
-    field_name = 'Pantheon: ' + m.series.name
-    field_data = ''
-    for monster in sorted(pantheon_list, key=lambda x: x.monster_no_na):
-        field_data += '\n' + monsterToHeader(monster, link=True)
-    embed.add_field(name=field_name, value=field_data)
-    
-    return embed
-
+	full_pantheon = m.series.monsters
+	pantheon_list = list(filter(lambda x: x.evo_from is None, full_pantheon))
+	if len(pantheon_list) == 0 or len(pantheon_list) > 6:
+		return None
+	
+	embed = monsterToBaseEmbed(m)
+	
+	field_name = 'Pantheon: ' + m.series.name
+	field_data = ''
+	for monster in sorted(pantheon_list, key=lambda x: x.monster_no_na):
+		field_data += '\n' + monsterToHeader(monster, link=True)
+	embed.add_field(name=field_name, value=field_data)
+	
+	return embed
 
 def monsterToSkillupsEmbed(m: padguide2.PgMonster):
-    skillups_list = m.active_skill.monsters_with_active if m.active_skill else []
-    skillups_list = list(filter(lambda m: m.sell_mp < 3000, skillups_list))
-    server_skillups = m.active_skill.server_skillups if m.active_skill else []
-    
-    if len(skillups_list) + len(server_skillups) == 0:
-        return None
-    
-    embed = monsterToBaseEmbed(m)
-    
-    skillups_to_skip = []
-    for server, skillup in server_skillups.items():
-        skillup_header = 'Skillup in ' + server
-        skillup_body = monsterToHeader(skillup, link=True)
-        embed.add_field(name=skillup_header, value=skillup_body)
-        skillups_to_skip.append(skillup.monster_no_na)
-    
-    field_name = 'Skillups'
-    field_data = ''
-    
-    # Prevent huge skillup lists
-    if len(skillups_list) > 8:
-        field_data = '({} skillups omitted)'.format(len(skillups_list) - 8)
-        skillups_list = skillups_list[0:8]
-    
-    for monster in sorted(skillups_list, key=lambda x: x.monster_no_na):
-        if monster.monster_no_na in skillups_to_skip:
-            continue
-        field_data += '\n' + monsterToHeader(monster, link=True)
-    
-    if len(field_data.strip()):
-        embed.add_field(name=field_name, value=field_data)
-    
-    return embed
-
+	skillups_list = m.active_skill.monsters_with_active if m.active_skill else []
+	skillups_list = list(filter(lambda m: m.sell_mp < 3000, skillups_list))
+	server_skillups = m.active_skill.server_skillups if m.active_skill else []
+	
+	if len(skillups_list) + len(server_skillups) == 0:
+		return None
+	
+	embed = monsterToBaseEmbed(m)
+	
+	skillups_to_skip = []
+	for server, skillup in server_skillups.items():
+		skillup_header = 'Skillup in ' + server
+		skillup_body = monsterToHeader(skillup, link=True)
+		embed.add_field(name=skillup_header, value=skillup_body)
+		skillups_to_skip.append(skillup.monster_no_na)
+	
+	field_name = 'Skillups'
+	field_data = ''
+	
+	# Prevent huge skillup lists
+	if len(skillups_list) > 8:
+		field_data = '({} skillups omitted)'.format(len(skillups_list) - 8)
+		skillups_list = skillups_list[0:8]
+	
+	for monster in sorted(skillups_list, key=lambda x: x.monster_no_na):
+		if monster.monster_no_na in skillups_to_skip:
+			continue
+		field_data += '\n' + monsterToHeader(monster, link=True)
+	
+	if len(field_data.strip()):
+		embed.add_field(name=field_name, value=field_data)
+	
+	return embed
 
 def monsterToPicUrl(m: padguide2.PgMonster):
-    return get_pic_url(m)
-
+	return get_pic_url(m)
 
 def monsterToPicEmbed(m: padguide2.PgMonster, animated=False):
-    embed = monsterToBaseEmbed(m)
-    url = monsterToPicUrl(m)
-    embed.set_image(url=url)
-    # Clear the thumbnail, don't need it on pic
-    embed.set_thumbnail(url='')
-    if animated:
-        description = '[{}]({}) –– [{}]({})'.format(
-            'HQ (MP4)', monsterToVideoUrl(m), 'LQ (GIF)', monsterToGifUrl(m))
-        embed.add_field(name='Animated links', value=description)
-    
-    return embed
-
+	embed = monsterToBaseEmbed(m)
+	url = monsterToPicUrl(m)
+	embed.set_image(url=url)
+	# Clear the thumbnail, don't need it on pic
+	embed.set_thumbnail(url='')
+	if animated:
+		description = '[{}]({}) –– [{}]({})'.format(
+			'HQ (MP4)', monsterToVideoUrl(m), 'LQ (GIF)', monsterToGifUrl(m))
+		embed.add_field(name='Animated links', value=description)
+	
+	return embed
 
 def monsterToVideoUrl(m: padguide2.PgMonster):
-    return VIDEO_TEMPLATE.format(m.monster_no_jp)
-
+	return VIDEO_TEMPLATE.format(m.monster_no_jp)
 
 def monsterToGifUrl(m: padguide2.PgMonster):
-    return GIF_TEMPLATE.format(m.monster_no_jp)
-
+	return GIF_TEMPLATE.format(m.monster_no_jp)
 
 def monsterToGifEmbed(m: padguide2.PgMonster):
-    embed = monsterToBaseEmbed(m)
-    url = monsterToGifUrl(m)
-    embed.set_image(url=url)
-    # Clear the thumbnail, don't need it on pic
-    embed.set_thumbnail(url='')
-    return embed
-
+	embed = monsterToBaseEmbed(m)
+	url = monsterToGifUrl(m)
+	embed.set_image(url=url)
+	# Clear the thumbnail, don't need it on pic
+	embed.set_thumbnail(url='')
+	return embed
 
 def monstersToLsEmbed(left_m: padguide2.PgMonster, right_m: padguide2.PgMonster):
-    lhp, latk, lrcv, lresist = left_m.leader_skill_data.get_data()
-    rhp, ratk, rrcv, rresist = right_m.leader_skill_data.get_data()
-    multiplier_text = createMultiplierText(lhp, latk, lrcv, lresist, rhp, ratk, rrcv, rresist)
-    
-    embed = discord.Embed()
-    embed.title = 'Multiplier [{}]\n\n'.format(multiplier_text)
-    description = ''
-    description += '\n**{}**\n{}'.format(
-        monsterToHeader(left_m, link=True),
-        left_m.leader_skill.desc if left_m.leader_skill else 'None/Missing')
-    description += '\n**{}**\n{}'.format(
-        monsterToHeader(right_m, link=True),
-        right_m.leader_skill.desc if right_m.leader_skill else 'None/Missing')
-    embed.description = description
-    
-    return embed
-
+	lhp, latk, lrcv, lresist = left_m.leader_skill_data.get_data()
+	rhp, ratk, rrcv, rresist = right_m.leader_skill_data.get_data()
+	multiplier_text = createMultiplierText(lhp, latk, lrcv, lresist, rhp, ratk, rrcv, rresist)
+	
+	embed = discord.Embed()
+	embed.title = 'Multiplier [{}]\n\n'.format(multiplier_text)
+	description = ''
+	description += '\n**{}**\n{}'.format(
+		monsterToHeader(left_m, link=True),
+		left_m.leader_skill.desc if left_m.leader_skill else 'None/Missing')
+	description += '\n**{}**\n{}'.format(
+		monsterToHeader(right_m, link=True),
+		right_m.leader_skill.desc if right_m.leader_skill else 'None/Missing')
+	embed.description = description
+	
+	return embed
 
 def monsterToHeaderEmbed(m: padguide2.PgMonster):
-    header = monsterToLongHeader(m, link=True)
-    embed = discord.Embed()
-    embed.description = header
-    return embed
-
+	header = monsterToLongHeader(m, link=True)
+	embed = discord.Embed()
+	embed.description = header
+	return embed
 
 def monsterToTypeString(m: padguide2.PgMonster):
-    output = m.type1
-    if m.type2:
-        output += '/' + m.type2
-    if m.type3:
-        output += '/' + m.type3
-    return output
-
+	output = m.type1
+	if m.type2:
+		output += '/' + m.type2
+	if m.type3:
+		output += '/' + m.type3
+	return output
 
 def monsterToAcquireString(m: padguide2.PgMonster):
-    acquire_text = None
-    if m.farmable and not m.mp_evo:
-        # Some MP shop monsters 'drop' in PADR
-        acquire_text = 'Farmable'
-    elif m.farmable_evo and not m.mp_evo:
-        acquire_text = 'Farmable Evo'
-    elif m.in_pem:
-        acquire_text = 'In PEM'
-    elif m.pem_evo:
-        acquire_text = 'PEM Evo'
-    elif m.in_rem:
-        acquire_text = 'In REM'
-    elif m.rem_evo:
-        acquire_text = 'REM Evo'
-    elif m.in_mpshop:
-        acquire_text = 'MP Shop'
-    elif m.mp_evo:
-        acquire_text = 'MP Shop Evo'
-    return acquire_text
-
+	acquire_text = None
+	if m.farmable and not m.mp_evo:
+		# Some MP shop monsters 'drop' in PADR
+		acquire_text = 'Farmable'
+	elif m.farmable_evo and not m.mp_evo:
+		acquire_text = 'Farmable Evo'
+	elif m.in_pem:
+		acquire_text = 'In PEM'
+	elif m.pem_evo:
+		acquire_text = 'PEM Evo'
+	elif m.in_rem:
+		acquire_text = 'In REM'
+	elif m.rem_evo:
+		acquire_text = 'REM Evo'
+	elif m.in_mpshop:
+		acquire_text = 'MP Shop'
+	elif m.mp_evo:
+		acquire_text = 'MP Shop Evo'
+	return acquire_text
 
 def match_emoji(emoji_list, name):
-    for e in emoji_list:
-        if e.name == name:
-            return e
-    return None
-
+	for e in emoji_list:
+		if e.name == name:
+			return e
+	return None
 
 def monsterToEmbed(m: padguide2.PgMonster, emoji_list):
-    embed = monsterToBaseEmbed(m)
-    
-    info_row_1 = monsterToTypeString(m)
-    acquire_text = monsterToAcquireString(m)
-    
-    info_row_2 = '**Rarity** {}\n**Cost** {}'.format(m.rarity, m.cost)
-    if acquire_text:
-        info_row_2 += '\n**{}**'.format(acquire_text)
-    if m.is_inheritable:
-        info_row_2 += '\n**Inheritable**'
-    else:
-        info_row_2 += '\n**Not inheritable**'
-    
-    embed.add_field(name=info_row_1, value=info_row_2)
-    
-    if m.limitbreak_stats and m.limitbreak_stats > 1:
-        def lb(x):
-            return int(round(m.limitbreak_stats * x))
-        
-        stats_row_1 = 'Weighted {} | LB {}'.format(m.weighted_stats, lb(m.weighted_stats))
-        stats_row_2 = '**HP** {} ({})\n**ATK** {} ({})\n**RCV** {} ({})'.format(
-            m.hp, lb(m.hp), m.atk, lb(m.atk), m.rcv, lb(m.rcv))
-    else:
-        stats_row_1 = 'Weighted {}'.format(m.weighted_stats)
-        stats_row_2 = '**HP** {}\n**ATK** {}\n**RCV** {}'.format(m.hp, m.atk, m.rcv)
-    embed.add_field(name=stats_row_1, value=stats_row_2)
-    
-    awakenings_row = ''
-    for idx, a in enumerate(m.awakenings):
-        a = a.get_name()
-        mapped_awakening = AWAKENING_NAME_MAP_RPAD.get(a, a)
-        mapped_awakening = match_emoji(emoji_list, mapped_awakening)
-        
-        if mapped_awakening is None:
-            mapped_awakening = AWAKENING_NAME_MAP.get(a, a)
-        
-        # Wrap superawakenings to the next line
-        if len(m.awakenings) - idx == m.superawakening_count:
-            awakenings_row += '\n{}'.format(mapped_awakening)
-        else:
-            awakenings_row += ' {}'.format(mapped_awakening)
-    
-    awakenings_row = awakenings_row.strip()
-    
-    if not len(awakenings_row):
-        awakenings_row = 'No Awakenings'
-    
-    killers = compute_killers(m.type1, m.type2, m.type3)
-    killers_row = '**Available Killers:** {}'.format(' '.join(killers))
-    
-    embed.description = '{}\n{}'.format(awakenings_row, killers_row)
-    
-    if len(m.server_actives) >= 2:
-        for server, active in m.server_actives.items():
-            active_header = '({} Server) Active Skill ({} -> {})'.format(server,
-                                                                         active.turn_max, active.turn_min)
-            active_body = active.desc
-            embed.add_field(name=active_header, value=active_body, inline=False)
-    else:
-        active_header = 'Active Skill'
-        active_body = 'None/Missing'
-        if m.active_skill:
-            active_header = 'Active Skill ({} -> {})'.format(m.active_skill.turn_max,
-                                                             m.active_skill.turn_min)
-            active_body = m.active_skill.desc
-        embed.add_field(name=active_header, value=active_body, inline=False)
-    
-    ls_row = m.leader_skill.desc if m.leader_skill else 'None/Missing'
-    ls_header = 'Leader Skill'
-    if m.leader_skill_data:
-        hp, atk, rcv, resist = m.leader_skill_data.get_data()
-        multiplier_text = createMultiplierText(hp, atk, rcv, resist)
-        ls_header += " [ {} ]".format(multiplier_text)
-    embed.add_field(name=ls_header, value=ls_row, inline=False)
-    
-    return embed
-
+	embed = monsterToBaseEmbed(m)
+	
+	info_row_1 = monsterToTypeString(m)
+	acquire_text = monsterToAcquireString(m)
+	
+	info_row_2 = '**Rarity** {}\n**Cost** {}'.format(m.rarity, m.cost)
+	if acquire_text:
+		info_row_2 += '\n**{}**'.format(acquire_text)
+	if m.is_inheritable:
+		info_row_2 += '\n**Inheritable**'
+	else:
+		info_row_2 += '\n**Not inheritable**'
+	
+	embed.add_field(name=info_row_1, value=info_row_2)
+	
+	if m.limitbreak_stats and m.limitbreak_stats > 1:
+		def lb(x):
+			return int(round(m.limitbreak_stats * x))
+		
+		stats_row_1 = 'Weighted {} | LB {}'.format(m.weighted_stats, lb(m.weighted_stats))
+		stats_row_2 = '**HP** {} ({})\n**ATK** {} ({})\n**RCV** {} ({})'.format(
+			m.hp, lb(m.hp), m.atk, lb(m.atk), m.rcv, lb(m.rcv))
+	else:
+		stats_row_1 = 'Weighted {}'.format(m.weighted_stats)
+		stats_row_2 = '**HP** {}\n**ATK** {}\n**RCV** {}'.format(m.hp, m.atk, m.rcv)
+	embed.add_field(name=stats_row_1, value=stats_row_2)
+	
+	awakenings_row = ''
+	for idx, a in enumerate(m.awakenings):
+		a = a.get_name()
+		mapped_awakening = AWAKENING_NAME_MAP_RPAD.get(a, a)
+		mapped_awakening = match_emoji(emoji_list, mapped_awakening)
+		
+		if mapped_awakening is None:
+			mapped_awakening = AWAKENING_NAME_MAP.get(a, a)
+		
+		# Wrap superawakenings to the next line
+		if len(m.awakenings) - idx == m.superawakening_count:
+			awakenings_row += '\n{}'.format(mapped_awakening)
+		else:
+			awakenings_row += ' {}'.format(mapped_awakening)
+	
+	awakenings_row = awakenings_row.strip()
+	
+	if not len(awakenings_row):
+		awakenings_row = 'No Awakenings'
+	
+	killers = compute_killers(m.type1, m.type2, m.type3)
+	killers_row = '**Available Killers:** {}'.format(' '.join(killers))
+	
+	embed.description = '{}\n{}'.format(awakenings_row, killers_row)
+	
+	if len(m.server_actives) >= 2:
+		for server, active in m.server_actives.items():
+			active_header = '({} Server) Active Skill ({} -> {})'.format(server,
+																		 active.turn_max, active.turn_min)
+			active_body = active.desc
+			embed.add_field(name=active_header, value=active_body, inline=False)
+	else:
+		active_header = 'Active Skill'
+		active_body = 'None/Missing'
+		if m.active_skill:
+			active_header = 'Active Skill ({} -> {})'.format(m.active_skill.turn_max,
+															 m.active_skill.turn_min)
+			active_body = m.active_skill.desc
+		embed.add_field(name=active_header, value=active_body, inline=False)
+	
+	ls_row = m.leader_skill.desc if m.leader_skill else 'None/Missing'
+	ls_header = 'Leader Skill'
+	if m.leader_skill_data:
+		hp, atk, rcv, resist = m.leader_skill_data.get_data()
+		multiplier_text = createMultiplierText(hp, atk, rcv, resist)
+		ls_header += " [ {} ]".format(multiplier_text)
+	embed.add_field(name=ls_header, value=ls_row, inline=False)
+	
+	return embed
 
 def monsterToOtherInfoEmbed(m: padguide2.PgMonster):
-    embed = monsterToBaseEmbed(m)
-    # Clear the thumbnail, takes up too much space
-    embed.set_thumbnail(url='')
-    
-    stat_cols = ['', 'Max', 'M297', 'Inh', 'I297']
-    tbl = prettytable.PrettyTable(stat_cols)
-    tbl.hrules = prettytable.NONE
-    tbl.vrules = prettytable.NONE
-    tbl.align = "r"
-    hhp = m.hp + 99 * 10
-    hatk = m.atk + 99 * 5
-    hrcv = m.rcv + 99 * 3
-    tbl.add_row(['HP', m.hp, hhp, int(m.hp * .1), int(hhp * .1)])
-    tbl.add_row(['ATK', m.atk, hatk, int(m.atk * .05), int(hatk * .05)])
-    tbl.add_row(['RCV', m.rcv, hrcv, int(m.rcv * .15), int(hrcv * .15)])
-    
-    body_text = box(tbl.get_string())
-    
-    search_text = YT_SEARCH_TEMPLATE.format(m.name_jp)
-    skyozora_text = SKYOZORA_TEMPLATE.format(m.monster_no_jp)
-    body_text += "\n**JP Name**: {} | [YouTube]({}) | [Skyozora]({})".format(
-        m.name_jp, search_text, skyozora_text)
-    
-    if m.history_us:
-        body_text += '\n**History:** {}'.format(m.history_us)
-    
-    body_text += '\n**Series:** {}'.format(m.series.name)
-    body_text += '\n**Sell MP:** {:,}'.format(m.sell_mp)
-    if m.buy_mp > 0:
-        body_text += "  **Buy MP:** {:,}".format(m.buy_mp)
-    
-    if m.exp < 1000000:
-        xp_text = '{:,}'.format(m.exp)
-    else:
-        xp_text = '{:.1f}'.format(m.exp / 1000000).rstrip('0').rstrip('.') + 'M'
-    body_text += '\n**XP to Max:** {}'.format(xp_text)
-    body_text += '  **Max Level:**: {}'.format(m.max_level)
-    body_text += '\n**Rarity:** {} **Cost:** {}'.format(m.rarity, m.cost)
-    
-    if m.translated_jp_name:
-        body_text += '\n**Google Translated:** {}'.format(m.translated_jp_name)
-    
-    embed.description = body_text
-    
-    return embed
-
+	embed = monsterToBaseEmbed(m)
+	# Clear the thumbnail, takes up too much space
+	embed.set_thumbnail(url='')
+	
+	stat_cols = ['', 'Max', 'M297', 'Inh', 'I297']
+	tbl = prettytable.PrettyTable(stat_cols)
+	tbl.hrules = prettytable.NONE
+	tbl.vrules = prettytable.NONE
+	tbl.align = "r"
+	hhp = m.hp + 99 * 10
+	hatk = m.atk + 99 * 5
+	hrcv = m.rcv + 99 * 3
+	tbl.add_row(['HP', m.hp, hhp, int(m.hp * .1), int(hhp * .1)])
+	tbl.add_row(['ATK', m.atk, hatk, int(m.atk * .05), int(hatk * .05)])
+	tbl.add_row(['RCV', m.rcv, hrcv, int(m.rcv * .15), int(hrcv * .15)])
+	
+	body_text = box(tbl.get_string())
+	
+	search_text = YT_SEARCH_TEMPLATE.format(m.name_jp)
+	skyozora_text = SKYOZORA_TEMPLATE.format(m.monster_no_jp)
+	body_text += "\n**JP Name**: {} | [YouTube]({}) | [Skyozora]({})".format(
+		m.name_jp, search_text, skyozora_text)
+	
+	if m.history_us:
+		body_text += '\n**History:** {}'.format(m.history_us)
+	
+	body_text += '\n**Series:** {}'.format(m.series.name)
+	body_text += '\n**Sell MP:** {:,}'.format(m.sell_mp)
+	if m.buy_mp > 0:
+		body_text += "  **Buy MP:** {:,}".format(m.buy_mp)
+	
+	if m.exp < 1000000:
+		xp_text = '{:,}'.format(m.exp)
+	else:
+		xp_text = '{:.1f}'.format(m.exp / 1000000).rstrip('0').rstrip('.') + 'M'
+	body_text += '\n**XP to Max:** {}'.format(xp_text)
+	body_text += '  **Max Level:**: {}'.format(m.max_level)
+	body_text += '\n**Rarity:** {} **Cost:** {}'.format(m.rarity, m.cost)
+	
+	if m.translated_jp_name:
+		body_text += '\n**Google Translated:** {}'.format(m.translated_jp_name)
+	
+	embed.description = body_text
+	
+	return embed
 
 def monsters_to_rotation_list(monster_list, server: str, index_all: padguide2.MonsterIndex):
-    # Shorten some of the longer names
-    name_remap = {
-        'Extreme King Metal Tamadra': 'Fat Tama',
-        'Extreme King Metal Dragon': 'EKMD',
-        'Ancient Green Sacred Mask': 'Green Mask',
-        'Ancient Blue Sacred Mask': 'Blue Mask',
-    }
-    ignore_monsters = [
-        'Ancient Draggie Knight',
-    ]
-    
-    monster_list.sort(key=lambda m: m.monster_no, reverse=True)
-    next_rotation_date = None
-    for m in monster_list:
-        if server in m.future_skillup_rotation:
-            next_rotation_date = m.future_skillup_rotation[server].rotation_date_str
-            break
-    
-    cols = [server + ' Skillup', 'Current']
-    if next_rotation_date:
-        cols.append(next_rotation_date)
-    tbl = prettytable.PrettyTable(cols)
-    tbl.hrules = prettytable.HEADER
-    tbl.vrules = prettytable.NONE
-    tbl.align = "l"
-    
-    def cell_name(m: padguide2.PgMonster):
-        nm = index_all.monster_no_to_named_monster[m.monster_no]
-        name = nm.group_computed_basename.title()
-        return name_remap.get(name, name)
-    
-    for m in monster_list:
-        skill = m.server_actives[server]
-        
-        sm = skill.monsters_with_active
-        
-        # Since some newer monsters like jewel of creation are being used as
-        # skillups, exclude them from the list of skillup targets.
-        
-        def is_bad_type(m):
-            return set(['enhance', 'evolve', 'vendor']).intersection(set(m.types))
-        
-        sm = max(sm, key=lambda x: (not is_bad_type(x), x.monster_no))
-        
-        skillup_name = cell_name(m)
-        if skillup_name in ignore_monsters:
-            continue
-        row = [skillup_name, cell_name(sm)]
-        if next_rotation_date:
-            if server in m.future_skillup_rotation:
-                next_skill = m.future_skillup_rotation[server].skill
-                nm = max(next_skill.monsters_with_active, key=lambda x: x.monster_no)
-                row.append(cell_name(nm))
-            else:
-                row.append('')
-        tbl.add_row(row)
-    
-    return tbl.get_string()
-
+	# Shorten some of the longer names
+	name_remap = {
+		'Extreme King Metal Tamadra': 'Fat Tama',
+		'Extreme King Metal Dragon': 'EKMD',
+		'Ancient Green Sacred Mask': 'Green Mask',
+		'Ancient Blue Sacred Mask': 'Blue Mask',
+	}
+	ignore_monsters = [
+		'Ancient Draggie Knight',
+	]
+	
+	monster_list.sort(key=lambda m: m.monster_no, reverse=True)
+	next_rotation_date = None
+	for m in monster_list:
+		if server in m.future_skillup_rotation:
+			next_rotation_date = m.future_skillup_rotation[server].rotation_date_str
+			break
+	
+	cols = [server + ' Skillup', 'Current']
+	if next_rotation_date:
+		cols.append(next_rotation_date)
+	tbl = prettytable.PrettyTable(cols)
+	tbl.hrules = prettytable.HEADER
+	tbl.vrules = prettytable.NONE
+	tbl.align = "l"
+	
+	def cell_name(m: padguide2.PgMonster):
+		nm = index_all.monster_no_to_named_monster[m.monster_no]
+		name = nm.group_computed_basename.title()
+		return name_remap.get(name, name)
+	
+	for m in monster_list:
+		skill = m.server_actives[server]
+		
+		sm = skill.monsters_with_active
+		
+		# Since some newer monsters like jewel of creation are being used as
+		# skillups, exclude them from the list of skillup targets.
+		
+		def is_bad_type(m):
+			return set(['enhance', 'evolve', 'vendor']).intersection(set(m.types))
+		
+		sm = max(sm, key=lambda x: (not is_bad_type(x), x.monster_no))
+		
+		skillup_name = cell_name(m)
+		if skillup_name in ignore_monsters:
+			continue
+		row = [skillup_name, cell_name(sm)]
+		if next_rotation_date:
+			if server in m.future_skillup_rotation:
+				next_skill = m.future_skillup_rotation[server].skill
+				nm = max(next_skill.monsters_with_active, key=lambda x: x.monster_no)
+				row.append(cell_name(nm))
+			else:
+				row.append('')
+		tbl.add_row(row)
+	
+	return tbl.get_string()
 
 AWAKENING_NAME_MAP_RPAD = {
-    'Enhanced Attack': 'boost_atk',
-    'Enhanced HP': 'boost_hp',
-    'Enhanced Heal': 'boost_rcv',
-    
-    'Enhanced Team HP': 'teamboost_hp',
-    'Enhanced Team Attack': 'teamboost_atk',
-    'Enhanced Team RCV': 'teamboost_rcv',
-    
-    'God Killer': 'killer_god',
-    'Dragon Killer': 'killer_dragon',
-    'Devil Killer': 'killer_devil',
-    'Machine Killer': 'killer_machine',
-    'Balanced Killer': 'killer_balance',
-    'Attacker Killer': 'killer_attacker',
-    
-    'Physical Killer': 'killer_physical',
-    'Healer Killer': 'killer_healer',
-    'Evolve Material Killer': 'killer_evomat',
-    'Awaken Material Killer': 'killer_awoken',
-    'Enhance Material Killer': 'killer_enhancemat',
-    'Vendor Material Killer': 'killer_vendor',
-    
-    'Auto-Recover': 'misc_autoheal',
-    'Recover Bind': 'misc_bindclear',
-    'Enhanced Combo': 'misc_comboboost',
-    'Super Enhanced Combo': 'misc_super_comboboost',
-    'Guard Break': 'misc_guardbreak',
-    'Multi Boost': 'misc_multiboost',
-    'Additional Attack': 'misc_extraattack',
-    'Skill Boost': 'misc_sb',
-    'Extend Time': 'misc_te',
-    'Two-Pronged Attack': 'misc_tpa',
-    'Damage Void Shield Penetration': 'misc_voidshield',
-    'Awoken Assist': 'misc_assist',
-    
-    'Enhanced Fire Orbs': 'oe_fire',
-    'Enhanced Water Orbs': 'oe_water',
-    'Enhanced Wood Orbs': 'oe_wood',
-    'Enhanced Light Orbs': 'oe_light',
-    'Enhanced Dark Orbs': 'oe_dark',
-    'Enhanced Heal Orbs': 'oe_heart',
-    
-    'Reduce Fire Damage': 'reduce_fire',
-    'Reduce Water Damage': 'reduce_water',
-    'Reduce Wood Damage': 'reduce_wood',
-    'Reduce Light Damage': 'reduce_light',
-    'Reduce Dark Damage': 'reduce_dark',
-    
-    'Resistance-Bind': 'res_bind',
-    'Resistance-Dark': 'res_blind',
-    'Resistance-Jammers': 'res_jammer',
-    'Resistance-Poison': 'res_poison',
-    'Resistance-Skill Bind': 'res_skillbind',
-    
-    'Enhanced Fire Att.': 'row_fire',
-    'Enhanced Water Att.': 'row_water',
-    'Enhanced Wood Att.': 'row_wood',
-    'Enhanced Light Att.': 'row_light',
-    'Enhanced Dark Att.': 'row_dark',
-    
-    'Skill Charge': 'misc_skillcharge',
-    'Super Additional Attack': 'misc_super_extraattack',
-    'Resistance-Bind＋': 'res_bind_super',
-    'Extend Time＋': 'misc_te_super',
-    'Resistance-Cloud': 'res_cloud',
-    'Resistance-Board Restrict': 'res_seal',
-    'Skill Boost＋': 'misc_sb_super',
-    'L-Shape Attack': 'l_attack',
-    'L-Shape Damage Reduction': 'l_shield',
-    'Enhance when HP is below 50%': 'attack_boost_low',
-    'Enhance when HP is above 80%': 'attack_boost_high',
-    'Combo Orb': 'orb_combo',
-    'Skill Voice': 'misc_voice',
-    'Dungeon Bonus': 'misc_dungeonbonus',
+	'Enhanced Attack': 'boost_atk',
+	'Enhanced HP': 'boost_hp',
+	'Enhanced Heal': 'boost_rcv',
+	
+	'Enhanced Team HP': 'teamboost_hp',
+	'Enhanced Team Attack': 'teamboost_atk',
+	'Enhanced Team RCV': 'teamboost_rcv',
+	
+	'God Killer': 'killer_god',
+	'Dragon Killer': 'killer_dragon',
+	'Devil Killer': 'killer_devil',
+	'Machine Killer': 'killer_machine',
+	'Balanced Killer': 'killer_balance',
+	'Attacker Killer': 'killer_attacker',
+	
+	'Physical Killer': 'killer_physical',
+	'Healer Killer': 'killer_healer',
+	'Evolve Material Killer': 'killer_evomat',
+	'Awaken Material Killer': 'killer_awoken',
+	'Enhance Material Killer': 'killer_enhancemat',
+	'Vendor Material Killer': 'killer_vendor',
+	
+	'Auto-Recover': 'misc_autoheal',
+	'Recover Bind': 'misc_bindclear',
+	'Enhanced Combo': 'misc_comboboost',
+	'Super Enhanced Combo': 'misc_super_comboboost',
+	'Guard Break': 'misc_guardbreak',
+	'Multi Boost': 'misc_multiboost',
+	'Additional Attack': 'misc_extraattack',
+	'Skill Boost': 'misc_sb',
+	'Extend Time': 'misc_te',
+	'Two-Pronged Attack': 'misc_tpa',
+	'Damage Void Shield Penetration': 'misc_voidshield',
+	'Awoken Assist': 'misc_assist',
+	
+	'Enhanced Fire Orbs': 'oe_fire',
+	'Enhanced Water Orbs': 'oe_water',
+	'Enhanced Wood Orbs': 'oe_wood',
+	'Enhanced Light Orbs': 'oe_light',
+	'Enhanced Dark Orbs': 'oe_dark',
+	'Enhanced Heal Orbs': 'oe_heart',
+	
+	'Reduce Fire Damage': 'reduce_fire',
+	'Reduce Water Damage': 'reduce_water',
+	'Reduce Wood Damage': 'reduce_wood',
+	'Reduce Light Damage': 'reduce_light',
+	'Reduce Dark Damage': 'reduce_dark',
+	
+	'Resistance-Bind': 'res_bind',
+	'Resistance-Dark': 'res_blind',
+	'Resistance-Jammers': 'res_jammer',
+	'Resistance-Poison': 'res_poison',
+	'Resistance-Skill Bind': 'res_skillbind',
+	
+	'Enhanced Fire Att.': 'row_fire',
+	'Enhanced Water Att.': 'row_water',
+	'Enhanced Wood Att.': 'row_wood',
+	'Enhanced Light Att.': 'row_light',
+	'Enhanced Dark Att.': 'row_dark',
+	
+	'Skill Charge': 'misc_skillcharge',
+	'Super Additional Attack': 'misc_super_extraattack',
+	'Resistance-Bind＋': 'res_bind_super',
+	'Extend Time＋': 'misc_te_super',
+	'Resistance-Cloud': 'res_cloud',
+	'Resistance-Board Restrict': 'res_seal',
+	'Skill Boost＋': 'misc_sb_super',
+	'L-Shape Attack': 'l_attack',
+	'L-Shape Damage Reduction': 'l_shield',
+	'Enhance when HP is below 50%': 'attack_boost_low',
+	'Enhance when HP is above 80%': 'attack_boost_high',
+	'Combo Orb': 'orb_combo',
+	'Skill Voice': 'misc_voice',
+	'Dungeon Bonus': 'misc_dungeonbonus',
 }
 
 AWAKENING_NAME_MAP = {
-    'Enhanced Fire Orbs': 'R-OE',
-    'Enhanced Water Orbs': 'B-OE',
-    'Enhanced Wood Orbs': 'G-OE',
-    'Enhanced Light Orbs': 'L-OE',
-    'Enhanced Dark Orbs': 'D-OE',
-    'Enhanced Heal Orbs': 'H-OE',
-    
-    'Enhanced Fire Att.': 'R-RE',
-    'Enhanced Water Att.': 'B-RE',
-    'Enhanced Wood Att.': 'G-RE',
-    'Enhanced Light Att.': 'L-RE',
-    'Enhanced Dark Att.': 'D-RE',
-    
-    'Enhanced HP': 'HP',
-    'Enhanced Attack': 'ATK',
-    'Enhanced Heal': 'RCV',
-    
-    'Enhanced Team HP': 'TEAM-HP',
-    'Enhanced Team Attack': 'TEAM-ATK',
-    'Enhanced Team RCV': 'TEAM-RCV',
-    
-    'Auto-Recover': 'AUTO-RECOVER',
-    'Skill Boost': 'SB',
-    'Resistance-Skill Bind': 'SBR',
-    'Two-Pronged Attack': 'TPA',
-    'Multi Boost': 'MULTI-BOOST',
-    'Recover Bind': 'RCV-BIND',
-    'Extend Time': 'TE',
-    'Enhanced Combo': 'COMBO-BOOST',
-    'Guard Break': 'DEF-BREAK',
-    'Additional Attack': 'EXTRA-ATK',
-    'Damage Void Shield Penetration': 'VOID-BREAK',
-    'Awoken Assist': 'ASSIST',
-    
-    'Resistance-Bind': 'RES-BIND',
-    'Resistance-Dark': 'RES-BLIND',
-    'Resistance-Poison': 'RES-POISON',
-    'Resistance-Jammers': 'RES-JAMMER',
-    
-    'Reduce Fire Damage': 'R-RES',
-    'Reduce Water Damage': 'B-RES',
-    'Reduce Wood Damage': 'G-RES',
-    'Reduce Light Damage': 'L-RES',
-    'Reduce Dark Damage': 'D-RES',
-    
-    'Healer Killer': 'K-HEALER',
-    'Machine Killer': 'K-MACHINE',
-    'Dragon Killer': 'K-DRAGON',
-    'Attacker Killer': 'K-ATTACKER',
-    'Physical Killer': 'K-PHYSICAL',
-    'God Killer': 'K-GOD',
-    'Devil Killer': 'K-DEVIL',
-    'Balance Killer': 'K-BALANCE',
+	'Enhanced Fire Orbs': 'R-OE',
+	'Enhanced Water Orbs': 'B-OE',
+	'Enhanced Wood Orbs': 'G-OE',
+	'Enhanced Light Orbs': 'L-OE',
+	'Enhanced Dark Orbs': 'D-OE',
+	'Enhanced Heal Orbs': 'H-OE',
+	
+	'Enhanced Fire Att.': 'R-RE',
+	'Enhanced Water Att.': 'B-RE',
+	'Enhanced Wood Att.': 'G-RE',
+	'Enhanced Light Att.': 'L-RE',
+	'Enhanced Dark Att.': 'D-RE',
+	
+	'Enhanced HP': 'HP',
+	'Enhanced Attack': 'ATK',
+	'Enhanced Heal': 'RCV',
+	
+	'Enhanced Team HP': 'TEAM-HP',
+	'Enhanced Team Attack': 'TEAM-ATK',
+	'Enhanced Team RCV': 'TEAM-RCV',
+	
+	'Auto-Recover': 'AUTO-RECOVER',
+	'Skill Boost': 'SB',
+	'Resistance-Skill Bind': 'SBR',
+	'Two-Pronged Attack': 'TPA',
+	'Multi Boost': 'MULTI-BOOST',
+	'Recover Bind': 'RCV-BIND',
+	'Extend Time': 'TE',
+	'Enhanced Combo': 'COMBO-BOOST',
+	'Guard Break': 'DEF-BREAK',
+	'Additional Attack': 'EXTRA-ATK',
+	'Damage Void Shield Penetration': 'VOID-BREAK',
+	'Awoken Assist': 'ASSIST',
+	
+	'Resistance-Bind': 'RES-BIND',
+	'Resistance-Dark': 'RES-BLIND',
+	'Resistance-Poison': 'RES-POISON',
+	'Resistance-Jammers': 'RES-JAMMER',
+	
+	'Reduce Fire Damage': 'R-RES',
+	'Reduce Water Damage': 'B-RES',
+	'Reduce Wood Damage': 'G-RES',
+	'Reduce Light Damage': 'L-RES',
+	'Reduce Dark Damage': 'D-RES',
+	
+	'Healer Killer': 'K-HEALER',
+	'Machine Killer': 'K-MACHINE',
+	'Dragon Killer': 'K-DRAGON',
+	'Attacker Killer': 'K-ATTACKER',
+	'Physical Killer': 'K-PHYSICAL',
+	'God Killer': 'K-GOD',
+	'Devil Killer': 'K-DEVIL',
+	'Balance Killer': 'K-BALANCE',
 }
 
-
 def createMultiplierText(hp1, atk1, rcv1, resist1, hp2=None, atk2=None, rcv2=None, resist2=None):
-    hp2, atk2, rcv2, resist2 = hp2 or hp1, atk2 or atk1, rcv2 or rcv1, resist2 or resist1
-    
-    def fmtNum(val):
-        return ('{:.2f}').format(val).strip('0').rstrip('.')
-    
-    text = "{}/{}/{}".format(fmtNum(hp1 * hp2), fmtNum(atk1 * atk2), fmtNum(rcv1 * rcv2))
-    if resist1 * resist2 < 1:
-        resist1 = resist1 if resist1 < 1 else 0
-        resist2 = resist2 if resist2 < 1 else 0
-        text += ' Resist {}%'.format(fmtNum(100 * (1 - (1 - resist1) * (1 - resist2))))
-    return text
-
+	hp2, atk2, rcv2, resist2 = hp2 or hp1, atk2 or atk1, rcv2 or rcv1, resist2 or resist1
+	
+	def fmtNum(val):
+		return ('{:.2f}').format(val).strip('0').rstrip('.')
+	
+	text = "{}/{}/{}".format(fmtNum(hp1 * hp2), fmtNum(atk1 * atk2), fmtNum(rcv1 * rcv2))
+	if resist1 * resist2 < 1:
+		resist1 = resist1 if resist1 < 1 else 0
+		resist2 = resist2 if resist2 < 1 else 0
+		text += ' Resist {}%'.format(fmtNum(100 * (1 - (1 - resist1) * (1 - resist2))))
+	return text
 
 def _map_awakenings_text(m: padguide2.PgMonster):
-    awakenings_row = ''
-    unique_awakenings = set(m.awakening_names)
-    for a in unique_awakenings:
-        count = m.awakening_names.count(a)
-        awakenings_row += ' {}x{}'.format(AWAKENING_NAME_MAP.get(a, a), count)
-    awakenings_row = awakenings_row.strip()
-    
-    if not len(awakenings_row):
-        awakenings_row = 'No Awakenings'
-    
-    return awakenings_row
-
+	awakenings_row = ''
+	unique_awakenings = set(m.awakening_names)
+	for a in unique_awakenings:
+		count = m.awakening_names.count(a)
+		awakenings_row += ' {}x{}'.format(AWAKENING_NAME_MAP.get(a, a), count)
+	awakenings_row = awakenings_row.strip()
+	
+	if not len(awakenings_row):
+		awakenings_row = 'No Awakenings'
+	
+	return awakenings_row
 
 # TODO: move to padguide2
 def compute_killers(*types):
-    if 'Balance' in types:
-        return ['Any']
-    killers = set()
-    for t in types:
-        killers.update(type_to_killers_map.get(t, []))
-    return sorted(killers)
-
+	if 'Balance' in types:
+		return ['Any']
+	killers = set()
+	for t in types:
+		killers.update(type_to_killers_map.get(t, []))
+	return sorted(killers)
 
 type_to_killers_map = {
-    'God': ['Devil'],
-    'Devil': ['God'],
-    'Machine': ['God', 'Balance'],
-    'Dragon': ['Machine', 'Healer'],
-    'Physical': ['Machine', 'Healer'],
-    'Attacker': ['Devil', 'Physical'],
-    'Healer': ['Dragon', 'Attacker'],
+	'God': ['Devil'],
+	'Devil': ['God'],
+	'Machine': ['God', 'Balance'],
+	'Dragon': ['Machine', 'Healer'],
+	'Physical': ['Machine', 'Healer'],
+	'Attacker': ['Devil', 'Physical'],
+	'Healer': ['Dragon', 'Attacker'],
 }

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -23,6 +23,7 @@ from .utils import checks
 from .utils.chat_formatting import *
 from .utils.dataIO import dataIO
 
+
 HELP_MSG = """
 ^helpid : shows this message
 ^id <query> : look up a monster and print a link to puzzledragonx
@@ -45,6 +46,7 @@ submit an override suggestion: https://docs.google.com/forms/d/1kJH9Q0S8iqqULwrR
 
 EMBED_NOT_GENERATED = -1
 
+
 INFO_PDX_TEMPLATE = 'http://www.puzzledragonx.com/en/monster.asp?n={}'
 RPAD_PIC_TEMPLATE = 'https://f002.backblazeb2.com/file/miru-data/padimages/{}/full/{}.png'
 RPAD_PORTRAIT_TEMPLATE = 'https://f002.backblazeb2.com/file/miru-data/padimages/{}/portrait/{}.png'
@@ -56,1093 +58,1087 @@ SKYOZORA_TEMPLATE = 'http://pad.skyozora.com/pets/{}'
 
 
 def get_pdx_url(m):
-	return INFO_PDX_TEMPLATE.format(rpadutils.get_pdx_id(m))
+    return INFO_PDX_TEMPLATE.format(rpadutils.get_pdx_id(m))
 
 
 def get_portrait_url(m):
-	if int(m.monster_no) != m.monster_no_na:
-		return RPAD_PORTRAIT_TEMPLATE.format('na', m.monster_no_na)
-	else:
-		return RPAD_PORTRAIT_TEMPLATE.format('jp', m.monster_no_jp)
+    if int(m.monster_no) != m.monster_no_na:
+        return RPAD_PORTRAIT_TEMPLATE.format('na', m.monster_no_na)
+    else:
+        return RPAD_PORTRAIT_TEMPLATE.format('jp', m.monster_no_jp)
 
 
 def get_pic_url(m):
-	if int(m.monster_no) != m.monster_no_na:
-		return RPAD_PIC_TEMPLATE.format('na', m.monster_no_na)
-	else:
-		return RPAD_PIC_TEMPLATE.format('jp', m.monster_no_jp)
+    if int(m.monster_no) != m.monster_no_na:
+        return RPAD_PIC_TEMPLATE.format('na', m.monster_no_na)
+    else:
+        return RPAD_PIC_TEMPLATE.format('jp', m.monster_no_jp)
 
 
 class PadInfo:
-	def __init__(self, bot):
-		self.bot = bot
-		
-		self.settings = PadInfoSettings("padinfo")
-		
-		self.index_all = padguide2.empty_index()
-		self.index_na = padguide2.empty_index()
-		
-		self.menu = Menu(bot)
-		
-		# These emojis are the keys into the idmenu submenus
-		self.id_emoji = '\N{INFORMATION SOURCE}'
-		self.evo_emoji = char_to_emoji('e')
-		self.mats_emoji = char_to_emoji('m')
-		self.ls_emoji = '\N{INFORMATION SOURCE}'
-		self.left_emoji = char_to_emoji('l')
-		self.right_emoji = char_to_emoji('r')
-		self.pantheon_emoji = '\N{CLASSICAL BUILDING}'
-		self.skillups_emoji = '\N{MEAT ON BONE}'
-		self.pic_emoji = '\N{FRAME WITH PICTURE}'
-		self.other_info_emoji = '\N{SCROLL}'
-		
-		self.historic_lookups_file_path = "data/padinfo/historic_lookups.json"
-		self.historic_lookups_file_path_id2 = "data/padinfo/historic_lookups_id2.json"
-		if not dataIO.is_valid_json(self.historic_lookups_file_path):
-			print("Creating empty historic_lookups.json...")
-			dataIO.save_json(self.historic_lookups_file_path, {})
-		
-		if not dataIO.is_valid_json(self.historic_lookups_file_path_id2):
-			print("Creating empty historic_lookups_id2.json...")
-			dataIO.save_json(self.historic_lookups_file_path_id2, {})
-		
-		self.historic_lookups = dataIO.load_json(self.historic_lookups_file_path)
-		self.historic_lookups_id2 = dataIO.load_json(self.historic_lookups_file_path_id2)
-	
-	def __unload(self):
-		# Manually nulling out database because the GC for cogs seems to be pretty shitty
-		self.index_all = padguide2.empty_index()
-		self.index_na = padguide2.empty_index()
-		self.historic_lookups = {}
-		self.historic_lookups_id2 = {}
-	
-	async def reload_nicknames(self):
-		await self.bot.wait_until_ready()
-		while self == self.bot.get_cog('PadInfo'):
-			try:
-				await self.refresh_index()
-				print('Done refreshing PadInfo')
-			except Exception as ex:
-				print("reload padinfo loop caught exception " + str(ex))
-				traceback.print_exc()
-			
-			await asyncio.sleep(60 * 60 * 1)
-	
-	async def refresh_index(self):
-		"""Refresh the monster indexes."""
-		pg_cog = self.bot.get_cog('PadGuide2')
-		await pg_cog.wait_until_ready()
-		self.index_all = pg_cog.create_index()
-		self.index_na = pg_cog.create_index(lambda m: m.on_na)
-	
-	def get_monster_by_no(self, monster_no: int):
-		pg_cog = self.bot.get_cog('PadGuide2')
-		return pg_cog.get_monster_by_no(monster_no)
-	
-	@commands.command(pass_context=True)
-	async def skillrotation(self, ctx, server: str = 'NA'):
-		"""Print the current rotating skillups for a server (NA/JP)"""
-		server = normalizeServer(server)
-		if server not in ['NA', 'JP']:
-			await self.bot.say(inline('Supported servers are NA, JP'))
-			return
-		
-		pg_cog = self.bot.get_cog('PadGuide2')
-		monsters = pg_cog.database.rotating_skillups(server)
-		
-		for page in pagify(monsters_to_rotation_list(monsters, server, self.index_all)):
-			await self.bot.say(box(page))
-	
-	@commands.command(pass_context=True)
-	async def jpname(self, ctx, *, query: str):
-		"""Print the Japanese name of a monster"""
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			await self.bot.say(monsterToHeader(m))
-			await self.bot.say(box(m.name_jp))
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(name="id", pass_context=True)
-	async def _do_id_all(self, ctx, *, query: str):
-		"""Monster info (main tab)"""
-		await self._do_id(ctx, query)
-	
-	@commands.command(name="idna", pass_context=True)
-	async def _do_id_na(self, ctx, *, query: str):
-		"""Monster info (limited to NA monsters ONLY)"""
-		await self._do_id(ctx, query, na_only=True)
-	
-	async def _do_id(self, ctx, query: str, na_only=False):
-		m, err, debug_info = self.findMonster(query, na_only=na_only)
-		if m is not None:
-			await self._do_idmenu(ctx, m, self.id_emoji)
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(name="id2", pass_context=True)
-	async def _do_id2_all(self, ctx, *, query: str):
-		"""Monster info (main tab)"""
-		await self._do_id2(ctx, query)
-	
-	@commands.command(name="id2na", pass_context=True)
-	async def _do_id2_na(self, ctx, *, query: str):
-		"""Monster info (limited to NA monsters ONLY)"""
-		await self._do_id2(ctx, query, na_only=True)
-	
-	async def _do_id2(self, ctx, query: str, na_only=False):
-		m, err, debug_info = self.findMonster2(query, na_only=na_only)
-		if m is not None:
-			await self._do_idmenu(ctx, m, self.id_emoji)
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(name="evos", pass_context=True)
-	async def evos(self, ctx, *, query: str):
-		"""Monster info (evolutions tab)"""
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			await self._do_idmenu(ctx, m, self.evo_emoji)
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(name="mats", pass_context=True, aliases=['evomats', 'evomat'])
-	async def evomats(self, ctx, *, query: str):
-		"""Monster info (evo materials tab)"""
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			await self._do_idmenu(ctx, m, self.mats_emoji)
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(pass_context=True)
-	async def pantheon(self, ctx, *, query: str):
-		"""Monster info (pantheon tab)"""
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			menu = await self._do_idmenu(ctx, m, self.pantheon_emoji)
-			if menu == EMBED_NOT_GENERATED:
-				await self.bot.say(inline('Not a pantheon monster'))
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(pass_context=True)
-	async def skillups(self, ctx, *, query: str):
-		"""Monster info (evolutions tab)"""
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			menu = await self._do_idmenu(ctx, m, self.skillups_emoji)
-			if menu == EMBED_NOT_GENERATED:
-				await self.bot.say(inline('No skillups available'))
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	async def _do_idmenu(self, ctx, m, starting_menu_emoji):
-		id_embed = monsterToEmbed(m, self.get_emojis())
-		evo_embed = monsterToEvoEmbed(m)
-		mats_embed = monsterToEvoMatsEmbed(m)
-		animated = self.check_monster_animated(m.monster_no_jp)
-		pic_embed = monsterToPicEmbed(m, animated=animated)
-		other_info_embed = monsterToOtherInfoEmbed(m)
-		
-		emoji_to_embed = OrderedDict()
-		emoji_to_embed[self.id_emoji] = id_embed
-		emoji_to_embed[self.evo_emoji] = evo_embed
-		emoji_to_embed[self.mats_emoji] = mats_embed
-		emoji_to_embed[self.pic_emoji] = pic_embed
-		
-		pantheon_embed = monsterToPantheonEmbed(m)
-		if pantheon_embed:
-			emoji_to_embed[self.pantheon_emoji] = pantheon_embed
-		
-		skillups_embed = monsterToSkillupsEmbed(m)
-		if skillups_embed:
-			emoji_to_embed[self.skillups_emoji] = skillups_embed
-		
-		emoji_to_embed[self.other_info_emoji] = other_info_embed
-		
-		return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed)
-	
-	async def _do_evolistmenu(self, ctx, sm):
-		monsters = sm.alt_evos
-		monsters.sort(key=lambda m: m.monster_no)
-		
-		emoji_to_embed = OrderedDict()
-		for idx, m in enumerate(monsters):
-			emoji = char_to_emoji(str(idx))
-			emoji_to_embed[emoji] = monsterToEmbed(m, self.get_emojis())
-			if m == sm:
-				starting_menu_emoji = emoji
-		
-		return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed, timeout=60)
-	
-	async def _do_menu(self, ctx, starting_menu_emoji, emoji_to_embed, timeout=30):
-		if starting_menu_emoji not in emoji_to_embed:
-			# Selected menu wasn't generated for this monster
-			return EMBED_NOT_GENERATED
-		
-		remove_emoji = self.menu.emoji['no']
-		emoji_to_embed[remove_emoji] = self.menu.reaction_delete_message
-		
-		try:
-			result_msg, result_embed = await self.menu.custom_menu(ctx, emoji_to_embed, starting_menu_emoji,
-																   timeout=timeout)
-			if result_msg and result_embed:
-				# Message is finished but not deleted, clear the footer
-				result_embed.set_footer(text=discord.Embed.Empty)
-				await self.bot.edit_message(result_msg, embed=result_embed)
-		except Exception as ex:
-			print('Menu failure', ex)
-	
-	@commands.command(pass_context=True, aliases=['img'])
-	async def pic(self, ctx, *, query: str):
-		"""Monster info (full image tab)"""
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			await self._do_idmenu(ctx, m, self.pic_emoji)
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(pass_context=True, aliases=['stats'])
-	async def otherinfo(self, ctx, *, query: str):
-		"""Monster info (misc info tab)"""
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			await self._do_idmenu(ctx, m, self.other_info_emoji)
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(pass_context=True)
-	async def lookup(self, ctx, *, query: str):
-		"""Short info results for a monster query"""
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			embed = monsterToHeaderEmbed(m)
-			await self.bot.say(embed=embed)
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(pass_context=True)
-	async def evolist(self, ctx, *, query):
-		"""Monster info (for all monsters in the evo tree)"""
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			await self._do_evolistmenu(ctx, m)
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(pass_context=True, aliases=['leaders', 'leaderskills', 'ls'])
-	async def leaderskill(self, ctx, left_query: str, right_query: str = None, *, bad=None):
-		"""Display the multiplier and leaderskills for two monsters
+    def __init__(self, bot):
+        self.bot = bot
 
-		If either your left or right query contains spaces, wrap in quotes.
-		e.g.: ^leaderskill "r sonia" "b sonia"
-		"""
-		if bad:
-			await self.bot.say(inline('Too many inputs. Try wrapping your queries in quotes.'))
-			return
-		
-		# Handle a very specific failure case, user typing something like "uuvo ragdra"
-		if ' ' not in left_query and right_query is not None and ' ' not in right_query and bad is None:
-			combined_query = left_query + ' ' + right_query
-			nm, err, debug_info = self._findMonster(combined_query)
-			if nm and left_query in nm.prefixes:
-				left_query = combined_query
-				right_query = None
-		
-		left_m, left_err, _ = self.findMonster(left_query)
-		if right_query:
-			right_m, right_err, _ = self.findMonster(right_query)
-		else:
-			right_m, right_err, = left_m, left_err
-		
-		err_msg = '{} query failed to match a monster: [ {} ]. If your query is multiple words, wrap it in quotes.'
-		if left_err:
-			await self.bot.say(inline(err_msg.format('Left', left_query)))
-			return
-		if right_err:
-			await self.bot.say(inline(err_msg.format('Right', right_query)))
-			return
-		
-		emoji_to_embed = OrderedDict()
-		emoji_to_embed[self.ls_emoji] = monstersToLsEmbed(left_m, right_m)
-		emoji_to_embed[self.left_emoji] = monsterToEmbed(left_m, self.get_emojis())
-		emoji_to_embed[self.right_emoji] = monsterToEmbed(right_m, self.get_emojis())
-		
-		await self._do_menu(ctx, self.ls_emoji, emoji_to_embed)
-	
-	@commands.command(name="helpid", pass_context=True, aliases=['helppic', 'helpimg'])
-	async def _helpid(self, ctx):
-		"""Whispers you info on how to craft monster queries for ^id"""
-		await self.bot.whisper(box(HELP_MSG))
-	
-	@commands.command(pass_context=True)
-	async def padsay(self, ctx, server, *, query: str = None):
-		"""Speak the voice line of a monster into your current chat"""
-		voice = ctx.message.author.voice
-		channel = voice.voice_channel
-		if channel is None:
-			await self.bot.say(inline('You must be in a voice channel to use this command'))
-			return
-		
-		speech_cog = self.bot.get_cog('Speech')
-		if not speech_cog:
-			await self.bot.say(inline('Speech seems to be offline'))
-			return
-		
-		if server.lower() not in ['na', 'jp']:
-			query = server + ' ' + (query or '')
-			server = 'na'
-		query = query.strip().lower()
-		
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			base_dir = '/home/tactical0retreat/pad_data/voices/fixed'
-			voice_file = os.path.join(base_dir, server, '{}.wav'.format(m.monster_no_na))
-			header = '{} ({})'.format(monsterToHeader(m), server)
-			if not os.path.exists(voice_file):
-				await self.bot.say(inline('Could not find voice for ' + header))
-				return
-			await self.bot.say('Speaking for ' + header)
-			await speech_cog.play_path(channel, voice_file)
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.group(pass_context=True)
-	@checks.is_owner()
-	async def padinfo(self, ctx):
-		"""PAD info management"""
-		if ctx.invoked_subcommand is None:
-			await send_cmd_help(ctx)
-	
-	@padinfo.command(pass_context=True)
-	@checks.is_owner()
-	async def setemojiservers(self, ctx, *, emoji_servers=''):
-		"""Set the emoji servers by ID (csv)"""
-		self.settings.emojiServers().clear()
-		if emoji_servers:
-			self.settings.setEmojiServers(emoji_servers.split(','))
-		await self.bot.say(inline('Set {} servers'.format(len(self.settings.emojiServers()))))
-	
-	def get_emojis(self):
-		server_ids = self.settings.emojiServers()
-		return [e for s in self.bot.servers if s.id in server_ids for e in s.emojis]
-	
-	def makeFailureMsg(self, err):
-		msg = 'Lookup failed: {}.\n'.format(err)
-		msg += 'Try one of <id>, <name>, [argbld]/[rgbld] <name>. Unexpected results? Use ^helpid for more info.'
-		return box(msg)
-	
-	def findMonster(self, query, na_only=False):
-		query = rmdiacritics(query)
-		nm, err, debug_info = self._findMonster(query, na_only)
-		
-		monster_no = nm.monster_no if nm else -1
-		self.historic_lookups[query] = monster_no
-		dataIO.save_json(self.historic_lookups_file_path, self.historic_lookups)
-		
-		m = self.get_monster_by_no(nm.monster_no) if nm else None
-		
-		return m, err, debug_info
-	
-	def _findMonster(self, query, na_only=False):
-		monster_index = self.index_na if na_only else self.index_all
-		return monster_index.find_monster(query)
-	
-	def findMonster2(self, query, na_only=False):
-		query = rmdiacritics(query)
-		nm, err, debug_info = self._findMonster2(query, na_only)
-		
-		monster_no = nm.monster_no if nm else -1
-		self.historic_lookups_id2[query] = monster_no
-		dataIO.save_json(self.historic_lookups_file_path_id2, self.historic_lookups_id2)
-		
-		m = self.get_monster_by_no(nm.monster_no) if nm else None
-		
-		return m, err, debug_info
-	
-	def _findMonster2(self, query, na_only=False):
-		monster_index = self.index_na if na_only else self.index_all
-		return monster_index.find_monster2(query)
-	
-	def map_awakenings_text(self, m):
-		"""Exported for use in other cogs"""
-		return _map_awakenings_text(m)
-	
-	@padinfo.command(pass_context=True)
-	@checks.is_owner()
-	async def setanimationdir(self, ctx, *, animation_dir=''):
-		"""Set a directory containing animated images"""
-		self.settings.setAnimationDir(animation_dir)
-		await self.bot.say(inline('Done'))
-	
-	def check_monster_animated(self, monster_id: int):
-		if not self.settings.animationDir():
-			return False
-		
-		try:
-			animated_ids = set()
-			for f in os.listdir(self.settings.animationDir()):
-				f = f.replace('.mp4', '')
-				if f.isdigit() and int(f) == monster_id:
-					return True
-		except:
-			pass
-		
-		return False
+        self.settings = PadInfoSettings("padinfo")
+
+        self.index_all = padguide2.empty_index()
+        self.index_na = padguide2.empty_index()
+
+        self.menu = Menu(bot)
+
+        # These emojis are the keys into the idmenu submenus
+        self.id_emoji = '\N{INFORMATION SOURCE}'
+        self.evo_emoji = char_to_emoji('e')
+        self.mats_emoji = char_to_emoji('m')
+        self.ls_emoji = '\N{INFORMATION SOURCE}'
+        self.left_emoji = char_to_emoji('l')
+        self.right_emoji = char_to_emoji('r')
+        self.pantheon_emoji = '\N{CLASSICAL BUILDING}'
+        self.skillups_emoji = '\N{MEAT ON BONE}'
+        self.pic_emoji = '\N{FRAME WITH PICTURE}'
+        self.other_info_emoji = '\N{SCROLL}'
+
+        self.historic_lookups_file_path = "data/padinfo/historic_lookups.json"
+        self.historic_lookups_file_path_id2 = "data/padinfo/historic_lookups_id2.json"
+        if not dataIO.is_valid_json(self.historic_lookups_file_path):
+            print("Creating empty historic_lookups.json...")
+            dataIO.save_json(self.historic_lookups_file_path, {})
+
+        if not dataIO.is_valid_json(self.historic_lookups_file_path_id2):
+            print("Creating empty historic_lookups_id2.json...")
+            dataIO.save_json(self.historic_lookups_file_path_id2, {})
+        
+        self.historic_lookups = dataIO.load_json(self.historic_lookups_file_path)
+        self.historic_lookups_id2 = dataIO.load_json(self.historic_lookups_file_path_id2)
+
+    def __unload(self):
+        # Manually nulling out database because the GC for cogs seems to be pretty shitty
+        self.index_all = padguide2.empty_index()
+        self.index_na = padguide2.empty_index()
+        self.historic_lookups = {}
+        self.historic_lookups_id2 = {}
+
+    async def reload_nicknames(self):
+        await self.bot.wait_until_ready()
+        while self == self.bot.get_cog('PadInfo'):
+            try:
+                await self.refresh_index()
+                print('Done refreshing PadInfo')
+            except Exception as ex:
+                print("reload padinfo loop caught exception " + str(ex))
+                traceback.print_exc()
+
+            await asyncio.sleep(60 * 60 * 1)
+
+    async def refresh_index(self):
+        """Refresh the monster indexes."""
+        pg_cog = self.bot.get_cog('PadGuide2')
+        await pg_cog.wait_until_ready()
+        self.index_all = pg_cog.create_index()
+        self.index_na = pg_cog.create_index(lambda m: m.on_na)
+
+    def get_monster_by_no(self, monster_no: int):
+        pg_cog = self.bot.get_cog('PadGuide2')
+        return pg_cog.get_monster_by_no(monster_no)
+
+    @commands.command(pass_context=True)
+    async def skillrotation(self, ctx, server: str='NA'):
+        """Print the current rotating skillups for a server (NA/JP)"""
+        server = normalizeServer(server)
+        if server not in ['NA', 'JP']:
+            await self.bot.say(inline('Supported servers are NA, JP'))
+            return
+
+        pg_cog = self.bot.get_cog('PadGuide2')
+        monsters = pg_cog.database.rotating_skillups(server)
+
+        for page in pagify(monsters_to_rotation_list(monsters, server, self.index_all)):
+            await self.bot.say(box(page))
+
+    @commands.command(pass_context=True)
+    async def jpname(self, ctx, *, query: str):
+        """Print the Japanese name of a monster"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self.bot.say(monsterToHeader(m))
+            await self.bot.say(box(m.name_jp))
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+
+    @commands.command(name="id", pass_context=True)
+    async def _do_id_all(self, ctx, *, query: str):
+        """Monster info (main tab)"""
+        await self._do_id(ctx, query)
+
+    @commands.command(name="idna", pass_context=True)
+    async def _do_id_na(self, ctx, *, query: str):
+        """Monster info (limited to NA monsters ONLY)"""
+        await self._do_id(ctx, query, na_only=True)
+
+    async def _do_id(self, ctx, query: str, na_only=False):
+        m, err, debug_info = self.findMonster(query, na_only=na_only)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.id_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+
+    @commands.command(name="id2", pass_context=True)
+    async def _do_id2_all(self, ctx, *, query: str):
+        """Monster info (main tab)"""
+        await self._do_id2(ctx, query)
+    
+    @commands.command(name="id2na", pass_context=True)
+    async def _do_id2_na(self, ctx, *, query: str):
+        """Monster info (limited to NA monsters ONLY)"""
+        await self._do_id2(ctx, query, na_only=True)
+
+    async def _do_id2(self, ctx, query: str, na_only=False):
+        m, err, debug_info = self.findMonster2(query, na_only=na_only)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.id_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+
+    @commands.command(name="evos", pass_context=True)
+    async def evos(self, ctx, *, query: str):
+        """Monster info (evolutions tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.evo_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+
+    @commands.command(name="mats", pass_context=True, aliases=['evomats', 'evomat'])
+    async def evomats(self, ctx, *, query: str):
+        """Monster info (evo materials tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.mats_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+
+    @commands.command(pass_context=True)
+    async def pantheon(self, ctx, *, query: str):
+        """Monster info (pantheon tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            menu = await self._do_idmenu(ctx, m, self.pantheon_emoji)
+            if menu == EMBED_NOT_GENERATED:
+                await self.bot.say(inline('Not a pantheon monster'))
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+
+    @commands.command(pass_context=True)
+    async def skillups(self, ctx, *, query: str):
+        """Monster info (evolutions tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            menu = await self._do_idmenu(ctx, m, self.skillups_emoji)
+            if menu == EMBED_NOT_GENERATED:
+                await self.bot.say(inline('No skillups available'))
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+
+    async def _do_idmenu(self, ctx, m, starting_menu_emoji):
+        id_embed = monsterToEmbed(m, self.get_emojis())
+        evo_embed = monsterToEvoEmbed(m)
+        mats_embed = monsterToEvoMatsEmbed(m)
+        animated = self.check_monster_animated(m.monster_no_jp)
+        pic_embed = monsterToPicEmbed(m, animated=animated)
+        other_info_embed = monsterToOtherInfoEmbed(m)
+
+        emoji_to_embed = OrderedDict()
+        emoji_to_embed[self.id_emoji] = id_embed
+        emoji_to_embed[self.evo_emoji] = evo_embed
+        emoji_to_embed[self.mats_emoji] = mats_embed
+        emoji_to_embed[self.pic_emoji] = pic_embed
+
+        pantheon_embed = monsterToPantheonEmbed(m)
+        if pantheon_embed:
+            emoji_to_embed[self.pantheon_emoji] = pantheon_embed
+
+        skillups_embed = monsterToSkillupsEmbed(m)
+        if skillups_embed:
+            emoji_to_embed[self.skillups_emoji] = skillups_embed
+
+        emoji_to_embed[self.other_info_emoji] = other_info_embed
+
+        return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed)
+
+    async def _do_evolistmenu(self, ctx, sm):
+        monsters = sm.alt_evos
+        monsters.sort(key=lambda m: m.monster_no)
+
+        emoji_to_embed = OrderedDict()
+        for idx, m in enumerate(monsters):
+            emoji = char_to_emoji(str(idx))
+            emoji_to_embed[emoji] = monsterToEmbed(m, self.get_emojis())
+            if m == sm:
+                starting_menu_emoji = emoji
+
+        return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed, timeout=60)
+
+    async def _do_menu(self, ctx, starting_menu_emoji, emoji_to_embed, timeout=30):
+        if starting_menu_emoji not in emoji_to_embed:
+            # Selected menu wasn't generated for this monster
+            return EMBED_NOT_GENERATED
+
+        remove_emoji = self.menu.emoji['no']
+        emoji_to_embed[remove_emoji] = self.menu.reaction_delete_message
+
+        try:
+            result_msg, result_embed = await self.menu.custom_menu(ctx, emoji_to_embed, starting_menu_emoji, timeout=timeout)
+            if result_msg and result_embed:
+                # Message is finished but not deleted, clear the footer
+                result_embed.set_footer(text=discord.Embed.Empty)
+                await self.bot.edit_message(result_msg, embed=result_embed)
+        except Exception as ex:
+            print('Menu failure', ex)
+
+    @commands.command(pass_context=True, aliases=['img'])
+    async def pic(self, ctx, *, query: str):
+        """Monster info (full image tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.pic_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+
+    @commands.command(pass_context=True, aliases=['stats'])
+    async def otherinfo(self, ctx, *, query: str):
+        """Monster info (misc info tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.other_info_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+
+    @commands.command(pass_context=True)
+    async def lookup(self, ctx, *, query: str):
+        """Short info results for a monster query"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            embed = monsterToHeaderEmbed(m)
+            await self.bot.say(embed=embed)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+
+    @commands.command(pass_context=True)
+    async def evolist(self, ctx, *, query):
+        """Monster info (for all monsters in the evo tree)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self._do_evolistmenu(ctx, m)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+
+    @commands.command(pass_context=True, aliases=['leaders', 'leaderskills', 'ls'])
+    async def leaderskill(self, ctx, left_query: str, right_query: str=None, *, bad=None):
+        """Display the multiplier and leaderskills for two monsters
+
+        If either your left or right query contains spaces, wrap in quotes.
+        e.g.: ^leaderskill "r sonia" "b sonia"
+        """
+        if bad:
+            await self.bot.say(inline('Too many inputs. Try wrapping your queries in quotes.'))
+            return
+
+        # Handle a very specific failure case, user typing something like "uuvo ragdra"
+        if ' ' not in left_query and right_query is not None and ' ' not in right_query and bad is None:
+            combined_query = left_query + ' ' + right_query
+            nm, err, debug_info = self._findMonster(combined_query)
+            if nm and left_query in nm.prefixes:
+                left_query = combined_query
+                right_query = None
+
+        left_m, left_err, _ = self.findMonster(left_query)
+        if right_query:
+            right_m, right_err, _ = self.findMonster(right_query)
+        else:
+            right_m, right_err, = left_m, left_err
+
+        err_msg = '{} query failed to match a monster: [ {} ]. If your query is multiple words, wrap it in quotes.'
+        if left_err:
+            await self.bot.say(inline(err_msg.format('Left', left_query)))
+            return
+        if right_err:
+            await self.bot.say(inline(err_msg.format('Right', right_query)))
+            return
+
+        emoji_to_embed = OrderedDict()
+        emoji_to_embed[self.ls_emoji] = monstersToLsEmbed(left_m, right_m)
+        emoji_to_embed[self.left_emoji] = monsterToEmbed(left_m, self.get_emojis())
+        emoji_to_embed[self.right_emoji] = monsterToEmbed(right_m, self.get_emojis())
+
+        await self._do_menu(ctx, self.ls_emoji, emoji_to_embed)
+
+    @commands.command(name="helpid", pass_context=True, aliases=['helppic', 'helpimg'])
+    async def _helpid(self, ctx):
+        """Whispers you info on how to craft monster queries for ^id"""
+        await self.bot.whisper(box(HELP_MSG))
+
+    @commands.command(pass_context=True)
+    async def padsay(self, ctx, server, *, query: str=None):
+        """Speak the voice line of a monster into your current chat"""
+        voice = ctx.message.author.voice
+        channel = voice.voice_channel
+        if channel is None:
+            await self.bot.say(inline('You must be in a voice channel to use this command'))
+            return
+
+        speech_cog = self.bot.get_cog('Speech')
+        if not speech_cog:
+            await self.bot.say(inline('Speech seems to be offline'))
+            return
+
+        if server.lower() not in ['na', 'jp']:
+            query = server + ' ' + (query or '')
+            server = 'na'
+        query = query.strip().lower()
+
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            base_dir = '/home/tactical0retreat/pad_data/voices/fixed'
+            voice_file = os.path.join(base_dir, server, '{}.wav'.format(m.monster_no_na))
+            header = '{} ({})'.format(monsterToHeader(m), server)
+            if not os.path.exists(voice_file):
+                await self.bot.say(inline('Could not find voice for ' + header))
+                return
+            await self.bot.say('Speaking for ' + header)
+            await speech_cog.play_path(channel, voice_file)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+
+    @commands.group(pass_context=True)
+    @checks.is_owner()
+    async def padinfo(self, ctx):
+        """PAD info management"""
+        if ctx.invoked_subcommand is None:
+            await send_cmd_help(ctx)
+
+    @padinfo.command(pass_context=True)
+    @checks.is_owner()
+    async def setemojiservers(self, ctx, *, emoji_servers=''):
+        """Set the emoji servers by ID (csv)"""
+        self.settings.emojiServers().clear()
+        if emoji_servers:
+            self.settings.setEmojiServers(emoji_servers.split(','))
+        await self.bot.say(inline('Set {} servers'.format(len(self.settings.emojiServers()))))
+
+    def get_emojis(self):
+        server_ids = self.settings.emojiServers()
+        return [e for s in self.bot.servers if s.id in server_ids for e in s.emojis]
+
+    def makeFailureMsg(self, err):
+        msg = 'Lookup failed: {}.\n'.format(err)
+        msg += 'Try one of <id>, <name>, [argbld]/[rgbld] <name>. Unexpected results? Use ^helpid for more info.'
+        return box(msg)
+
+    def findMonster(self, query, na_only=False):
+        query = rmdiacritics(query)
+        nm, err, debug_info = self._findMonster(query, na_only)
+
+        monster_no = nm.monster_no if nm else -1
+        self.historic_lookups[query] = monster_no
+        dataIO.save_json(self.historic_lookups_file_path, self.historic_lookups)
+
+        m = self.get_monster_by_no(nm.monster_no) if nm else None
+
+        return m, err, debug_info
+
+    def _findMonster(self, query, na_only=False):
+        monster_index = self.index_na if na_only else self.index_all
+        return monster_index.find_monster(query)
+
+    def findMonster2(self, query, na_only=False):
+        query = rmdiacritics(query)
+        nm, err, debug_info = self._findMonster2(query, na_only)
+        
+        monster_no = nm.monster_no if nm else -1
+        self.historic_lookups_id2[query] = monster_no
+        dataIO.save_json(self.historic_lookups_file_path_id2, self.historic_lookups_id2)
+        
+        m = self.get_monster_by_no(nm.monster_no) if nm else None
+        
+        return m, err, debug_info
+    
+    def _findMonster2(self, query, na_only=False):
+        monster_index = self.index_na if na_only else self.index_all
+        return monster_index.find_monster2(query)
+
+    def map_awakenings_text(self, m):
+        """Exported for use in other cogs"""
+        return _map_awakenings_text(m)
+
+    @padinfo.command(pass_context=True)
+    @checks.is_owner()
+    async def setanimationdir(self, ctx, *, animation_dir=''):
+        """Set a directory containing animated images"""
+        self.settings.setAnimationDir(animation_dir)
+        await self.bot.say(inline('Done'))
+
+    def check_monster_animated(self, monster_id: int):
+        if not self.settings.animationDir():
+            return False
+
+        try:
+            animated_ids = set()
+            for f in os.listdir(self.settings.animationDir()):
+                f = f.replace('.mp4', '')
+                if f.isdigit() and int(f) == monster_id:
+                    return True
+        except:
+            pass
+
+        return False
 
 
 def setup(bot):
-	print('padinfo bot setup')
-	n = PadInfo(bot)
-	bot.add_cog(n)
-	bot.loop.create_task(n.reload_nicknames())
-	print('done adding padinfo bot')
+    print('padinfo bot setup')
+    n = PadInfo(bot)
+    bot.add_cog(n)
+    bot.loop.create_task(n.reload_nicknames())
+    print('done adding padinfo bot')
 
 
 class PadInfoSettings(CogSettings):
-	def make_default_settings(self):
-		config = {
-			'animation_dir': '',
-		}
-		return config
-	
-	def emojiServers(self):
-		key = 'emoji_servers'
-		if key not in self.bot_settings:
-			self.bot_settings[key] = []
-		return self.bot_settings[key]
-	
-	def setEmojiServers(self, emoji_servers):
-		es = self.emojiServers()
-		es.clear()
-		es.extend(emoji_servers)
-		self.save_settings()
-	
-	def animationDir(self):
-		return self.bot_settings['animation_dir']
-	
-	def setAnimationDir(self, animation_dir):
-		self.bot_settings['animation_dir'] = animation_dir
-		self.save_settings()
+    def make_default_settings(self):
+        config = {
+            'animation_dir': '',
+        }
+        return config
+
+    def emojiServers(self):
+        key = 'emoji_servers'
+        if key not in self.bot_settings:
+            self.bot_settings[key] = []
+        return self.bot_settings[key]
+
+    def setEmojiServers(self, emoji_servers):
+        es = self.emojiServers()
+        es.clear()
+        es.extend(emoji_servers)
+        self.save_settings()
+
+    def animationDir(self):
+        return self.bot_settings['animation_dir']
+
+    def setAnimationDir(self, animation_dir):
+        self.bot_settings['animation_dir'] = animation_dir
+        self.save_settings()
 
 
 def monsterToHeader(m: padguide2.PgMonster, link=False):
-	msg = 'No. {} {}'.format(m.monster_no_na, m.name_na)
-	return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
+    msg = 'No. {} {}'.format(m.monster_no_na, m.name_na)
+    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
 
 
 def monsterToJpSuffix(m: padguide2.PgMonster):
-	suffix = ""
-	if m.roma_subname:
-		suffix += ' [{}]'.format(m.roma_subname)
-	if not m.on_na:
-		suffix += ' (JP only)'
-	return suffix
+    suffix = ""
+    if m.roma_subname:
+        suffix += ' [{}]'.format(m.roma_subname)
+    if not m.on_na:
+        suffix += ' (JP only)'
+    return suffix
 
 
 def monsterToLongHeader(m: padguide2.PgMonster, link=False):
-	msg = monsterToHeader(m) + monsterToJpSuffix(m)
-	return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
+    msg = monsterToHeader(m) + monsterToJpSuffix(m)
+    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
 
 
 def monsterToLongHeaderWithAttr(m: padguide2.PgMonster, link=False):
-	header = 'No. {} {} {}'.format(
-		m.monster_no_na,
-		"({}{})".format(attr_prefix_map[m.attr1], "/" +
-												  attr_prefix_map[m.attr2] if m.attr2 else ""),
-		m.name_na)
-	msg = header + monsterToJpSuffix(m)
-	return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
+    header = 'No. {} {} {}'.format(
+        m.monster_no_na,
+        "({}{})".format(attr_prefix_map[m.attr1], "/" +
+                        attr_prefix_map[m.attr2] if m.attr2 else ""),
+        m.name_na)
+    msg = header + monsterToJpSuffix(m)
+    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
 
 
 def monsterToEvoText(m: padguide2.PgMonster):
-	output = monsterToLongHeader(m)
-	for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
-		output += "\n\t- {}".format(monsterToLongHeader(ae))
-	return output
+    output = monsterToLongHeader(m)
+    for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
+        output += "\n\t- {}".format(monsterToLongHeader(ae))
+    return output
 
 
 def monsterToThumbnailUrl(m: padguide2.PgMonster):
-	return get_portrait_url(m)
+    return get_portrait_url(m)
 
 
 def monsterToBaseEmbed(m: padguide2.PgMonster):
-	header = monsterToLongHeader(m)
-	embed = discord.Embed()
-	embed.set_thumbnail(url=monsterToThumbnailUrl(m))
-	embed.title = header
-	embed.url = get_pdx_url(m)
-	embed.set_footer(text='Requester may click the reactions below to switch tabs')
-	return embed
+    header = monsterToLongHeader(m)
+    embed = discord.Embed()
+    embed.set_thumbnail(url=monsterToThumbnailUrl(m))
+    embed.title = header
+    embed.url = get_pdx_url(m)
+    embed.set_footer(text='Requester may click the reactions below to switch tabs')
+    return embed
 
 
 def monsterToEvoEmbed(m: padguide2.PgMonster):
-	embed = monsterToBaseEmbed(m)
-	
-	if not len(m.alt_evos):
-		embed.description = 'No alternate evos'
-		return embed
-	
-	field_name = '{} alternate evos'.format(len(m.alt_evos))
-	field_data = ''
-	for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
-		field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
-	
-	embed.add_field(name=field_name, value=field_data)
-	
-	return embed
+    embed = monsterToBaseEmbed(m)
+
+    if not len(m.alt_evos):
+        embed.description = 'No alternate evos'
+        return embed
+
+    field_name = '{} alternate evos'.format(len(m.alt_evos))
+    field_data = ''
+    for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
+        field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
+
+    embed.add_field(name=field_name, value=field_data)
+
+    return embed
 
 
 def monsterToEvoMatsEmbed(m: padguide2.PgMonster):
-	embed = monsterToBaseEmbed(m)
-	
-	mats_for_evo_size = len(m.mats_for_evo)
-	material_of_size = len(m.material_of)
-	
-	field_name = 'Evo materials'
-	field_data = ''
-	if mats_for_evo_size:
-		for ae in m.mats_for_evo:
-			field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
-	else:
-		field_data = 'None'
-	embed.add_field(name=field_name, value=field_data)
-	
-	if not material_of_size:
-		return embed
-	
-	field_name = 'Material for'
-	field_data = ''
-	if material_of_size > 5:
-		field_data = '{} monsters'.format(material_of_size)
-	else:
-		item_count = min(material_of_size, 5)
-		for ae in sorted(m.material_of, key=lambda x: x.monster_no_na, reverse=True)[:item_count]:
-			field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
-	embed.add_field(name=field_name, value=field_data)
-	
-	return embed
+    embed = monsterToBaseEmbed(m)
+
+    mats_for_evo_size = len(m.mats_for_evo)
+    material_of_size = len(m.material_of)
+
+    field_name = 'Evo materials'
+    field_data = ''
+    if mats_for_evo_size:
+        for ae in m.mats_for_evo:
+            field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
+    else:
+        field_data = 'None'
+    embed.add_field(name=field_name, value=field_data)
+
+    if not material_of_size:
+        return embed
+
+    field_name = 'Material for'
+    field_data = ''
+    if material_of_size > 5:
+        field_data = '{} monsters'.format(material_of_size)
+    else:
+        item_count = min(material_of_size, 5)
+        for ae in sorted(m.material_of, key=lambda x: x.monster_no_na, reverse=True)[:item_count]:
+            field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
+    embed.add_field(name=field_name, value=field_data)
+
+    return embed
 
 
 def monsterToPantheonEmbed(m: padguide2.PgMonster):
-	full_pantheon = m.series.monsters
-	pantheon_list = list(filter(lambda x: x.evo_from is None, full_pantheon))
-	if len(pantheon_list) == 0 or len(pantheon_list) > 6:
-		return None
-	
-	embed = monsterToBaseEmbed(m)
-	
-	field_name = 'Pantheon: ' + m.series.name
-	field_data = ''
-	for monster in sorted(pantheon_list, key=lambda x: x.monster_no_na):
-		field_data += '\n' + monsterToHeader(monster, link=True)
-	embed.add_field(name=field_name, value=field_data)
-	
-	return embed
+    full_pantheon = m.series.monsters
+    pantheon_list = list(filter(lambda x: x.evo_from is None, full_pantheon))
+    if len(pantheon_list) == 0 or len(pantheon_list) > 6:
+        return None
+
+    embed = monsterToBaseEmbed(m)
+
+    field_name = 'Pantheon: ' + m.series.name
+    field_data = ''
+    for monster in sorted(pantheon_list, key=lambda x: x.monster_no_na):
+        field_data += '\n' + monsterToHeader(monster, link=True)
+    embed.add_field(name=field_name, value=field_data)
+
+    return embed
 
 
 def monsterToSkillupsEmbed(m: padguide2.PgMonster):
-	skillups_list = m.active_skill.monsters_with_active if m.active_skill else []
-	skillups_list = list(filter(lambda m: m.sell_mp < 3000, skillups_list))
-	server_skillups = m.active_skill.server_skillups if m.active_skill else []
-	
-	if len(skillups_list) + len(server_skillups) == 0:
-		return None
-	
-	embed = monsterToBaseEmbed(m)
-	
-	skillups_to_skip = []
-	for server, skillup in server_skillups.items():
-		skillup_header = 'Skillup in ' + server
-		skillup_body = monsterToHeader(skillup, link=True)
-		embed.add_field(name=skillup_header, value=skillup_body)
-		skillups_to_skip.append(skillup.monster_no_na)
-	
-	field_name = 'Skillups'
-	field_data = ''
-	
-	# Prevent huge skillup lists
-	if len(skillups_list) > 8:
-		field_data = '({} skillups omitted)'.format(len(skillups_list) - 8)
-		skillups_list = skillups_list[0:8]
-	
-	for monster in sorted(skillups_list, key=lambda x: x.monster_no_na):
-		if monster.monster_no_na in skillups_to_skip:
-			continue
-		field_data += '\n' + monsterToHeader(monster, link=True)
-	
-	if len(field_data.strip()):
-		embed.add_field(name=field_name, value=field_data)
-	
-	return embed
+    skillups_list = m.active_skill.monsters_with_active if m.active_skill else []
+    skillups_list = list(filter(lambda m: m.sell_mp < 3000, skillups_list))
+    server_skillups = m.active_skill.server_skillups if m.active_skill else []
+
+    if len(skillups_list) + len(server_skillups) == 0:
+        return None
+
+    embed = monsterToBaseEmbed(m)
+
+    skillups_to_skip = []
+    for server, skillup in server_skillups.items():
+        skillup_header = 'Skillup in ' + server
+        skillup_body = monsterToHeader(skillup, link=True)
+        embed.add_field(name=skillup_header, value=skillup_body)
+        skillups_to_skip.append(skillup.monster_no_na)
+
+    field_name = 'Skillups'
+    field_data = ''
+
+    # Prevent huge skillup lists
+    if len(skillups_list) > 8:
+        field_data = '({} skillups omitted)'.format(len(skillups_list) - 8)
+        skillups_list = skillups_list[0:8]
+
+    for monster in sorted(skillups_list, key=lambda x: x.monster_no_na):
+        if monster.monster_no_na in skillups_to_skip:
+            continue
+        field_data += '\n' + monsterToHeader(monster, link=True)
+
+    if len(field_data.strip()):
+        embed.add_field(name=field_name, value=field_data)
+
+    return embed
 
 
 def monsterToPicUrl(m: padguide2.PgMonster):
-	return get_pic_url(m)
+    return get_pic_url(m)
 
 
 def monsterToPicEmbed(m: padguide2.PgMonster, animated=False):
-	embed = monsterToBaseEmbed(m)
-	url = monsterToPicUrl(m)
-	embed.set_image(url=url)
-	# Clear the thumbnail, don't need it on pic
-	embed.set_thumbnail(url='')
-	if animated:
-		description = '[{}]({}) –– [{}]({})'.format(
-			'HQ (MP4)', monsterToVideoUrl(m), 'LQ (GIF)', monsterToGifUrl(m))
-		embed.add_field(name='Animated links', value=description)
-	
-	return embed
+    embed = monsterToBaseEmbed(m)
+    url = monsterToPicUrl(m)
+    embed.set_image(url=url)
+    # Clear the thumbnail, don't need it on pic
+    embed.set_thumbnail(url='')
+    if animated:
+        description = '[{}]({}) –– [{}]({})'.format(
+            'HQ (MP4)', monsterToVideoUrl(m), 'LQ (GIF)', monsterToGifUrl(m))
+        embed.add_field(name='Animated links', value=description)
+
+    return embed
 
 
 def monsterToVideoUrl(m: padguide2.PgMonster):
-	return VIDEO_TEMPLATE.format(m.monster_no_jp)
+    return VIDEO_TEMPLATE.format(m.monster_no_jp)
 
 
 def monsterToGifUrl(m: padguide2.PgMonster):
-	return GIF_TEMPLATE.format(m.monster_no_jp)
+    return GIF_TEMPLATE.format(m.monster_no_jp)
 
 
 def monsterToGifEmbed(m: padguide2.PgMonster):
-	embed = monsterToBaseEmbed(m)
-	url = monsterToGifUrl(m)
-	embed.set_image(url=url)
-	# Clear the thumbnail, don't need it on pic
-	embed.set_thumbnail(url='')
-	return embed
+    embed = monsterToBaseEmbed(m)
+    url = monsterToGifUrl(m)
+    embed.set_image(url=url)
+    # Clear the thumbnail, don't need it on pic
+    embed.set_thumbnail(url='')
+    return embed
 
 
 def monstersToLsEmbed(left_m: padguide2.PgMonster, right_m: padguide2.PgMonster):
-	lhp, latk, lrcv, lresist = left_m.leader_skill_data.get_data()
-	rhp, ratk, rrcv, rresist = right_m.leader_skill_data.get_data()
-	multiplier_text = createMultiplierText(lhp, latk, lrcv, lresist, rhp, ratk, rrcv, rresist)
-	
-	embed = discord.Embed()
-	embed.title = 'Multiplier [{}]\n\n'.format(multiplier_text)
-	description = ''
-	description += '\n**{}**\n{}'.format(
-		monsterToHeader(left_m, link=True),
-		left_m.leader_skill.desc if left_m.leader_skill else 'None/Missing')
-	description += '\n**{}**\n{}'.format(
-		monsterToHeader(right_m, link=True),
-		right_m.leader_skill.desc if right_m.leader_skill else 'None/Missing')
-	embed.description = description
-	
-	return embed
+    lhp, latk, lrcv, lresist = left_m.leader_skill_data.get_data()
+    rhp, ratk, rrcv, rresist = right_m.leader_skill_data.get_data()
+    multiplier_text = createMultiplierText(lhp, latk, lrcv, lresist, rhp, ratk, rrcv, rresist)
+
+    embed = discord.Embed()
+    embed.title = 'Multiplier [{}]\n\n'.format(multiplier_text)
+    description = ''
+    description += '\n**{}**\n{}'.format(
+        monsterToHeader(left_m, link=True),
+        left_m.leader_skill.desc if left_m.leader_skill else 'None/Missing')
+    description += '\n**{}**\n{}'.format(
+        monsterToHeader(right_m, link=True),
+        right_m.leader_skill.desc if right_m.leader_skill else 'None/Missing')
+    embed.description = description
+
+    return embed
 
 
 def monsterToHeaderEmbed(m: padguide2.PgMonster):
-	header = monsterToLongHeader(m, link=True)
-	embed = discord.Embed()
-	embed.description = header
-	return embed
+    header = monsterToLongHeader(m, link=True)
+    embed = discord.Embed()
+    embed.description = header
+    return embed
 
 
 def monsterToTypeString(m: padguide2.PgMonster):
-	output = m.type1
-	if m.type2:
-		output += '/' + m.type2
-	if m.type3:
-		output += '/' + m.type3
-	return output
+    output = m.type1
+    if m.type2:
+        output += '/' + m.type2
+    if m.type3:
+        output += '/' + m.type3
+    return output
 
 
 def monsterToAcquireString(m: padguide2.PgMonster):
-	acquire_text = None
-	if m.farmable and not m.mp_evo:
-		# Some MP shop monsters 'drop' in PADR
-		acquire_text = 'Farmable'
-	elif m.farmable_evo and not m.mp_evo:
-		acquire_text = 'Farmable Evo'
-	elif m.in_pem:
-		acquire_text = 'In PEM'
-	elif m.pem_evo:
-		acquire_text = 'PEM Evo'
-	elif m.in_rem:
-		acquire_text = 'In REM'
-	elif m.rem_evo:
-		acquire_text = 'REM Evo'
-	elif m.in_mpshop:
-		acquire_text = 'MP Shop'
-	elif m.mp_evo:
-		acquire_text = 'MP Shop Evo'
-	return acquire_text
+    acquire_text = None
+    if m.farmable and not m.mp_evo:
+        # Some MP shop monsters 'drop' in PADR
+        acquire_text = 'Farmable'
+    elif m.farmable_evo and not m.mp_evo:
+        acquire_text = 'Farmable Evo'
+    elif m.in_pem:
+        acquire_text = 'In PEM'
+    elif m.pem_evo:
+        acquire_text = 'PEM Evo'
+    elif m.in_rem:
+        acquire_text = 'In REM'
+    elif m.rem_evo:
+        acquire_text = 'REM Evo'
+    elif m.in_mpshop:
+        acquire_text = 'MP Shop'
+    elif m.mp_evo:
+        acquire_text = 'MP Shop Evo'
+    return acquire_text
 
 
 def match_emoji(emoji_list, name):
-	for e in emoji_list:
-		if e.name == name:
-			return e
-	return None
+    for e in emoji_list:
+        if e.name == name:
+            return e
+    return None
 
 
 def monsterToEmbed(m: padguide2.PgMonster, emoji_list):
-	embed = monsterToBaseEmbed(m)
-	
-	info_row_1 = monsterToTypeString(m)
-	acquire_text = monsterToAcquireString(m)
-	
-	info_row_2 = '**Rarity** {}\n**Cost** {}'.format(m.rarity, m.cost)
-	if acquire_text:
-		info_row_2 += '\n**{}**'.format(acquire_text)
-	if m.is_inheritable:
-		info_row_2 += '\n**Inheritable**'
-	else:
-		info_row_2 += '\n**Not inheritable**'
-	
-	embed.add_field(name=info_row_1, value=info_row_2)
-	
-	if m.limitbreak_stats and m.limitbreak_stats > 1:
-		def lb(x):
-			return int(round(m.limitbreak_stats * x))
-		
-		stats_row_1 = 'Weighted {} | LB {}'.format(m.weighted_stats, lb(m.weighted_stats))
-		stats_row_2 = '**HP** {} ({})\n**ATK** {} ({})\n**RCV** {} ({})'.format(
-			m.hp, lb(m.hp), m.atk, lb(m.atk), m.rcv, lb(m.rcv))
-	else:
-		stats_row_1 = 'Weighted {}'.format(m.weighted_stats)
-		stats_row_2 = '**HP** {}\n**ATK** {}\n**RCV** {}'.format(m.hp, m.atk, m.rcv)
-	embed.add_field(name=stats_row_1, value=stats_row_2)
-	
-	awakenings_row = ''
-	for idx, a in enumerate(m.awakenings):
-		a = a.get_name()
-		mapped_awakening = AWAKENING_NAME_MAP_RPAD.get(a, a)
-		mapped_awakening = match_emoji(emoji_list, mapped_awakening)
-		
-		if mapped_awakening is None:
-			mapped_awakening = AWAKENING_NAME_MAP.get(a, a)
-		
-		# Wrap superawakenings to the next line
-		if len(m.awakenings) - idx == m.superawakening_count:
-			awakenings_row += '\n{}'.format(mapped_awakening)
-		else:
-			awakenings_row += ' {}'.format(mapped_awakening)
-	
-	awakenings_row = awakenings_row.strip()
-	
-	if not len(awakenings_row):
-		awakenings_row = 'No Awakenings'
-	
-	killers = compute_killers(m.type1, m.type2, m.type3)
-	killers_row = '**Available Killers:** {}'.format(' '.join(killers))
-	
-	embed.description = '{}\n{}'.format(awakenings_row, killers_row)
-	
-	if len(m.server_actives) >= 2:
-		for server, active in m.server_actives.items():
-			active_header = '({} Server) Active Skill ({} -> {})'.format(server,
-																		 active.turn_max, active.turn_min)
-			active_body = active.desc
-			embed.add_field(name=active_header, value=active_body, inline=False)
-	else:
-		active_header = 'Active Skill'
-		active_body = 'None/Missing'
-		if m.active_skill:
-			active_header = 'Active Skill ({} -> {})'.format(m.active_skill.turn_max,
-															 m.active_skill.turn_min)
-			active_body = m.active_skill.desc
-		embed.add_field(name=active_header, value=active_body, inline=False)
-	
-	ls_row = m.leader_skill.desc if m.leader_skill else 'None/Missing'
-	ls_header = 'Leader Skill'
-	if m.leader_skill_data:
-		hp, atk, rcv, resist = m.leader_skill_data.get_data()
-		multiplier_text = createMultiplierText(hp, atk, rcv, resist)
-		ls_header += " [ {} ]".format(multiplier_text)
-	embed.add_field(name=ls_header, value=ls_row, inline=False)
-	
-	return embed
+    embed = monsterToBaseEmbed(m)
+
+    info_row_1 = monsterToTypeString(m)
+    acquire_text = monsterToAcquireString(m)
+
+    info_row_2 = '**Rarity** {}\n**Cost** {}'.format(m.rarity, m.cost)
+    if acquire_text:
+        info_row_2 += '\n**{}**'.format(acquire_text)
+    if m.is_inheritable:
+        info_row_2 += '\n**Inheritable**'
+    else:
+        info_row_2 += '\n**Not inheritable**'
+
+    embed.add_field(name=info_row_1, value=info_row_2)
+
+    if m.limitbreak_stats and m.limitbreak_stats > 1:
+        def lb(x): return int(round(m.limitbreak_stats * x))
+        stats_row_1 = 'Weighted {} | LB {}'.format(m.weighted_stats, lb(m.weighted_stats))
+        stats_row_2 = '**HP** {} ({})\n**ATK** {} ({})\n**RCV** {} ({})'.format(
+            m.hp, lb(m.hp), m.atk, lb(m.atk), m.rcv, lb(m.rcv))
+    else:
+        stats_row_1 = 'Weighted {}'.format(m.weighted_stats)
+        stats_row_2 = '**HP** {}\n**ATK** {}\n**RCV** {}'.format(m.hp, m.atk, m.rcv)
+    embed.add_field(name=stats_row_1, value=stats_row_2)
+
+    awakenings_row = ''
+    for idx, a in enumerate(m.awakenings):
+        a = a.get_name()
+        mapped_awakening = AWAKENING_NAME_MAP_RPAD.get(a, a)
+        mapped_awakening = match_emoji(emoji_list, mapped_awakening)
+
+        if mapped_awakening is None:
+            mapped_awakening = AWAKENING_NAME_MAP.get(a, a)
+
+        # Wrap superawakenings to the next line
+        if len(m.awakenings) - idx == m.superawakening_count:
+            awakenings_row += '\n{}'.format(mapped_awakening)
+        else:
+            awakenings_row += ' {}'.format(mapped_awakening)
+
+    awakenings_row = awakenings_row.strip()
+
+    if not len(awakenings_row):
+        awakenings_row = 'No Awakenings'
+
+    killers = compute_killers(m.type1, m.type2, m.type3)
+    killers_row = '**Available Killers:** {}'.format(' '.join(killers))
+
+    embed.description = '{}\n{}'.format(awakenings_row, killers_row)
+
+    if len(m.server_actives) >= 2:
+        for server, active in m.server_actives.items():
+            active_header = '({} Server) Active Skill ({} -> {})'.format(server,
+                                                                         active.turn_max, active.turn_min)
+            active_body = active.desc
+            embed.add_field(name=active_header, value=active_body, inline=False)
+    else:
+        active_header = 'Active Skill'
+        active_body = 'None/Missing'
+        if m.active_skill:
+            active_header = 'Active Skill ({} -> {})'.format(m.active_skill.turn_max,
+                                                             m.active_skill.turn_min)
+            active_body = m.active_skill.desc
+        embed.add_field(name=active_header, value=active_body, inline=False)
+
+    ls_row = m.leader_skill.desc if m.leader_skill else 'None/Missing'
+    ls_header = 'Leader Skill'
+    if m.leader_skill_data:
+        hp, atk, rcv, resist = m.leader_skill_data.get_data()
+        multiplier_text = createMultiplierText(hp, atk, rcv, resist)
+        ls_header += " [ {} ]".format(multiplier_text)
+    embed.add_field(name=ls_header, value=ls_row, inline=False)
+
+    return embed
 
 
 def monsterToOtherInfoEmbed(m: padguide2.PgMonster):
-	embed = monsterToBaseEmbed(m)
-	# Clear the thumbnail, takes up too much space
-	embed.set_thumbnail(url='')
-	
-	stat_cols = ['', 'Max', 'M297', 'Inh', 'I297']
-	tbl = prettytable.PrettyTable(stat_cols)
-	tbl.hrules = prettytable.NONE
-	tbl.vrules = prettytable.NONE
-	tbl.align = "r"
-	hhp = m.hp + 99 * 10
-	hatk = m.atk + 99 * 5
-	hrcv = m.rcv + 99 * 3
-	tbl.add_row(['HP', m.hp, hhp, int(m.hp * .1), int(hhp * .1)])
-	tbl.add_row(['ATK', m.atk, hatk, int(m.atk * .05), int(hatk * .05)])
-	tbl.add_row(['RCV', m.rcv, hrcv, int(m.rcv * .15), int(hrcv * .15)])
-	
-	body_text = box(tbl.get_string())
-	
-	search_text = YT_SEARCH_TEMPLATE.format(m.name_jp)
-	skyozora_text = SKYOZORA_TEMPLATE.format(m.monster_no_jp)
-	body_text += "\n**JP Name**: {} | [YouTube]({}) | [Skyozora]({})".format(
-		m.name_jp, search_text, skyozora_text)
-	
-	if m.history_us:
-		body_text += '\n**History:** {}'.format(m.history_us)
-	
-	body_text += '\n**Series:** {}'.format(m.series.name)
-	body_text += '\n**Sell MP:** {:,}'.format(m.sell_mp)
-	if m.buy_mp > 0:
-		body_text += "  **Buy MP:** {:,}".format(m.buy_mp)
-	
-	if m.exp < 1000000:
-		xp_text = '{:,}'.format(m.exp)
-	else:
-		xp_text = '{:.1f}'.format(m.exp / 1000000).rstrip('0').rstrip('.') + 'M'
-	body_text += '\n**XP to Max:** {}'.format(xp_text)
-	body_text += '  **Max Level:**: {}'.format(m.max_level)
-	body_text += '\n**Rarity:** {} **Cost:** {}'.format(m.rarity, m.cost)
-	
-	if m.translated_jp_name:
-		body_text += '\n**Google Translated:** {}'.format(m.translated_jp_name)
-	
-	embed.description = body_text
-	
-	return embed
+    embed = monsterToBaseEmbed(m)
+    # Clear the thumbnail, takes up too much space
+    embed.set_thumbnail(url='')
+
+    stat_cols = ['', 'Max', 'M297', 'Inh', 'I297']
+    tbl = prettytable.PrettyTable(stat_cols)
+    tbl.hrules = prettytable.NONE
+    tbl.vrules = prettytable.NONE
+    tbl.align = "r"
+    hhp = m.hp + 99 * 10
+    hatk = m.atk + 99 * 5
+    hrcv = m.rcv + 99 * 3
+    tbl.add_row(['HP', m.hp, hhp, int(m.hp * .1), int(hhp * .1)])
+    tbl.add_row(['ATK', m.atk, hatk, int(m.atk * .05), int(hatk * .05)])
+    tbl.add_row(['RCV', m.rcv, hrcv, int(m.rcv * .15), int(hrcv * .15)])
+
+    body_text = box(tbl.get_string())
+
+    search_text = YT_SEARCH_TEMPLATE.format(m.name_jp)
+    skyozora_text = SKYOZORA_TEMPLATE.format(m.monster_no_jp)
+    body_text += "\n**JP Name**: {} | [YouTube]({}) | [Skyozora]({})".format(
+        m.name_jp, search_text, skyozora_text)
+
+    if m.history_us:
+        body_text += '\n**History:** {}'.format(m.history_us)
+
+    body_text += '\n**Series:** {}'.format(m.series.name)
+    body_text += '\n**Sell MP:** {:,}'.format(m.sell_mp)
+    if m.buy_mp > 0:
+        body_text += "  **Buy MP:** {:,}".format(m.buy_mp)
+
+    if m.exp < 1000000:
+        xp_text = '{:,}'.format(m.exp)
+    else:
+        xp_text = '{:.1f}'.format(m.exp / 1000000).rstrip('0').rstrip('.') + 'M'
+    body_text += '\n**XP to Max:** {}'.format(xp_text)
+    body_text += '  **Max Level:**: {}'.format(m.max_level)
+    body_text += '\n**Rarity:** {} **Cost:** {}'.format(m.rarity, m.cost)
+
+    if m.translated_jp_name:
+        body_text += '\n**Google Translated:** {}'.format(m.translated_jp_name)
+
+    embed.description = body_text
+
+    return embed
 
 
 def monsters_to_rotation_list(monster_list, server: str, index_all: padguide2.MonsterIndex):
-	# Shorten some of the longer names
-	name_remap = {
-		'Extreme King Metal Tamadra': 'Fat Tama',
-		'Extreme King Metal Dragon': 'EKMD',
-		'Ancient Green Sacred Mask': 'Green Mask',
-		'Ancient Blue Sacred Mask': 'Blue Mask',
-	}
-	ignore_monsters = [
-		'Ancient Draggie Knight',
-	]
-	
-	monster_list.sort(key=lambda m: m.monster_no, reverse=True)
-	next_rotation_date = None
-	for m in monster_list:
-		if server in m.future_skillup_rotation:
-			next_rotation_date = m.future_skillup_rotation[server].rotation_date_str
-			break
-	
-	cols = [server + ' Skillup', 'Current']
-	if next_rotation_date:
-		cols.append(next_rotation_date)
-	tbl = prettytable.PrettyTable(cols)
-	tbl.hrules = prettytable.HEADER
-	tbl.vrules = prettytable.NONE
-	tbl.align = "l"
-	
-	def cell_name(m: padguide2.PgMonster):
-		nm = index_all.monster_no_to_named_monster[m.monster_no]
-		name = nm.group_computed_basename.title()
-		return name_remap.get(name, name)
-	
-	for m in monster_list:
-		skill = m.server_actives[server]
-		
-		sm = skill.monsters_with_active
-		
-		# Since some newer monsters like jewel of creation are being used as
-		# skillups, exclude them from the list of skillup targets.
-		
-		def is_bad_type(m):
-			return set(['enhance', 'evolve', 'vendor']).intersection(set(m.types))
-		
-		sm = max(sm, key=lambda x: (not is_bad_type(x), x.monster_no))
-		
-		skillup_name = cell_name(m)
-		if skillup_name in ignore_monsters:
-			continue
-		row = [skillup_name, cell_name(sm)]
-		if next_rotation_date:
-			if server in m.future_skillup_rotation:
-				next_skill = m.future_skillup_rotation[server].skill
-				nm = max(next_skill.monsters_with_active, key=lambda x: x.monster_no)
-				row.append(cell_name(nm))
-			else:
-				row.append('')
-		tbl.add_row(row)
-	
-	return tbl.get_string()
+    # Shorten some of the longer names
+    name_remap = {
+        'Extreme King Metal Tamadra': 'Fat Tama',
+        'Extreme King Metal Dragon': 'EKMD',
+        'Ancient Green Sacred Mask': 'Green Mask',
+        'Ancient Blue Sacred Mask': 'Blue Mask',
+    }
+    ignore_monsters = [
+        'Ancient Draggie Knight',
+    ]
+
+    monster_list.sort(key=lambda m: m.monster_no, reverse=True)
+    next_rotation_date = None
+    for m in monster_list:
+        if server in m.future_skillup_rotation:
+            next_rotation_date = m.future_skillup_rotation[server].rotation_date_str
+            break
+
+    cols = [server + ' Skillup', 'Current']
+    if next_rotation_date:
+        cols.append(next_rotation_date)
+    tbl = prettytable.PrettyTable(cols)
+    tbl.hrules = prettytable.HEADER
+    tbl.vrules = prettytable.NONE
+    tbl.align = "l"
+
+    def cell_name(m: padguide2.PgMonster):
+        nm = index_all.monster_no_to_named_monster[m.monster_no]
+        name = nm.group_computed_basename.title()
+        return name_remap.get(name, name)
+
+    for m in monster_list:
+        skill = m.server_actives[server]
+
+        sm = skill.monsters_with_active
+        # Since some newer monsters like jewel of creation are being used as
+        # skillups, exclude them from the list of skillup targets.
+
+        def is_bad_type(m):
+            return set(['enhance', 'evolve', 'vendor']).intersection(set(m.types))
+        sm = max(sm, key=lambda x: (not is_bad_type(x), x.monster_no))
+
+        skillup_name = cell_name(m)
+        if skillup_name in ignore_monsters:
+            continue
+        row = [skillup_name, cell_name(sm)]
+        if next_rotation_date:
+            if server in m.future_skillup_rotation:
+                next_skill = m.future_skillup_rotation[server].skill
+                nm = max(next_skill.monsters_with_active, key=lambda x: x.monster_no)
+                row.append(cell_name(nm))
+            else:
+                row.append('')
+        tbl.add_row(row)
+
+    return tbl.get_string()
 
 
 AWAKENING_NAME_MAP_RPAD = {
-	'Enhanced Attack': 'boost_atk',
-	'Enhanced HP': 'boost_hp',
-	'Enhanced Heal': 'boost_rcv',
-	
-	'Enhanced Team HP': 'teamboost_hp',
-	'Enhanced Team Attack': 'teamboost_atk',
-	'Enhanced Team RCV': 'teamboost_rcv',
-	
-	'God Killer': 'killer_god',
-	'Dragon Killer': 'killer_dragon',
-	'Devil Killer': 'killer_devil',
-	'Machine Killer': 'killer_machine',
-	'Balanced Killer': 'killer_balance',
-	'Attacker Killer': 'killer_attacker',
-	
-	'Physical Killer': 'killer_physical',
-	'Healer Killer': 'killer_healer',
-	'Evolve Material Killer': 'killer_evomat',
-	'Awaken Material Killer': 'killer_awoken',
-	'Enhance Material Killer': 'killer_enhancemat',
-	'Vendor Material Killer': 'killer_vendor',
-	
-	'Auto-Recover': 'misc_autoheal',
-	'Recover Bind': 'misc_bindclear',
-	'Enhanced Combo': 'misc_comboboost',
-	'Super Enhanced Combo': 'misc_super_comboboost',
-	'Guard Break': 'misc_guardbreak',
-	'Multi Boost': 'misc_multiboost',
-	'Additional Attack': 'misc_extraattack',
-	'Skill Boost': 'misc_sb',
-	'Extend Time': 'misc_te',
-	'Two-Pronged Attack': 'misc_tpa',
-	'Damage Void Shield Penetration': 'misc_voidshield',
-	'Awoken Assist': 'misc_assist',
-	
-	'Enhanced Fire Orbs': 'oe_fire',
-	'Enhanced Water Orbs': 'oe_water',
-	'Enhanced Wood Orbs': 'oe_wood',
-	'Enhanced Light Orbs': 'oe_light',
-	'Enhanced Dark Orbs': 'oe_dark',
-	'Enhanced Heal Orbs': 'oe_heart',
-	
-	'Reduce Fire Damage': 'reduce_fire',
-	'Reduce Water Damage': 'reduce_water',
-	'Reduce Wood Damage': 'reduce_wood',
-	'Reduce Light Damage': 'reduce_light',
-	'Reduce Dark Damage': 'reduce_dark',
-	
-	'Resistance-Bind': 'res_bind',
-	'Resistance-Dark': 'res_blind',
-	'Resistance-Jammers': 'res_jammer',
-	'Resistance-Poison': 'res_poison',
-	'Resistance-Skill Bind': 'res_skillbind',
-	
-	'Enhanced Fire Att.': 'row_fire',
-	'Enhanced Water Att.': 'row_water',
-	'Enhanced Wood Att.': 'row_wood',
-	'Enhanced Light Att.': 'row_light',
-	'Enhanced Dark Att.': 'row_dark',
-	
-	'Skill Charge': 'misc_skillcharge',
-	'Super Additional Attack': 'misc_super_extraattack',
-	'Resistance-Bind＋': 'res_bind_super',
-	'Extend Time＋': 'misc_te_super',
-	'Resistance-Cloud': 'res_cloud',
-	'Resistance-Board Restrict': 'res_seal',
-	'Skill Boost＋': 'misc_sb_super',
-	'L-Shape Attack': 'l_attack',
-	'L-Shape Damage Reduction': 'l_shield',
-	'Enhance when HP is below 50%': 'attack_boost_low',
-	'Enhance when HP is above 80%': 'attack_boost_high',
-	'Combo Orb': 'orb_combo',
-	'Skill Voice': 'misc_voice',
-	'Dungeon Bonus': 'misc_dungeonbonus',
+    'Enhanced Attack': 'boost_atk',
+    'Enhanced HP': 'boost_hp',
+    'Enhanced Heal': 'boost_rcv',
+
+    'Enhanced Team HP': 'teamboost_hp',
+    'Enhanced Team Attack': 'teamboost_atk',
+    'Enhanced Team RCV': 'teamboost_rcv',
+
+    'God Killer': 'killer_god',
+    'Dragon Killer': 'killer_dragon',
+    'Devil Killer': 'killer_devil',
+    'Machine Killer': 'killer_machine',
+    'Balanced Killer': 'killer_balance',
+    'Attacker Killer': 'killer_attacker',
+
+    'Physical Killer': 'killer_physical',
+    'Healer Killer': 'killer_healer',
+    'Evolve Material Killer': 'killer_evomat',
+    'Awaken Material Killer': 'killer_awoken',
+    'Enhance Material Killer': 'killer_enhancemat',
+    'Vendor Material Killer': 'killer_vendor',
+
+    'Auto-Recover': 'misc_autoheal',
+    'Recover Bind': 'misc_bindclear',
+    'Enhanced Combo': 'misc_comboboost',
+    'Super Enhanced Combo': 'misc_super_comboboost',
+    'Guard Break': 'misc_guardbreak',
+    'Multi Boost': 'misc_multiboost',
+    'Additional Attack': 'misc_extraattack',
+    'Skill Boost': 'misc_sb',
+    'Extend Time': 'misc_te',
+    'Two-Pronged Attack': 'misc_tpa',
+    'Damage Void Shield Penetration': 'misc_voidshield',
+    'Awoken Assist': 'misc_assist',
+
+    'Enhanced Fire Orbs': 'oe_fire',
+    'Enhanced Water Orbs': 'oe_water',
+    'Enhanced Wood Orbs': 'oe_wood',
+    'Enhanced Light Orbs': 'oe_light',
+    'Enhanced Dark Orbs': 'oe_dark',
+    'Enhanced Heal Orbs': 'oe_heart',
+
+    'Reduce Fire Damage': 'reduce_fire',
+    'Reduce Water Damage': 'reduce_water',
+    'Reduce Wood Damage': 'reduce_wood',
+    'Reduce Light Damage': 'reduce_light',
+    'Reduce Dark Damage': 'reduce_dark',
+
+    'Resistance-Bind': 'res_bind',
+    'Resistance-Dark': 'res_blind',
+    'Resistance-Jammers': 'res_jammer',
+    'Resistance-Poison': 'res_poison',
+    'Resistance-Skill Bind': 'res_skillbind',
+
+    'Enhanced Fire Att.': 'row_fire',
+    'Enhanced Water Att.': 'row_water',
+    'Enhanced Wood Att.': 'row_wood',
+    'Enhanced Light Att.': 'row_light',
+    'Enhanced Dark Att.': 'row_dark',
+
+    'Skill Charge': 'misc_skillcharge',
+    'Super Additional Attack': 'misc_super_extraattack',
+    'Resistance-Bind＋': 'res_bind_super',
+    'Extend Time＋': 'misc_te_super',
+    'Resistance-Cloud': 'res_cloud',
+    'Resistance-Board Restrict': 'res_seal',
+    'Skill Boost＋': 'misc_sb_super',
+    'L-Shape Attack': 'l_attack',
+    'L-Shape Damage Reduction': 'l_shield',
+    'Enhance when HP is below 50%': 'attack_boost_low',
+    'Enhance when HP is above 80%': 'attack_boost_high',
+    'Combo Orb': 'orb_combo',
+    'Skill Voice': 'misc_voice',
+    'Dungeon Bonus': 'misc_dungeonbonus',
 }
 
 AWAKENING_NAME_MAP = {
-	'Enhanced Fire Orbs': 'R-OE',
-	'Enhanced Water Orbs': 'B-OE',
-	'Enhanced Wood Orbs': 'G-OE',
-	'Enhanced Light Orbs': 'L-OE',
-	'Enhanced Dark Orbs': 'D-OE',
-	'Enhanced Heal Orbs': 'H-OE',
-	
-	'Enhanced Fire Att.': 'R-RE',
-	'Enhanced Water Att.': 'B-RE',
-	'Enhanced Wood Att.': 'G-RE',
-	'Enhanced Light Att.': 'L-RE',
-	'Enhanced Dark Att.': 'D-RE',
-	
-	'Enhanced HP': 'HP',
-	'Enhanced Attack': 'ATK',
-	'Enhanced Heal': 'RCV',
-	
-	'Enhanced Team HP': 'TEAM-HP',
-	'Enhanced Team Attack': 'TEAM-ATK',
-	'Enhanced Team RCV': 'TEAM-RCV',
-	
-	'Auto-Recover': 'AUTO-RECOVER',
-	'Skill Boost': 'SB',
-	'Resistance-Skill Bind': 'SBR',
-	'Two-Pronged Attack': 'TPA',
-	'Multi Boost': 'MULTI-BOOST',
-	'Recover Bind': 'RCV-BIND',
-	'Extend Time': 'TE',
-	'Enhanced Combo': 'COMBO-BOOST',
-	'Guard Break': 'DEF-BREAK',
-	'Additional Attack': 'EXTRA-ATK',
-	'Damage Void Shield Penetration': 'VOID-BREAK',
-	'Awoken Assist': 'ASSIST',
-	
-	'Resistance-Bind': 'RES-BIND',
-	'Resistance-Dark': 'RES-BLIND',
-	'Resistance-Poison': 'RES-POISON',
-	'Resistance-Jammers': 'RES-JAMMER',
-	
-	'Reduce Fire Damage': 'R-RES',
-	'Reduce Water Damage': 'B-RES',
-	'Reduce Wood Damage': 'G-RES',
-	'Reduce Light Damage': 'L-RES',
-	'Reduce Dark Damage': 'D-RES',
-	
-	'Healer Killer': 'K-HEALER',
-	'Machine Killer': 'K-MACHINE',
-	'Dragon Killer': 'K-DRAGON',
-	'Attacker Killer': 'K-ATTACKER',
-	'Physical Killer': 'K-PHYSICAL',
-	'God Killer': 'K-GOD',
-	'Devil Killer': 'K-DEVIL',
-	'Balance Killer': 'K-BALANCE',
+    'Enhanced Fire Orbs': 'R-OE',
+    'Enhanced Water Orbs': 'B-OE',
+    'Enhanced Wood Orbs': 'G-OE',
+    'Enhanced Light Orbs': 'L-OE',
+    'Enhanced Dark Orbs': 'D-OE',
+    'Enhanced Heal Orbs': 'H-OE',
+
+    'Enhanced Fire Att.': 'R-RE',
+    'Enhanced Water Att.': 'B-RE',
+    'Enhanced Wood Att.': 'G-RE',
+    'Enhanced Light Att.': 'L-RE',
+    'Enhanced Dark Att.': 'D-RE',
+
+    'Enhanced HP': 'HP',
+    'Enhanced Attack': 'ATK',
+    'Enhanced Heal': 'RCV',
+
+    'Enhanced Team HP': 'TEAM-HP',
+    'Enhanced Team Attack': 'TEAM-ATK',
+    'Enhanced Team RCV': 'TEAM-RCV',
+
+    'Auto-Recover': 'AUTO-RECOVER',
+    'Skill Boost': 'SB',
+    'Resistance-Skill Bind': 'SBR',
+    'Two-Pronged Attack': 'TPA',
+    'Multi Boost': 'MULTI-BOOST',
+    'Recover Bind': 'RCV-BIND',
+    'Extend Time': 'TE',
+    'Enhanced Combo': 'COMBO-BOOST',
+    'Guard Break': 'DEF-BREAK',
+    'Additional Attack': 'EXTRA-ATK',
+    'Damage Void Shield Penetration': 'VOID-BREAK',
+    'Awoken Assist': 'ASSIST',
+
+    'Resistance-Bind': 'RES-BIND',
+    'Resistance-Dark': 'RES-BLIND',
+    'Resistance-Poison': 'RES-POISON',
+    'Resistance-Jammers': 'RES-JAMMER',
+
+    'Reduce Fire Damage': 'R-RES',
+    'Reduce Water Damage': 'B-RES',
+    'Reduce Wood Damage': 'G-RES',
+    'Reduce Light Damage': 'L-RES',
+    'Reduce Dark Damage': 'D-RES',
+
+    'Healer Killer': 'K-HEALER',
+    'Machine Killer': 'K-MACHINE',
+    'Dragon Killer': 'K-DRAGON',
+    'Attacker Killer': 'K-ATTACKER',
+    'Physical Killer': 'K-PHYSICAL',
+    'God Killer': 'K-GOD',
+    'Devil Killer': 'K-DEVIL',
+    'Balance Killer': 'K-BALANCE',
 }
 
 
 def createMultiplierText(hp1, atk1, rcv1, resist1, hp2=None, atk2=None, rcv2=None, resist2=None):
-	hp2, atk2, rcv2, resist2 = hp2 or hp1, atk2 or atk1, rcv2 or rcv1, resist2 or resist1
-	
-	def fmtNum(val):
-		return ('{:.2f}').format(val).strip('0').rstrip('.')
-	
-	text = "{}/{}/{}".format(fmtNum(hp1 * hp2), fmtNum(atk1 * atk2), fmtNum(rcv1 * rcv2))
-	if resist1 * resist2 < 1:
-		resist1 = resist1 if resist1 < 1 else 0
-		resist2 = resist2 if resist2 < 1 else 0
-		text += ' Resist {}%'.format(fmtNum(100 * (1 - (1 - resist1) * (1 - resist2))))
-	return text
+    hp2, atk2, rcv2, resist2 = hp2 or hp1, atk2 or atk1, rcv2 or rcv1, resist2 or resist1
+
+    def fmtNum(val):
+        return ('{:.2f}').format(val).strip('0').rstrip('.')
+    text = "{}/{}/{}".format(fmtNum(hp1 * hp2), fmtNum(atk1 * atk2), fmtNum(rcv1 * rcv2))
+    if resist1 * resist2 < 1:
+        resist1 = resist1 if resist1 < 1 else 0
+        resist2 = resist2 if resist2 < 1 else 0
+        text += ' Resist {}%'.format(fmtNum(100 * (1 - (1 - resist1) * (1 - resist2))))
+    return text
 
 
 def _map_awakenings_text(m: padguide2.PgMonster):
-	awakenings_row = ''
-	unique_awakenings = set(m.awakening_names)
-	for a in unique_awakenings:
-		count = m.awakening_names.count(a)
-		awakenings_row += ' {}x{}'.format(AWAKENING_NAME_MAP.get(a, a), count)
-	awakenings_row = awakenings_row.strip()
-	
-	if not len(awakenings_row):
-		awakenings_row = 'No Awakenings'
-	
-	return awakenings_row
+    awakenings_row = ''
+    unique_awakenings = set(m.awakening_names)
+    for a in unique_awakenings:
+        count = m.awakening_names.count(a)
+        awakenings_row += ' {}x{}'.format(AWAKENING_NAME_MAP.get(a, a), count)
+    awakenings_row = awakenings_row.strip()
+
+    if not len(awakenings_row):
+        awakenings_row = 'No Awakenings'
+
+    return awakenings_row
 
 
 # TODO: move to padguide2
 def compute_killers(*types):
-	if 'Balance' in types:
-		return ['Any']
-	killers = set()
-	for t in types:
-		killers.update(type_to_killers_map.get(t, []))
-	return sorted(killers)
+    if 'Balance' in types:
+        return ['Any']
+    killers = set()
+    for t in types:
+        killers.update(type_to_killers_map.get(t, []))
+    return sorted(killers)
 
 
 type_to_killers_map = {
-	'God': ['Devil'],
-	'Devil': ['God'],
-	'Machine': ['God', 'Balance'],
-	'Dragon': ['Machine', 'Healer'],
-	'Physical': ['Machine', 'Healer'],
-	'Attacker': ['Devil', 'Physical'],
-	'Healer': ['Dragon', 'Attacker'],
+    'God': ['Devil'],
+    'Devil': ['God'],
+    'Machine': ['God', 'Balance'],
+    'Dragon': ['Machine', 'Healer'],
+    'Physical': ['Machine', 'Healer'],
+    'Attacker': ['Devil', 'Physical'],
+    'Healer': ['Dragon', 'Attacker'],
 }

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -56,1094 +56,1093 @@ SKYOZORA_TEMPLATE = 'http://pad.skyozora.com/pets/{}'
 
 
 def get_pdx_url(m):
-    return INFO_PDX_TEMPLATE.format(rpadutils.get_pdx_id(m))
+	return INFO_PDX_TEMPLATE.format(rpadutils.get_pdx_id(m))
 
 
 def get_portrait_url(m):
-    if int(m.monster_no) != m.monster_no_na:
-        return RPAD_PORTRAIT_TEMPLATE.format('na', m.monster_no_na)
-    else:
-        return RPAD_PORTRAIT_TEMPLATE.format('jp', m.monster_no_jp)
+	if int(m.monster_no) != m.monster_no_na:
+		return RPAD_PORTRAIT_TEMPLATE.format('na', m.monster_no_na)
+	else:
+		return RPAD_PORTRAIT_TEMPLATE.format('jp', m.monster_no_jp)
 
 
 def get_pic_url(m):
-    if int(m.monster_no) != m.monster_no_na:
-        return RPAD_PIC_TEMPLATE.format('na', m.monster_no_na)
-    else:
-        return RPAD_PIC_TEMPLATE.format('jp', m.monster_no_jp)
+	if int(m.monster_no) != m.monster_no_na:
+		return RPAD_PIC_TEMPLATE.format('na', m.monster_no_na)
+	else:
+		return RPAD_PIC_TEMPLATE.format('jp', m.monster_no_jp)
 
 
 class PadInfo:
-    def __init__(self, bot):
-        self.bot = bot
-        
-        self.settings = PadInfoSettings("padinfo")
-        
-        self.index_all = padguide2.empty_index()
-        self.index_na = padguide2.empty_index()
-        
-        self.menu = Menu(bot)
-        
-        # These emojis are the keys into the idmenu submenus
-        self.id_emoji = '\N{INFORMATION SOURCE}'
-        self.evo_emoji = char_to_emoji('e')
-        self.mats_emoji = char_to_emoji('m')
-        self.ls_emoji = '\N{INFORMATION SOURCE}'
-        self.left_emoji = char_to_emoji('l')
-        self.right_emoji = char_to_emoji('r')
-        self.pantheon_emoji = '\N{CLASSICAL BUILDING}'
-        self.skillups_emoji = '\N{MEAT ON BONE}'
-        self.pic_emoji = '\N{FRAME WITH PICTURE}'
-        self.other_info_emoji = '\N{SCROLL}'
-        
-        self.historic_lookups_file_path = "data/padinfo/historic_lookups.json"
-        self.historic_lookups_file_path_id2 = "data/padinfo/historic_lookups_id2.json"
-  
-        if not dataIO.is_valid_json(self.historic_lookups_file_path):
-            print("Creating empty historic_lookups.json...")
-            dataIO.save_json(self.historic_lookups_file_path, {})
+	def __init__(self, bot):
+		self.bot = bot
+		
+		self.settings = PadInfoSettings("padinfo")
+		
+		self.index_all = padguide2.empty_index()
+		self.index_na = padguide2.empty_index()
+		
+		self.menu = Menu(bot)
+		
+		# These emojis are the keys into the idmenu submenus
+		self.id_emoji = '\N{INFORMATION SOURCE}'
+		self.evo_emoji = char_to_emoji('e')
+		self.mats_emoji = char_to_emoji('m')
+		self.ls_emoji = '\N{INFORMATION SOURCE}'
+		self.left_emoji = char_to_emoji('l')
+		self.right_emoji = char_to_emoji('r')
+		self.pantheon_emoji = '\N{CLASSICAL BUILDING}'
+		self.skillups_emoji = '\N{MEAT ON BONE}'
+		self.pic_emoji = '\N{FRAME WITH PICTURE}'
+		self.other_info_emoji = '\N{SCROLL}'
+		
+		self.historic_lookups_file_path = "data/padinfo/historic_lookups.json"
+		self.historic_lookups_file_path_id2 = "data/padinfo/historic_lookups_id2.json"
+		if not dataIO.is_valid_json(self.historic_lookups_file_path):
+			print("Creating empty historic_lookups.json...")
+			dataIO.save_json(self.historic_lookups_file_path, {})
+		
+		if not dataIO.is_valid_json(self.historic_lookups_file_path_id2):
+			print("Creating empty historic_lookups_id2.json...")
+			dataIO.save_json(self.historic_lookups_file_path_id2, {})
+		
+		self.historic_lookups = dataIO.load_json(self.historic_lookups_file_path)
+		self.historic_lookups_id2 = dataIO.load_json(self.historic_lookups_file_path_id2)
+	
+	def __unload(self):
+		# Manually nulling out database because the GC for cogs seems to be pretty shitty
+		self.index_all = padguide2.empty_index()
+		self.index_na = padguide2.empty_index()
+		self.historic_lookups = {}
+		self.historic_lookups_id2 = {}
+	
+	async def reload_nicknames(self):
+		await self.bot.wait_until_ready()
+		while self == self.bot.get_cog('PadInfo'):
+			try:
+				await self.refresh_index()
+				print('Done refreshing PadInfo')
+			except Exception as ex:
+				print("reload padinfo loop caught exception " + str(ex))
+				traceback.print_exc()
+			
+			await asyncio.sleep(60 * 60 * 1)
+	
+	async def refresh_index(self):
+		"""Refresh the monster indexes."""
+		pg_cog = self.bot.get_cog('PadGuide2')
+		await pg_cog.wait_until_ready()
+		self.index_all = pg_cog.create_index()
+		self.index_na = pg_cog.create_index(lambda m: m.on_na)
+	
+	def get_monster_by_no(self, monster_no: int):
+		pg_cog = self.bot.get_cog('PadGuide2')
+		return pg_cog.get_monster_by_no(monster_no)
+	
+	@commands.command(pass_context=True)
+	async def skillrotation(self, ctx, server: str = 'NA'):
+		"""Print the current rotating skillups for a server (NA/JP)"""
+		server = normalizeServer(server)
+		if server not in ['NA', 'JP']:
+			await self.bot.say(inline('Supported servers are NA, JP'))
+			return
+		
+		pg_cog = self.bot.get_cog('PadGuide2')
+		monsters = pg_cog.database.rotating_skillups(server)
+		
+		for page in pagify(monsters_to_rotation_list(monsters, server, self.index_all)):
+			await self.bot.say(box(page))
+	
+	@commands.command(pass_context=True)
+	async def jpname(self, ctx, *, query: str):
+		"""Print the Japanese name of a monster"""
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			await self.bot.say(monsterToHeader(m))
+			await self.bot.say(box(m.name_jp))
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(name="id", pass_context=True)
+	async def _do_id_all(self, ctx, *, query: str):
+		"""Monster info (main tab)"""
+		await self._do_id(ctx, query)
+	
+	@commands.command(name="idna", pass_context=True)
+	async def _do_id_na(self, ctx, *, query: str):
+		"""Monster info (limited to NA monsters ONLY)"""
+		await self._do_id(ctx, query, na_only=True)
+	
+	async def _do_id(self, ctx, query: str, na_only=False):
+		m, err, debug_info = self.findMonster(query, na_only=na_only)
+		if m is not None:
+			await self._do_idmenu(ctx, m, self.id_emoji)
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(name="id2", pass_context=True)
+	async def _do_id2_all(self, ctx, *, query: str):
+		"""Monster info (main tab)"""
+		await self._do_id2(ctx, query)
+	
+	@commands.command(name="id2na", pass_context=True)
+	async def _do_id2_na(self, ctx, *, query: str):
+		"""Monster info (limited to NA monsters ONLY)"""
+		await self._do_id2(ctx, query, na_only=True)
+	
+	async def _do_id2(self, ctx, query: str, na_only=False):
+		m, err, debug_info = self.findMonster2(query, na_only=na_only)
+		if m is not None:
+			await self._do_idmenu(ctx, m, self.id_emoji)
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(name="evos", pass_context=True)
+	async def evos(self, ctx, *, query: str):
+		"""Monster info (evolutions tab)"""
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			await self._do_idmenu(ctx, m, self.evo_emoji)
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(name="mats", pass_context=True, aliases=['evomats', 'evomat'])
+	async def evomats(self, ctx, *, query: str):
+		"""Monster info (evo materials tab)"""
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			await self._do_idmenu(ctx, m, self.mats_emoji)
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(pass_context=True)
+	async def pantheon(self, ctx, *, query: str):
+		"""Monster info (pantheon tab)"""
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			menu = await self._do_idmenu(ctx, m, self.pantheon_emoji)
+			if menu == EMBED_NOT_GENERATED:
+				await self.bot.say(inline('Not a pantheon monster'))
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(pass_context=True)
+	async def skillups(self, ctx, *, query: str):
+		"""Monster info (evolutions tab)"""
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			menu = await self._do_idmenu(ctx, m, self.skillups_emoji)
+			if menu == EMBED_NOT_GENERATED:
+				await self.bot.say(inline('No skillups available'))
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	async def _do_idmenu(self, ctx, m, starting_menu_emoji):
+		id_embed = monsterToEmbed(m, self.get_emojis())
+		evo_embed = monsterToEvoEmbed(m)
+		mats_embed = monsterToEvoMatsEmbed(m)
+		animated = self.check_monster_animated(m.monster_no_jp)
+		pic_embed = monsterToPicEmbed(m, animated=animated)
+		other_info_embed = monsterToOtherInfoEmbed(m)
+		
+		emoji_to_embed = OrderedDict()
+		emoji_to_embed[self.id_emoji] = id_embed
+		emoji_to_embed[self.evo_emoji] = evo_embed
+		emoji_to_embed[self.mats_emoji] = mats_embed
+		emoji_to_embed[self.pic_emoji] = pic_embed
+		
+		pantheon_embed = monsterToPantheonEmbed(m)
+		if pantheon_embed:
+			emoji_to_embed[self.pantheon_emoji] = pantheon_embed
+		
+		skillups_embed = monsterToSkillupsEmbed(m)
+		if skillups_embed:
+			emoji_to_embed[self.skillups_emoji] = skillups_embed
+		
+		emoji_to_embed[self.other_info_emoji] = other_info_embed
+		
+		return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed)
+	
+	async def _do_evolistmenu(self, ctx, sm):
+		monsters = sm.alt_evos
+		monsters.sort(key=lambda m: m.monster_no)
+		
+		emoji_to_embed = OrderedDict()
+		for idx, m in enumerate(monsters):
+			emoji = char_to_emoji(str(idx))
+			emoji_to_embed[emoji] = monsterToEmbed(m, self.get_emojis())
+			if m == sm:
+				starting_menu_emoji = emoji
+		
+		return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed, timeout=60)
+	
+	async def _do_menu(self, ctx, starting_menu_emoji, emoji_to_embed, timeout=30):
+		if starting_menu_emoji not in emoji_to_embed:
+			# Selected menu wasn't generated for this monster
+			return EMBED_NOT_GENERATED
+		
+		remove_emoji = self.menu.emoji['no']
+		emoji_to_embed[remove_emoji] = self.menu.reaction_delete_message
+		
+		try:
+			result_msg, result_embed = await self.menu.custom_menu(ctx, emoji_to_embed, starting_menu_emoji,
+																   timeout=timeout)
+			if result_msg and result_embed:
+				# Message is finished but not deleted, clear the footer
+				result_embed.set_footer(text=discord.Embed.Empty)
+				await self.bot.edit_message(result_msg, embed=result_embed)
+		except Exception as ex:
+			print('Menu failure', ex)
+	
+	@commands.command(pass_context=True, aliases=['img'])
+	async def pic(self, ctx, *, query: str):
+		"""Monster info (full image tab)"""
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			await self._do_idmenu(ctx, m, self.pic_emoji)
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(pass_context=True, aliases=['stats'])
+	async def otherinfo(self, ctx, *, query: str):
+		"""Monster info (misc info tab)"""
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			await self._do_idmenu(ctx, m, self.other_info_emoji)
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(pass_context=True)
+	async def lookup(self, ctx, *, query: str):
+		"""Short info results for a monster query"""
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			embed = monsterToHeaderEmbed(m)
+			await self.bot.say(embed=embed)
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(pass_context=True)
+	async def evolist(self, ctx, *, query):
+		"""Monster info (for all monsters in the evo tree)"""
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			await self._do_evolistmenu(ctx, m)
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(pass_context=True, aliases=['leaders', 'leaderskills', 'ls'])
+	async def leaderskill(self, ctx, left_query: str, right_query: str = None, *, bad=None):
+		"""Display the multiplier and leaderskills for two monsters
 
-        if not dataIO.is_valid_json(self.historic_lookups_file_path_id2):
-            print("Creating empty historic_lookups_id2.json...")
-            dataIO.save_json(self.historic_lookups_file_path_id2, {})
-
-        self.historic_lookups = dataIO.load_json(self.historic_lookups_file_path)
-        self.historic_lookups_id2 = dataIO.load_json(self.historic_lookups_file_path_id2)
-    
-    def __unload(self):
-        # Manually nulling out database because the GC for cogs seems to be pretty shitty
-        self.index_all = padguide2.empty_index()
-        self.index_na = padguide2.empty_index()
-        self.historic_lookups = {}
-        self.historic_lookups_id2 = {}
-    
-    async def reload_nicknames(self):
-        await self.bot.wait_until_ready()
-        while self == self.bot.get_cog('PadInfo'):
-            try:
-                await self.refresh_index()
-                print('Done refreshing PadInfo')
-            except Exception as ex:
-                print("reload padinfo loop caught exception " + str(ex))
-                traceback.print_exc()
-            
-            await asyncio.sleep(60 * 60 * 1)
-    
-    async def refresh_index(self):
-        """Refresh the monster indexes."""
-        pg_cog = self.bot.get_cog('PadGuide2')
-        await pg_cog.wait_until_ready()
-        self.index_all = pg_cog.create_index()
-        self.index_na = pg_cog.create_index(lambda m: m.on_na)
-    
-    def get_monster_by_no(self, monster_no: int):
-        pg_cog = self.bot.get_cog('PadGuide2')
-        return pg_cog.get_monster_by_no(monster_no)
-    
-    @commands.command(pass_context=True)
-    async def skillrotation(self, ctx, server: str = 'NA'):
-        """Print the current rotating skillups for a server (NA/JP)"""
-        server = normalizeServer(server)
-        if server not in ['NA', 'JP']:
-            await self.bot.say(inline('Supported servers are NA, JP'))
-            return
-        
-        pg_cog = self.bot.get_cog('PadGuide2')
-        monsters = pg_cog.database.rotating_skillups(server)
-        
-        for page in pagify(monsters_to_rotation_list(monsters, server, self.index_all)):
-            await self.bot.say(box(page))
-    
-    @commands.command(pass_context=True)
-    async def jpname(self, ctx, *, query: str):
-        """Print the Japanese name of a monster"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self.bot.say(monsterToHeader(m))
-            await self.bot.say(box(m.name_jp))
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-    
-    @commands.command(name="id", pass_context=True)
-    async def _do_id_all(self, ctx, *, query: str):
-        """Monster info (main tab)"""
-        await self._do_id(ctx, query)
-    
-    @commands.command(name="idna", pass_context=True)
-    async def _do_id_na(self, ctx, *, query: str):
-        """Monster info (limited to NA monsters ONLY)"""
-        await self._do_id(ctx, query, na_only=True)
-    
-    async def _do_id(self, ctx, query: str, na_only=False):
-        m, err, debug_info = self.findMonster(query, na_only=na_only)
-        if m is not None:
-            await self._do_idmenu(ctx, m, self.id_emoji)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-    
-    @commands.command(name="id2", pass_context=True)
-    async def _do_id2_all(self, ctx, *, query: str):
-        """Monster info (main tab)"""
-        await self._do_id2(ctx, query)
-    
-    @commands.command(name="id2na", pass_context=True)
-    async def _do_id2_na(self, ctx, *, query: str):
-        """Monster info (limited to NA monsters ONLY)"""
-        await self._do_id2(ctx, query, na_only=True)
-    
-    async def _do_id2(self, ctx, query: str, na_only=False):
-        m, err, debug_info = self.findMonster2(query, na_only=na_only)
-        if m is not None:
-            await self._do_idmenu(ctx, m, self.id_emoji)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-    
-    @commands.command(name="evos", pass_context=True)
-    async def evos(self, ctx, *, query: str):
-        """Monster info (evolutions tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self._do_idmenu(ctx, m, self.evo_emoji)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-    
-    @commands.command(name="mats", pass_context=True, aliases=['evomats', 'evomat'])
-    async def evomats(self, ctx, *, query: str):
-        """Monster info (evo materials tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self._do_idmenu(ctx, m, self.mats_emoji)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-    
-    @commands.command(pass_context=True)
-    async def pantheon(self, ctx, *, query: str):
-        """Monster info (pantheon tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            menu = await self._do_idmenu(ctx, m, self.pantheon_emoji)
-            if menu == EMBED_NOT_GENERATED:
-                await self.bot.say(inline('Not a pantheon monster'))
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-    
-    @commands.command(pass_context=True)
-    async def skillups(self, ctx, *, query: str):
-        """Monster info (evolutions tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            menu = await self._do_idmenu(ctx, m, self.skillups_emoji)
-            if menu == EMBED_NOT_GENERATED:
-                await self.bot.say(inline('No skillups available'))
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-    
-    async def _do_idmenu(self, ctx, m, starting_menu_emoji):
-        id_embed = monsterToEmbed(m, self.get_emojis())
-        evo_embed = monsterToEvoEmbed(m)
-        mats_embed = monsterToEvoMatsEmbed(m)
-        animated = self.check_monster_animated(m.monster_no_jp)
-        pic_embed = monsterToPicEmbed(m, animated=animated)
-        other_info_embed = monsterToOtherInfoEmbed(m)
-        
-        emoji_to_embed = OrderedDict()
-        emoji_to_embed[self.id_emoji] = id_embed
-        emoji_to_embed[self.evo_emoji] = evo_embed
-        emoji_to_embed[self.mats_emoji] = mats_embed
-        emoji_to_embed[self.pic_emoji] = pic_embed
-        
-        pantheon_embed = monsterToPantheonEmbed(m)
-        if pantheon_embed:
-            emoji_to_embed[self.pantheon_emoji] = pantheon_embed
-        
-        skillups_embed = monsterToSkillupsEmbed(m)
-        if skillups_embed:
-            emoji_to_embed[self.skillups_emoji] = skillups_embed
-        
-        emoji_to_embed[self.other_info_emoji] = other_info_embed
-        
-        return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed)
-    
-    async def _do_evolistmenu(self, ctx, sm):
-        monsters = sm.alt_evos
-        monsters.sort(key=lambda m: m.monster_no)
-        
-        emoji_to_embed = OrderedDict()
-        for idx, m in enumerate(monsters):
-            emoji = char_to_emoji(str(idx))
-            emoji_to_embed[emoji] = monsterToEmbed(m, self.get_emojis())
-            if m == sm:
-                starting_menu_emoji = emoji
-        
-        return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed, timeout=60)
-    
-    async def _do_menu(self, ctx, starting_menu_emoji, emoji_to_embed, timeout=30):
-        if starting_menu_emoji not in emoji_to_embed:
-            # Selected menu wasn't generated for this monster
-            return EMBED_NOT_GENERATED
-        
-        remove_emoji = self.menu.emoji['no']
-        emoji_to_embed[remove_emoji] = self.menu.reaction_delete_message
-        
-        try:
-            result_msg, result_embed = await self.menu.custom_menu(ctx, emoji_to_embed, starting_menu_emoji,
-                                                                   timeout=timeout)
-            if result_msg and result_embed:
-                # Message is finished but not deleted, clear the footer
-                result_embed.set_footer(text=discord.Embed.Empty)
-                await self.bot.edit_message(result_msg, embed=result_embed)
-        except Exception as ex:
-            print('Menu failure', ex)
-    
-    @commands.command(pass_context=True, aliases=['img'])
-    async def pic(self, ctx, *, query: str):
-        """Monster info (full image tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self._do_idmenu(ctx, m, self.pic_emoji)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-    
-    @commands.command(pass_context=True, aliases=['stats'])
-    async def otherinfo(self, ctx, *, query: str):
-        """Monster info (misc info tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self._do_idmenu(ctx, m, self.other_info_emoji)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-    
-    @commands.command(pass_context=True)
-    async def lookup(self, ctx, *, query: str):
-        """Short info results for a monster query"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            embed = monsterToHeaderEmbed(m)
-            await self.bot.say(embed=embed)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-    
-    @commands.command(pass_context=True)
-    async def evolist(self, ctx, *, query):
-        """Monster info (for all monsters in the evo tree)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self._do_evolistmenu(ctx, m)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-    
-    @commands.command(pass_context=True, aliases=['leaders', 'leaderskills', 'ls'])
-    async def leaderskill(self, ctx, left_query: str, right_query: str = None, *, bad=None):
-        """Display the multiplier and leaderskills for two monsters
-
-        If either your left or right query contains spaces, wrap in quotes.
-        e.g.: ^leaderskill "r sonia" "b sonia"
-        """
-        if bad:
-            await self.bot.say(inline('Too many inputs. Try wrapping your queries in quotes.'))
-            return
-        
-        # Handle a very specific failure case, user typing something like "uuvo ragdra"
-        if ' ' not in left_query and right_query is not None and ' ' not in right_query and bad is None:
-            combined_query = left_query + ' ' + right_query
-            nm, err, debug_info = self._findMonster(combined_query)
-            if nm and left_query in nm.prefixes:
-                left_query = combined_query
-                right_query = None
-        
-        left_m, left_err, _ = self.findMonster(left_query)
-        if right_query:
-            right_m, right_err, _ = self.findMonster(right_query)
-        else:
-            right_m, right_err, = left_m, left_err
-        
-        err_msg = '{} query failed to match a monster: [ {} ]. If your query is multiple words, wrap it in quotes.'
-        if left_err:
-            await self.bot.say(inline(err_msg.format('Left', left_query)))
-            return
-        if right_err:
-            await self.bot.say(inline(err_msg.format('Right', right_query)))
-            return
-        
-        emoji_to_embed = OrderedDict()
-        emoji_to_embed[self.ls_emoji] = monstersToLsEmbed(left_m, right_m)
-        emoji_to_embed[self.left_emoji] = monsterToEmbed(left_m, self.get_emojis())
-        emoji_to_embed[self.right_emoji] = monsterToEmbed(right_m, self.get_emojis())
-        
-        await self._do_menu(ctx, self.ls_emoji, emoji_to_embed)
-    
-    @commands.command(name="helpid", pass_context=True, aliases=['helppic', 'helpimg'])
-    async def _helpid(self, ctx):
-        """Whispers you info on how to craft monster queries for ^id"""
-        await self.bot.whisper(box(HELP_MSG))
-    
-    @commands.command(pass_context=True)
-    async def padsay(self, ctx, server, *, query: str = None):
-        """Speak the voice line of a monster into your current chat"""
-        voice = ctx.message.author.voice
-        channel = voice.voice_channel
-        if channel is None:
-            await self.bot.say(inline('You must be in a voice channel to use this command'))
-            return
-        
-        speech_cog = self.bot.get_cog('Speech')
-        if not speech_cog:
-            await self.bot.say(inline('Speech seems to be offline'))
-            return
-        
-        if server.lower() not in ['na', 'jp']:
-            query = server + ' ' + (query or '')
-            server = 'na'
-        query = query.strip().lower()
-        
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            base_dir = '/home/tactical0retreat/pad_data/voices/fixed'
-            voice_file = os.path.join(base_dir, server, '{}.wav'.format(m.monster_no_na))
-            header = '{} ({})'.format(monsterToHeader(m), server)
-            if not os.path.exists(voice_file):
-                await self.bot.say(inline('Could not find voice for ' + header))
-                return
-            await self.bot.say('Speaking for ' + header)
-            await speech_cog.play_path(channel, voice_file)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-    
-    @commands.group(pass_context=True)
-    @checks.is_owner()
-    async def padinfo(self, ctx):
-        """PAD info management"""
-        if ctx.invoked_subcommand is None:
-            await send_cmd_help(ctx)
-    
-    @padinfo.command(pass_context=True)
-    @checks.is_owner()
-    async def setemojiservers(self, ctx, *, emoji_servers=''):
-        """Set the emoji servers by ID (csv)"""
-        self.settings.emojiServers().clear()
-        if emoji_servers:
-            self.settings.setEmojiServers(emoji_servers.split(','))
-        await self.bot.say(inline('Set {} servers'.format(len(self.settings.emojiServers()))))
-    
-    def get_emojis(self):
-        server_ids = self.settings.emojiServers()
-        return [e for s in self.bot.servers if s.id in server_ids for e in s.emojis]
-    
-    def makeFailureMsg(self, err):
-        msg = 'Lookup failed: {}.\n'.format(err)
-        msg += 'Try one of <id>, <name>, [argbld]/[rgbld] <name>. Unexpected results? Use ^helpid for more info.'
-        return box(msg)
-    
-    def findMonster(self, query, na_only=False):
-        query = rmdiacritics(query)
-        nm, err, debug_info = self._findMonster(query, na_only)
-        
-        monster_no = nm.monster_no if nm else -1
-        self.historic_lookups[query] = monster_no
-        dataIO.save_json(self.historic_lookups_file_path, self.historic_lookups)
-        
-        m = self.get_monster_by_no(nm.monster_no) if nm else None
-        
-        return m, err, debug_info
-    
-    def _findMonster(self, query, na_only=False):
-        monster_index = self.index_na if na_only else self.index_all
-        return monster_index.find_monster(query)
-    
-    def findMonster2(self, query, na_only=False):
-        query = rmdiacritics(query)
-        nm, err, debug_info = self._findMonster2(query, na_only)
-        
-        monster_no = nm.monster_no if nm else -1
-        self.historic_lookups_id2[query] = monster_no
-        dataIO.save_json(self.historic_lookups_file_path_id2, self.historic_lookups_id2)
-        
-        m = self.get_monster_by_no(nm.monster_no) if nm else None
-        
-        return m, err, debug_info
-    
-    def _findMonster2(self, query, na_only=False):
-        monster_index = self.index_na if na_only else self.index_all
-        return monster_index.find_monster2(query)
-    
-    def map_awakenings_text(self, m):
-        """Exported for use in other cogs"""
-        return _map_awakenings_text(m)
-    
-    @padinfo.command(pass_context=True)
-    @checks.is_owner()
-    async def setanimationdir(self, ctx, *, animation_dir=''):
-        """Set a directory containing animated images"""
-        self.settings.setAnimationDir(animation_dir)
-        await self.bot.say(inline('Done'))
-    
-    def check_monster_animated(self, monster_id: int):
-        if not self.settings.animationDir():
-            return False
-        
-        try:
-            animated_ids = set()
-            for f in os.listdir(self.settings.animationDir()):
-                f = f.replace('.mp4', '')
-                if f.isdigit() and int(f) == monster_id:
-                    return True
-        except:
-            pass
-        
-        return False
+		If either your left or right query contains spaces, wrap in quotes.
+		e.g.: ^leaderskill "r sonia" "b sonia"
+		"""
+		if bad:
+			await self.bot.say(inline('Too many inputs. Try wrapping your queries in quotes.'))
+			return
+		
+		# Handle a very specific failure case, user typing something like "uuvo ragdra"
+		if ' ' not in left_query and right_query is not None and ' ' not in right_query and bad is None:
+			combined_query = left_query + ' ' + right_query
+			nm, err, debug_info = self._findMonster(combined_query)
+			if nm and left_query in nm.prefixes:
+				left_query = combined_query
+				right_query = None
+		
+		left_m, left_err, _ = self.findMonster(left_query)
+		if right_query:
+			right_m, right_err, _ = self.findMonster(right_query)
+		else:
+			right_m, right_err, = left_m, left_err
+		
+		err_msg = '{} query failed to match a monster: [ {} ]. If your query is multiple words, wrap it in quotes.'
+		if left_err:
+			await self.bot.say(inline(err_msg.format('Left', left_query)))
+			return
+		if right_err:
+			await self.bot.say(inline(err_msg.format('Right', right_query)))
+			return
+		
+		emoji_to_embed = OrderedDict()
+		emoji_to_embed[self.ls_emoji] = monstersToLsEmbed(left_m, right_m)
+		emoji_to_embed[self.left_emoji] = monsterToEmbed(left_m, self.get_emojis())
+		emoji_to_embed[self.right_emoji] = monsterToEmbed(right_m, self.get_emojis())
+		
+		await self._do_menu(ctx, self.ls_emoji, emoji_to_embed)
+	
+	@commands.command(name="helpid", pass_context=True, aliases=['helppic', 'helpimg'])
+	async def _helpid(self, ctx):
+		"""Whispers you info on how to craft monster queries for ^id"""
+		await self.bot.whisper(box(HELP_MSG))
+	
+	@commands.command(pass_context=True)
+	async def padsay(self, ctx, server, *, query: str = None):
+		"""Speak the voice line of a monster into your current chat"""
+		voice = ctx.message.author.voice
+		channel = voice.voice_channel
+		if channel is None:
+			await self.bot.say(inline('You must be in a voice channel to use this command'))
+			return
+		
+		speech_cog = self.bot.get_cog('Speech')
+		if not speech_cog:
+			await self.bot.say(inline('Speech seems to be offline'))
+			return
+		
+		if server.lower() not in ['na', 'jp']:
+			query = server + ' ' + (query or '')
+			server = 'na'
+		query = query.strip().lower()
+		
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			base_dir = '/home/tactical0retreat/pad_data/voices/fixed'
+			voice_file = os.path.join(base_dir, server, '{}.wav'.format(m.monster_no_na))
+			header = '{} ({})'.format(monsterToHeader(m), server)
+			if not os.path.exists(voice_file):
+				await self.bot.say(inline('Could not find voice for ' + header))
+				return
+			await self.bot.say('Speaking for ' + header)
+			await speech_cog.play_path(channel, voice_file)
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.group(pass_context=True)
+	@checks.is_owner()
+	async def padinfo(self, ctx):
+		"""PAD info management"""
+		if ctx.invoked_subcommand is None:
+			await send_cmd_help(ctx)
+	
+	@padinfo.command(pass_context=True)
+	@checks.is_owner()
+	async def setemojiservers(self, ctx, *, emoji_servers=''):
+		"""Set the emoji servers by ID (csv)"""
+		self.settings.emojiServers().clear()
+		if emoji_servers:
+			self.settings.setEmojiServers(emoji_servers.split(','))
+		await self.bot.say(inline('Set {} servers'.format(len(self.settings.emojiServers()))))
+	
+	def get_emojis(self):
+		server_ids = self.settings.emojiServers()
+		return [e for s in self.bot.servers if s.id in server_ids for e in s.emojis]
+	
+	def makeFailureMsg(self, err):
+		msg = 'Lookup failed: {}.\n'.format(err)
+		msg += 'Try one of <id>, <name>, [argbld]/[rgbld] <name>. Unexpected results? Use ^helpid for more info.'
+		return box(msg)
+	
+	def findMonster(self, query, na_only=False):
+		query = rmdiacritics(query)
+		nm, err, debug_info = self._findMonster(query, na_only)
+		
+		monster_no = nm.monster_no if nm else -1
+		self.historic_lookups[query] = monster_no
+		dataIO.save_json(self.historic_lookups_file_path, self.historic_lookups)
+		
+		m = self.get_monster_by_no(nm.monster_no) if nm else None
+		
+		return m, err, debug_info
+	
+	def _findMonster(self, query, na_only=False):
+		monster_index = self.index_na if na_only else self.index_all
+		return monster_index.find_monster(query)
+	
+	def findMonster2(self, query, na_only=False):
+		query = rmdiacritics(query)
+		nm, err, debug_info = self._findMonster2(query, na_only)
+		
+		monster_no = nm.monster_no if nm else -1
+		self.historic_lookups_id2[query] = monster_no
+		dataIO.save_json(self.historic_lookups_file_path_id2, self.historic_lookups_id2)
+		
+		m = self.get_monster_by_no(nm.monster_no) if nm else None
+		
+		return m, err, debug_info
+	
+	def _findMonster2(self, query, na_only=False):
+		monster_index = self.index_na if na_only else self.index_all
+		return monster_index.find_monster2(query)
+	
+	def map_awakenings_text(self, m):
+		"""Exported for use in other cogs"""
+		return _map_awakenings_text(m)
+	
+	@padinfo.command(pass_context=True)
+	@checks.is_owner()
+	async def setanimationdir(self, ctx, *, animation_dir=''):
+		"""Set a directory containing animated images"""
+		self.settings.setAnimationDir(animation_dir)
+		await self.bot.say(inline('Done'))
+	
+	def check_monster_animated(self, monster_id: int):
+		if not self.settings.animationDir():
+			return False
+		
+		try:
+			animated_ids = set()
+			for f in os.listdir(self.settings.animationDir()):
+				f = f.replace('.mp4', '')
+				if f.isdigit() and int(f) == monster_id:
+					return True
+		except:
+			pass
+		
+		return False
 
 
 def setup(bot):
-    print('padinfo bot setup')
-    n = PadInfo(bot)
-    bot.add_cog(n)
-    bot.loop.create_task(n.reload_nicknames())
-    print('done adding padinfo bot')
+	print('padinfo bot setup')
+	n = PadInfo(bot)
+	bot.add_cog(n)
+	bot.loop.create_task(n.reload_nicknames())
+	print('done adding padinfo bot')
 
 
 class PadInfoSettings(CogSettings):
-    def make_default_settings(self):
-        config = {
-            'animation_dir': '',
-        }
-        return config
-    
-    def emojiServers(self):
-        key = 'emoji_servers'
-        if key not in self.bot_settings:
-            self.bot_settings[key] = []
-        return self.bot_settings[key]
-    
-    def setEmojiServers(self, emoji_servers):
-        es = self.emojiServers()
-        es.clear()
-        es.extend(emoji_servers)
-        self.save_settings()
-    
-    def animationDir(self):
-        return self.bot_settings['animation_dir']
-    
-    def setAnimationDir(self, animation_dir):
-        self.bot_settings['animation_dir'] = animation_dir
-        self.save_settings()
+	def make_default_settings(self):
+		config = {
+			'animation_dir': '',
+		}
+		return config
+	
+	def emojiServers(self):
+		key = 'emoji_servers'
+		if key not in self.bot_settings:
+			self.bot_settings[key] = []
+		return self.bot_settings[key]
+	
+	def setEmojiServers(self, emoji_servers):
+		es = self.emojiServers()
+		es.clear()
+		es.extend(emoji_servers)
+		self.save_settings()
+	
+	def animationDir(self):
+		return self.bot_settings['animation_dir']
+	
+	def setAnimationDir(self, animation_dir):
+		self.bot_settings['animation_dir'] = animation_dir
+		self.save_settings()
 
 
 def monsterToHeader(m: padguide2.PgMonster, link=False):
-    msg = 'No. {} {}'.format(m.monster_no_na, m.name_na)
-    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
+	msg = 'No. {} {}'.format(m.monster_no_na, m.name_na)
+	return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
 
 
 def monsterToJpSuffix(m: padguide2.PgMonster):
-    suffix = ""
-    if m.roma_subname:
-        suffix += ' [{}]'.format(m.roma_subname)
-    if not m.on_na:
-        suffix += ' (JP only)'
-    return suffix
+	suffix = ""
+	if m.roma_subname:
+		suffix += ' [{}]'.format(m.roma_subname)
+	if not m.on_na:
+		suffix += ' (JP only)'
+	return suffix
 
 
 def monsterToLongHeader(m: padguide2.PgMonster, link=False):
-    msg = monsterToHeader(m) + monsterToJpSuffix(m)
-    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
+	msg = monsterToHeader(m) + monsterToJpSuffix(m)
+	return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
 
 
 def monsterToLongHeaderWithAttr(m: padguide2.PgMonster, link=False):
-    header = 'No. {} {} {}'.format(
-        m.monster_no_na,
-        "({}{})".format(attr_prefix_map[m.attr1], "/" +
-                                                  attr_prefix_map[m.attr2] if m.attr2 else ""),
-        m.name_na)
-    msg = header + monsterToJpSuffix(m)
-    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
+	header = 'No. {} {} {}'.format(
+		m.monster_no_na,
+		"({}{})".format(attr_prefix_map[m.attr1], "/" +
+												  attr_prefix_map[m.attr2] if m.attr2 else ""),
+		m.name_na)
+	msg = header + monsterToJpSuffix(m)
+	return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
 
 
 def monsterToEvoText(m: padguide2.PgMonster):
-    output = monsterToLongHeader(m)
-    for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
-        output += "\n\t- {}".format(monsterToLongHeader(ae))
-    return output
+	output = monsterToLongHeader(m)
+	for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
+		output += "\n\t- {}".format(monsterToLongHeader(ae))
+	return output
 
 
 def monsterToThumbnailUrl(m: padguide2.PgMonster):
-    return get_portrait_url(m)
+	return get_portrait_url(m)
 
 
 def monsterToBaseEmbed(m: padguide2.PgMonster):
-    header = monsterToLongHeader(m)
-    embed = discord.Embed()
-    embed.set_thumbnail(url=monsterToThumbnailUrl(m))
-    embed.title = header
-    embed.url = get_pdx_url(m)
-    embed.set_footer(text='Requester may click the reactions below to switch tabs')
-    return embed
+	header = monsterToLongHeader(m)
+	embed = discord.Embed()
+	embed.set_thumbnail(url=monsterToThumbnailUrl(m))
+	embed.title = header
+	embed.url = get_pdx_url(m)
+	embed.set_footer(text='Requester may click the reactions below to switch tabs')
+	return embed
 
 
 def monsterToEvoEmbed(m: padguide2.PgMonster):
-    embed = monsterToBaseEmbed(m)
-    
-    if not len(m.alt_evos):
-        embed.description = 'No alternate evos'
-        return embed
-    
-    field_name = '{} alternate evos'.format(len(m.alt_evos))
-    field_data = ''
-    for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
-        field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
-    
-    embed.add_field(name=field_name, value=field_data)
-    
-    return embed
+	embed = monsterToBaseEmbed(m)
+	
+	if not len(m.alt_evos):
+		embed.description = 'No alternate evos'
+		return embed
+	
+	field_name = '{} alternate evos'.format(len(m.alt_evos))
+	field_data = ''
+	for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
+		field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
+	
+	embed.add_field(name=field_name, value=field_data)
+	
+	return embed
 
 
 def monsterToEvoMatsEmbed(m: padguide2.PgMonster):
-    embed = monsterToBaseEmbed(m)
-    
-    mats_for_evo_size = len(m.mats_for_evo)
-    material_of_size = len(m.material_of)
-    
-    field_name = 'Evo materials'
-    field_data = ''
-    if mats_for_evo_size:
-        for ae in m.mats_for_evo:
-            field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
-    else:
-        field_data = 'None'
-    embed.add_field(name=field_name, value=field_data)
-    
-    if not material_of_size:
-        return embed
-    
-    field_name = 'Material for'
-    field_data = ''
-    if material_of_size > 5:
-        field_data = '{} monsters'.format(material_of_size)
-    else:
-        item_count = min(material_of_size, 5)
-        for ae in sorted(m.material_of, key=lambda x: x.monster_no_na, reverse=True)[:item_count]:
-            field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
-    embed.add_field(name=field_name, value=field_data)
-    
-    return embed
+	embed = monsterToBaseEmbed(m)
+	
+	mats_for_evo_size = len(m.mats_for_evo)
+	material_of_size = len(m.material_of)
+	
+	field_name = 'Evo materials'
+	field_data = ''
+	if mats_for_evo_size:
+		for ae in m.mats_for_evo:
+			field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
+	else:
+		field_data = 'None'
+	embed.add_field(name=field_name, value=field_data)
+	
+	if not material_of_size:
+		return embed
+	
+	field_name = 'Material for'
+	field_data = ''
+	if material_of_size > 5:
+		field_data = '{} monsters'.format(material_of_size)
+	else:
+		item_count = min(material_of_size, 5)
+		for ae in sorted(m.material_of, key=lambda x: x.monster_no_na, reverse=True)[:item_count]:
+			field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
+	embed.add_field(name=field_name, value=field_data)
+	
+	return embed
 
 
 def monsterToPantheonEmbed(m: padguide2.PgMonster):
-    full_pantheon = m.series.monsters
-    pantheon_list = list(filter(lambda x: x.evo_from is None, full_pantheon))
-    if len(pantheon_list) == 0 or len(pantheon_list) > 6:
-        return None
-    
-    embed = monsterToBaseEmbed(m)
-    
-    field_name = 'Pantheon: ' + m.series.name
-    field_data = ''
-    for monster in sorted(pantheon_list, key=lambda x: x.monster_no_na):
-        field_data += '\n' + monsterToHeader(monster, link=True)
-    embed.add_field(name=field_name, value=field_data)
-    
-    return embed
+	full_pantheon = m.series.monsters
+	pantheon_list = list(filter(lambda x: x.evo_from is None, full_pantheon))
+	if len(pantheon_list) == 0 or len(pantheon_list) > 6:
+		return None
+	
+	embed = monsterToBaseEmbed(m)
+	
+	field_name = 'Pantheon: ' + m.series.name
+	field_data = ''
+	for monster in sorted(pantheon_list, key=lambda x: x.monster_no_na):
+		field_data += '\n' + monsterToHeader(monster, link=True)
+	embed.add_field(name=field_name, value=field_data)
+	
+	return embed
 
 
 def monsterToSkillupsEmbed(m: padguide2.PgMonster):
-    skillups_list = m.active_skill.monsters_with_active if m.active_skill else []
-    skillups_list = list(filter(lambda m: m.sell_mp < 3000, skillups_list))
-    server_skillups = m.active_skill.server_skillups if m.active_skill else []
-    
-    if len(skillups_list) + len(server_skillups) == 0:
-        return None
-    
-    embed = monsterToBaseEmbed(m)
-    
-    skillups_to_skip = []
-    for server, skillup in server_skillups.items():
-        skillup_header = 'Skillup in ' + server
-        skillup_body = monsterToHeader(skillup, link=True)
-        embed.add_field(name=skillup_header, value=skillup_body)
-        skillups_to_skip.append(skillup.monster_no_na)
-    
-    field_name = 'Skillups'
-    field_data = ''
-    
-    # Prevent huge skillup lists
-    if len(skillups_list) > 8:
-        field_data = '({} skillups omitted)'.format(len(skillups_list) - 8)
-        skillups_list = skillups_list[0:8]
-    
-    for monster in sorted(skillups_list, key=lambda x: x.monster_no_na):
-        if monster.monster_no_na in skillups_to_skip:
-            continue
-        field_data += '\n' + monsterToHeader(monster, link=True)
-    
-    if len(field_data.strip()):
-        embed.add_field(name=field_name, value=field_data)
-    
-    return embed
+	skillups_list = m.active_skill.monsters_with_active if m.active_skill else []
+	skillups_list = list(filter(lambda m: m.sell_mp < 3000, skillups_list))
+	server_skillups = m.active_skill.server_skillups if m.active_skill else []
+	
+	if len(skillups_list) + len(server_skillups) == 0:
+		return None
+	
+	embed = monsterToBaseEmbed(m)
+	
+	skillups_to_skip = []
+	for server, skillup in server_skillups.items():
+		skillup_header = 'Skillup in ' + server
+		skillup_body = monsterToHeader(skillup, link=True)
+		embed.add_field(name=skillup_header, value=skillup_body)
+		skillups_to_skip.append(skillup.monster_no_na)
+	
+	field_name = 'Skillups'
+	field_data = ''
+	
+	# Prevent huge skillup lists
+	if len(skillups_list) > 8:
+		field_data = '({} skillups omitted)'.format(len(skillups_list) - 8)
+		skillups_list = skillups_list[0:8]
+	
+	for monster in sorted(skillups_list, key=lambda x: x.monster_no_na):
+		if monster.monster_no_na in skillups_to_skip:
+			continue
+		field_data += '\n' + monsterToHeader(monster, link=True)
+	
+	if len(field_data.strip()):
+		embed.add_field(name=field_name, value=field_data)
+	
+	return embed
 
 
 def monsterToPicUrl(m: padguide2.PgMonster):
-    return get_pic_url(m)
+	return get_pic_url(m)
 
 
 def monsterToPicEmbed(m: padguide2.PgMonster, animated=False):
-    embed = monsterToBaseEmbed(m)
-    url = monsterToPicUrl(m)
-    embed.set_image(url=url)
-    # Clear the thumbnail, don't need it on pic
-    embed.set_thumbnail(url='')
-    if animated:
-        description = '[{}]({}) –– [{}]({})'.format(
-            'HQ (MP4)', monsterToVideoUrl(m), 'LQ (GIF)', monsterToGifUrl(m))
-        embed.add_field(name='Animated links', value=description)
-    
-    return embed
+	embed = monsterToBaseEmbed(m)
+	url = monsterToPicUrl(m)
+	embed.set_image(url=url)
+	# Clear the thumbnail, don't need it on pic
+	embed.set_thumbnail(url='')
+	if animated:
+		description = '[{}]({}) –– [{}]({})'.format(
+			'HQ (MP4)', monsterToVideoUrl(m), 'LQ (GIF)', monsterToGifUrl(m))
+		embed.add_field(name='Animated links', value=description)
+	
+	return embed
 
 
 def monsterToVideoUrl(m: padguide2.PgMonster):
-    return VIDEO_TEMPLATE.format(m.monster_no_jp)
+	return VIDEO_TEMPLATE.format(m.monster_no_jp)
 
 
 def monsterToGifUrl(m: padguide2.PgMonster):
-    return GIF_TEMPLATE.format(m.monster_no_jp)
+	return GIF_TEMPLATE.format(m.monster_no_jp)
 
 
 def monsterToGifEmbed(m: padguide2.PgMonster):
-    embed = monsterToBaseEmbed(m)
-    url = monsterToGifUrl(m)
-    embed.set_image(url=url)
-    # Clear the thumbnail, don't need it on pic
-    embed.set_thumbnail(url='')
-    return embed
+	embed = monsterToBaseEmbed(m)
+	url = monsterToGifUrl(m)
+	embed.set_image(url=url)
+	# Clear the thumbnail, don't need it on pic
+	embed.set_thumbnail(url='')
+	return embed
 
 
 def monstersToLsEmbed(left_m: padguide2.PgMonster, right_m: padguide2.PgMonster):
-    lhp, latk, lrcv, lresist = left_m.leader_skill_data.get_data()
-    rhp, ratk, rrcv, rresist = right_m.leader_skill_data.get_data()
-    multiplier_text = createMultiplierText(lhp, latk, lrcv, lresist, rhp, ratk, rrcv, rresist)
-    
-    embed = discord.Embed()
-    embed.title = 'Multiplier [{}]\n\n'.format(multiplier_text)
-    description = ''
-    description += '\n**{}**\n{}'.format(
-        monsterToHeader(left_m, link=True),
-        left_m.leader_skill.desc if left_m.leader_skill else 'None/Missing')
-    description += '\n**{}**\n{}'.format(
-        monsterToHeader(right_m, link=True),
-        right_m.leader_skill.desc if right_m.leader_skill else 'None/Missing')
-    embed.description = description
-    
-    return embed
+	lhp, latk, lrcv, lresist = left_m.leader_skill_data.get_data()
+	rhp, ratk, rrcv, rresist = right_m.leader_skill_data.get_data()
+	multiplier_text = createMultiplierText(lhp, latk, lrcv, lresist, rhp, ratk, rrcv, rresist)
+	
+	embed = discord.Embed()
+	embed.title = 'Multiplier [{}]\n\n'.format(multiplier_text)
+	description = ''
+	description += '\n**{}**\n{}'.format(
+		monsterToHeader(left_m, link=True),
+		left_m.leader_skill.desc if left_m.leader_skill else 'None/Missing')
+	description += '\n**{}**\n{}'.format(
+		monsterToHeader(right_m, link=True),
+		right_m.leader_skill.desc if right_m.leader_skill else 'None/Missing')
+	embed.description = description
+	
+	return embed
 
 
 def monsterToHeaderEmbed(m: padguide2.PgMonster):
-    header = monsterToLongHeader(m, link=True)
-    embed = discord.Embed()
-    embed.description = header
-    return embed
+	header = monsterToLongHeader(m, link=True)
+	embed = discord.Embed()
+	embed.description = header
+	return embed
 
 
 def monsterToTypeString(m: padguide2.PgMonster):
-    output = m.type1
-    if m.type2:
-        output += '/' + m.type2
-    if m.type3:
-        output += '/' + m.type3
-    return output
+	output = m.type1
+	if m.type2:
+		output += '/' + m.type2
+	if m.type3:
+		output += '/' + m.type3
+	return output
 
 
 def monsterToAcquireString(m: padguide2.PgMonster):
-    acquire_text = None
-    if m.farmable and not m.mp_evo:
-        # Some MP shop monsters 'drop' in PADR
-        acquire_text = 'Farmable'
-    elif m.farmable_evo and not m.mp_evo:
-        acquire_text = 'Farmable Evo'
-    elif m.in_pem:
-        acquire_text = 'In PEM'
-    elif m.pem_evo:
-        acquire_text = 'PEM Evo'
-    elif m.in_rem:
-        acquire_text = 'In REM'
-    elif m.rem_evo:
-        acquire_text = 'REM Evo'
-    elif m.in_mpshop:
-        acquire_text = 'MP Shop'
-    elif m.mp_evo:
-        acquire_text = 'MP Shop Evo'
-    return acquire_text
+	acquire_text = None
+	if m.farmable and not m.mp_evo:
+		# Some MP shop monsters 'drop' in PADR
+		acquire_text = 'Farmable'
+	elif m.farmable_evo and not m.mp_evo:
+		acquire_text = 'Farmable Evo'
+	elif m.in_pem:
+		acquire_text = 'In PEM'
+	elif m.pem_evo:
+		acquire_text = 'PEM Evo'
+	elif m.in_rem:
+		acquire_text = 'In REM'
+	elif m.rem_evo:
+		acquire_text = 'REM Evo'
+	elif m.in_mpshop:
+		acquire_text = 'MP Shop'
+	elif m.mp_evo:
+		acquire_text = 'MP Shop Evo'
+	return acquire_text
 
 
 def match_emoji(emoji_list, name):
-    for e in emoji_list:
-        if e.name == name:
-            return e
-    return None
+	for e in emoji_list:
+		if e.name == name:
+			return e
+	return None
 
 
 def monsterToEmbed(m: padguide2.PgMonster, emoji_list):
-    embed = monsterToBaseEmbed(m)
-    
-    info_row_1 = monsterToTypeString(m)
-    acquire_text = monsterToAcquireString(m)
-    
-    info_row_2 = '**Rarity** {}\n**Cost** {}'.format(m.rarity, m.cost)
-    if acquire_text:
-        info_row_2 += '\n**{}**'.format(acquire_text)
-    if m.is_inheritable:
-        info_row_2 += '\n**Inheritable**'
-    else:
-        info_row_2 += '\n**Not inheritable**'
-    
-    embed.add_field(name=info_row_1, value=info_row_2)
-    
-    if m.limitbreak_stats and m.limitbreak_stats > 1:
-        def lb(x):
-            return int(round(m.limitbreak_stats * x))
-        
-        stats_row_1 = 'Weighted {} | LB {}'.format(m.weighted_stats, lb(m.weighted_stats))
-        stats_row_2 = '**HP** {} ({})\n**ATK** {} ({})\n**RCV** {} ({})'.format(
-            m.hp, lb(m.hp), m.atk, lb(m.atk), m.rcv, lb(m.rcv))
-    else:
-        stats_row_1 = 'Weighted {}'.format(m.weighted_stats)
-        stats_row_2 = '**HP** {}\n**ATK** {}\n**RCV** {}'.format(m.hp, m.atk, m.rcv)
-    embed.add_field(name=stats_row_1, value=stats_row_2)
-    
-    awakenings_row = ''
-    for idx, a in enumerate(m.awakenings):
-        a = a.get_name()
-        mapped_awakening = AWAKENING_NAME_MAP_RPAD.get(a, a)
-        mapped_awakening = match_emoji(emoji_list, mapped_awakening)
-        
-        if mapped_awakening is None:
-            mapped_awakening = AWAKENING_NAME_MAP.get(a, a)
-        
-        # Wrap superawakenings to the next line
-        if len(m.awakenings) - idx == m.superawakening_count:
-            awakenings_row += '\n{}'.format(mapped_awakening)
-        else:
-            awakenings_row += ' {}'.format(mapped_awakening)
-    
-    awakenings_row = awakenings_row.strip()
-    
-    if not len(awakenings_row):
-        awakenings_row = 'No Awakenings'
-    
-    killers = compute_killers(m.type1, m.type2, m.type3)
-    killers_row = '**Available Killers:** {}'.format(' '.join(killers))
-    
-    embed.description = '{}\n{}'.format(awakenings_row, killers_row)
-    
-    if len(m.server_actives) >= 2:
-        for server, active in m.server_actives.items():
-            active_header = '({} Server) Active Skill ({} -> {})'.format(server,
-                                                                         active.turn_max, active.turn_min)
-            active_body = active.desc
-            embed.add_field(name=active_header, value=active_body, inline=False)
-    else:
-        active_header = 'Active Skill'
-        active_body = 'None/Missing'
-        if m.active_skill:
-            active_header = 'Active Skill ({} -> {})'.format(m.active_skill.turn_max,
-                                                             m.active_skill.turn_min)
-            active_body = m.active_skill.desc
-        embed.add_field(name=active_header, value=active_body, inline=False)
-    
-    ls_row = m.leader_skill.desc if m.leader_skill else 'None/Missing'
-    ls_header = 'Leader Skill'
-    if m.leader_skill_data:
-        hp, atk, rcv, resist = m.leader_skill_data.get_data()
-        multiplier_text = createMultiplierText(hp, atk, rcv, resist)
-        ls_header += " [ {} ]".format(multiplier_text)
-    embed.add_field(name=ls_header, value=ls_row, inline=False)
-    
-    return embed
+	embed = monsterToBaseEmbed(m)
+	
+	info_row_1 = monsterToTypeString(m)
+	acquire_text = monsterToAcquireString(m)
+	
+	info_row_2 = '**Rarity** {}\n**Cost** {}'.format(m.rarity, m.cost)
+	if acquire_text:
+		info_row_2 += '\n**{}**'.format(acquire_text)
+	if m.is_inheritable:
+		info_row_2 += '\n**Inheritable**'
+	else:
+		info_row_2 += '\n**Not inheritable**'
+	
+	embed.add_field(name=info_row_1, value=info_row_2)
+	
+	if m.limitbreak_stats and m.limitbreak_stats > 1:
+		def lb(x):
+			return int(round(m.limitbreak_stats * x))
+		
+		stats_row_1 = 'Weighted {} | LB {}'.format(m.weighted_stats, lb(m.weighted_stats))
+		stats_row_2 = '**HP** {} ({})\n**ATK** {} ({})\n**RCV** {} ({})'.format(
+			m.hp, lb(m.hp), m.atk, lb(m.atk), m.rcv, lb(m.rcv))
+	else:
+		stats_row_1 = 'Weighted {}'.format(m.weighted_stats)
+		stats_row_2 = '**HP** {}\n**ATK** {}\n**RCV** {}'.format(m.hp, m.atk, m.rcv)
+	embed.add_field(name=stats_row_1, value=stats_row_2)
+	
+	awakenings_row = ''
+	for idx, a in enumerate(m.awakenings):
+		a = a.get_name()
+		mapped_awakening = AWAKENING_NAME_MAP_RPAD.get(a, a)
+		mapped_awakening = match_emoji(emoji_list, mapped_awakening)
+		
+		if mapped_awakening is None:
+			mapped_awakening = AWAKENING_NAME_MAP.get(a, a)
+		
+		# Wrap superawakenings to the next line
+		if len(m.awakenings) - idx == m.superawakening_count:
+			awakenings_row += '\n{}'.format(mapped_awakening)
+		else:
+			awakenings_row += ' {}'.format(mapped_awakening)
+	
+	awakenings_row = awakenings_row.strip()
+	
+	if not len(awakenings_row):
+		awakenings_row = 'No Awakenings'
+	
+	killers = compute_killers(m.type1, m.type2, m.type3)
+	killers_row = '**Available Killers:** {}'.format(' '.join(killers))
+	
+	embed.description = '{}\n{}'.format(awakenings_row, killers_row)
+	
+	if len(m.server_actives) >= 2:
+		for server, active in m.server_actives.items():
+			active_header = '({} Server) Active Skill ({} -> {})'.format(server,
+																		 active.turn_max, active.turn_min)
+			active_body = active.desc
+			embed.add_field(name=active_header, value=active_body, inline=False)
+	else:
+		active_header = 'Active Skill'
+		active_body = 'None/Missing'
+		if m.active_skill:
+			active_header = 'Active Skill ({} -> {})'.format(m.active_skill.turn_max,
+															 m.active_skill.turn_min)
+			active_body = m.active_skill.desc
+		embed.add_field(name=active_header, value=active_body, inline=False)
+	
+	ls_row = m.leader_skill.desc if m.leader_skill else 'None/Missing'
+	ls_header = 'Leader Skill'
+	if m.leader_skill_data:
+		hp, atk, rcv, resist = m.leader_skill_data.get_data()
+		multiplier_text = createMultiplierText(hp, atk, rcv, resist)
+		ls_header += " [ {} ]".format(multiplier_text)
+	embed.add_field(name=ls_header, value=ls_row, inline=False)
+	
+	return embed
 
 
 def monsterToOtherInfoEmbed(m: padguide2.PgMonster):
-    embed = monsterToBaseEmbed(m)
-    # Clear the thumbnail, takes up too much space
-    embed.set_thumbnail(url='')
-    
-    stat_cols = ['', 'Max', 'M297', 'Inh', 'I297']
-    tbl = prettytable.PrettyTable(stat_cols)
-    tbl.hrules = prettytable.NONE
-    tbl.vrules = prettytable.NONE
-    tbl.align = "r"
-    hhp = m.hp + 99 * 10
-    hatk = m.atk + 99 * 5
-    hrcv = m.rcv + 99 * 3
-    tbl.add_row(['HP', m.hp, hhp, int(m.hp * .1), int(hhp * .1)])
-    tbl.add_row(['ATK', m.atk, hatk, int(m.atk * .05), int(hatk * .05)])
-    tbl.add_row(['RCV', m.rcv, hrcv, int(m.rcv * .15), int(hrcv * .15)])
-    
-    body_text = box(tbl.get_string())
-    
-    search_text = YT_SEARCH_TEMPLATE.format(m.name_jp)
-    skyozora_text = SKYOZORA_TEMPLATE.format(m.monster_no_jp)
-    body_text += "\n**JP Name**: {} | [YouTube]({}) | [Skyozora]({})".format(
-        m.name_jp, search_text, skyozora_text)
-    
-    if m.history_us:
-        body_text += '\n**History:** {}'.format(m.history_us)
-    
-    body_text += '\n**Series:** {}'.format(m.series.name)
-    body_text += '\n**Sell MP:** {:,}'.format(m.sell_mp)
-    if m.buy_mp > 0:
-        body_text += "  **Buy MP:** {:,}".format(m.buy_mp)
-    
-    if m.exp < 1000000:
-        xp_text = '{:,}'.format(m.exp)
-    else:
-        xp_text = '{:.1f}'.format(m.exp / 1000000).rstrip('0').rstrip('.') + 'M'
-    body_text += '\n**XP to Max:** {}'.format(xp_text)
-    body_text += '  **Max Level:**: {}'.format(m.max_level)
-    body_text += '\n**Rarity:** {} **Cost:** {}'.format(m.rarity, m.cost)
-    
-    if m.translated_jp_name:
-        body_text += '\n**Google Translated:** {}'.format(m.translated_jp_name)
-    
-    embed.description = body_text
-    
-    return embed
+	embed = monsterToBaseEmbed(m)
+	# Clear the thumbnail, takes up too much space
+	embed.set_thumbnail(url='')
+	
+	stat_cols = ['', 'Max', 'M297', 'Inh', 'I297']
+	tbl = prettytable.PrettyTable(stat_cols)
+	tbl.hrules = prettytable.NONE
+	tbl.vrules = prettytable.NONE
+	tbl.align = "r"
+	hhp = m.hp + 99 * 10
+	hatk = m.atk + 99 * 5
+	hrcv = m.rcv + 99 * 3
+	tbl.add_row(['HP', m.hp, hhp, int(m.hp * .1), int(hhp * .1)])
+	tbl.add_row(['ATK', m.atk, hatk, int(m.atk * .05), int(hatk * .05)])
+	tbl.add_row(['RCV', m.rcv, hrcv, int(m.rcv * .15), int(hrcv * .15)])
+	
+	body_text = box(tbl.get_string())
+	
+	search_text = YT_SEARCH_TEMPLATE.format(m.name_jp)
+	skyozora_text = SKYOZORA_TEMPLATE.format(m.monster_no_jp)
+	body_text += "\n**JP Name**: {} | [YouTube]({}) | [Skyozora]({})".format(
+		m.name_jp, search_text, skyozora_text)
+	
+	if m.history_us:
+		body_text += '\n**History:** {}'.format(m.history_us)
+	
+	body_text += '\n**Series:** {}'.format(m.series.name)
+	body_text += '\n**Sell MP:** {:,}'.format(m.sell_mp)
+	if m.buy_mp > 0:
+		body_text += "  **Buy MP:** {:,}".format(m.buy_mp)
+	
+	if m.exp < 1000000:
+		xp_text = '{:,}'.format(m.exp)
+	else:
+		xp_text = '{:.1f}'.format(m.exp / 1000000).rstrip('0').rstrip('.') + 'M'
+	body_text += '\n**XP to Max:** {}'.format(xp_text)
+	body_text += '  **Max Level:**: {}'.format(m.max_level)
+	body_text += '\n**Rarity:** {} **Cost:** {}'.format(m.rarity, m.cost)
+	
+	if m.translated_jp_name:
+		body_text += '\n**Google Translated:** {}'.format(m.translated_jp_name)
+	
+	embed.description = body_text
+	
+	return embed
 
 
 def monsters_to_rotation_list(monster_list, server: str, index_all: padguide2.MonsterIndex):
-    # Shorten some of the longer names
-    name_remap = {
-        'Extreme King Metal Tamadra': 'Fat Tama',
-        'Extreme King Metal Dragon': 'EKMD',
-        'Ancient Green Sacred Mask': 'Green Mask',
-        'Ancient Blue Sacred Mask': 'Blue Mask',
-    }
-    ignore_monsters = [
-        'Ancient Draggie Knight',
-    ]
-    
-    monster_list.sort(key=lambda m: m.monster_no, reverse=True)
-    next_rotation_date = None
-    for m in monster_list:
-        if server in m.future_skillup_rotation:
-            next_rotation_date = m.future_skillup_rotation[server].rotation_date_str
-            break
-    
-    cols = [server + ' Skillup', 'Current']
-    if next_rotation_date:
-        cols.append(next_rotation_date)
-    tbl = prettytable.PrettyTable(cols)
-    tbl.hrules = prettytable.HEADER
-    tbl.vrules = prettytable.NONE
-    tbl.align = "l"
-    
-    def cell_name(m: padguide2.PgMonster):
-        nm = index_all.monster_no_to_named_monster[m.monster_no]
-        name = nm.group_computed_basename.title()
-        return name_remap.get(name, name)
-    
-    for m in monster_list:
-        skill = m.server_actives[server]
-        
-        sm = skill.monsters_with_active
-        
-        # Since some newer monsters like jewel of creation are being used as
-        # skillups, exclude them from the list of skillup targets.
-        
-        def is_bad_type(m):
-            return set(['enhance', 'evolve', 'vendor']).intersection(set(m.types))
-        
-        sm = max(sm, key=lambda x: (not is_bad_type(x), x.monster_no))
-        
-        skillup_name = cell_name(m)
-        if skillup_name in ignore_monsters:
-            continue
-        row = [skillup_name, cell_name(sm)]
-        if next_rotation_date:
-            if server in m.future_skillup_rotation:
-                next_skill = m.future_skillup_rotation[server].skill
-                nm = max(next_skill.monsters_with_active, key=lambda x: x.monster_no)
-                row.append(cell_name(nm))
-            else:
-                row.append('')
-        tbl.add_row(row)
-    
-    return tbl.get_string()
+	# Shorten some of the longer names
+	name_remap = {
+		'Extreme King Metal Tamadra': 'Fat Tama',
+		'Extreme King Metal Dragon': 'EKMD',
+		'Ancient Green Sacred Mask': 'Green Mask',
+		'Ancient Blue Sacred Mask': 'Blue Mask',
+	}
+	ignore_monsters = [
+		'Ancient Draggie Knight',
+	]
+	
+	monster_list.sort(key=lambda m: m.monster_no, reverse=True)
+	next_rotation_date = None
+	for m in monster_list:
+		if server in m.future_skillup_rotation:
+			next_rotation_date = m.future_skillup_rotation[server].rotation_date_str
+			break
+	
+	cols = [server + ' Skillup', 'Current']
+	if next_rotation_date:
+		cols.append(next_rotation_date)
+	tbl = prettytable.PrettyTable(cols)
+	tbl.hrules = prettytable.HEADER
+	tbl.vrules = prettytable.NONE
+	tbl.align = "l"
+	
+	def cell_name(m: padguide2.PgMonster):
+		nm = index_all.monster_no_to_named_monster[m.monster_no]
+		name = nm.group_computed_basename.title()
+		return name_remap.get(name, name)
+	
+	for m in monster_list:
+		skill = m.server_actives[server]
+		
+		sm = skill.monsters_with_active
+		
+		# Since some newer monsters like jewel of creation are being used as
+		# skillups, exclude them from the list of skillup targets.
+		
+		def is_bad_type(m):
+			return set(['enhance', 'evolve', 'vendor']).intersection(set(m.types))
+		
+		sm = max(sm, key=lambda x: (not is_bad_type(x), x.monster_no))
+		
+		skillup_name = cell_name(m)
+		if skillup_name in ignore_monsters:
+			continue
+		row = [skillup_name, cell_name(sm)]
+		if next_rotation_date:
+			if server in m.future_skillup_rotation:
+				next_skill = m.future_skillup_rotation[server].skill
+				nm = max(next_skill.monsters_with_active, key=lambda x: x.monster_no)
+				row.append(cell_name(nm))
+			else:
+				row.append('')
+		tbl.add_row(row)
+	
+	return tbl.get_string()
 
 
 AWAKENING_NAME_MAP_RPAD = {
-    'Enhanced Attack': 'boost_atk',
-    'Enhanced HP': 'boost_hp',
-    'Enhanced Heal': 'boost_rcv',
-    
-    'Enhanced Team HP': 'teamboost_hp',
-    'Enhanced Team Attack': 'teamboost_atk',
-    'Enhanced Team RCV': 'teamboost_rcv',
-    
-    'God Killer': 'killer_god',
-    'Dragon Killer': 'killer_dragon',
-    'Devil Killer': 'killer_devil',
-    'Machine Killer': 'killer_machine',
-    'Balanced Killer': 'killer_balance',
-    'Attacker Killer': 'killer_attacker',
-    
-    'Physical Killer': 'killer_physical',
-    'Healer Killer': 'killer_healer',
-    'Evolve Material Killer': 'killer_evomat',
-    'Awaken Material Killer': 'killer_awoken',
-    'Enhance Material Killer': 'killer_enhancemat',
-    'Vendor Material Killer': 'killer_vendor',
-    
-    'Auto-Recover': 'misc_autoheal',
-    'Recover Bind': 'misc_bindclear',
-    'Enhanced Combo': 'misc_comboboost',
-    'Super Enhanced Combo': 'misc_super_comboboost',
-    'Guard Break': 'misc_guardbreak',
-    'Multi Boost': 'misc_multiboost',
-    'Additional Attack': 'misc_extraattack',
-    'Skill Boost': 'misc_sb',
-    'Extend Time': 'misc_te',
-    'Two-Pronged Attack': 'misc_tpa',
-    'Damage Void Shield Penetration': 'misc_voidshield',
-    'Awoken Assist': 'misc_assist',
-    
-    'Enhanced Fire Orbs': 'oe_fire',
-    'Enhanced Water Orbs': 'oe_water',
-    'Enhanced Wood Orbs': 'oe_wood',
-    'Enhanced Light Orbs': 'oe_light',
-    'Enhanced Dark Orbs': 'oe_dark',
-    'Enhanced Heal Orbs': 'oe_heart',
-    
-    'Reduce Fire Damage': 'reduce_fire',
-    'Reduce Water Damage': 'reduce_water',
-    'Reduce Wood Damage': 'reduce_wood',
-    'Reduce Light Damage': 'reduce_light',
-    'Reduce Dark Damage': 'reduce_dark',
-    
-    'Resistance-Bind': 'res_bind',
-    'Resistance-Dark': 'res_blind',
-    'Resistance-Jammers': 'res_jammer',
-    'Resistance-Poison': 'res_poison',
-    'Resistance-Skill Bind': 'res_skillbind',
-    
-    'Enhanced Fire Att.': 'row_fire',
-    'Enhanced Water Att.': 'row_water',
-    'Enhanced Wood Att.': 'row_wood',
-    'Enhanced Light Att.': 'row_light',
-    'Enhanced Dark Att.': 'row_dark',
-    
-    'Skill Charge': 'misc_skillcharge',
-    'Super Additional Attack': 'misc_super_extraattack',
-    'Resistance-Bind＋': 'res_bind_super',
-    'Extend Time＋': 'misc_te_super',
-    'Resistance-Cloud': 'res_cloud',
-    'Resistance-Board Restrict': 'res_seal',
-    'Skill Boost＋': 'misc_sb_super',
-    'L-Shape Attack': 'l_attack',
-    'L-Shape Damage Reduction': 'l_shield',
-    'Enhance when HP is below 50%': 'attack_boost_low',
-    'Enhance when HP is above 80%': 'attack_boost_high',
-    'Combo Orb': 'orb_combo',
-    'Skill Voice': 'misc_voice',
-    'Dungeon Bonus': 'misc_dungeonbonus',
+	'Enhanced Attack': 'boost_atk',
+	'Enhanced HP': 'boost_hp',
+	'Enhanced Heal': 'boost_rcv',
+	
+	'Enhanced Team HP': 'teamboost_hp',
+	'Enhanced Team Attack': 'teamboost_atk',
+	'Enhanced Team RCV': 'teamboost_rcv',
+	
+	'God Killer': 'killer_god',
+	'Dragon Killer': 'killer_dragon',
+	'Devil Killer': 'killer_devil',
+	'Machine Killer': 'killer_machine',
+	'Balanced Killer': 'killer_balance',
+	'Attacker Killer': 'killer_attacker',
+	
+	'Physical Killer': 'killer_physical',
+	'Healer Killer': 'killer_healer',
+	'Evolve Material Killer': 'killer_evomat',
+	'Awaken Material Killer': 'killer_awoken',
+	'Enhance Material Killer': 'killer_enhancemat',
+	'Vendor Material Killer': 'killer_vendor',
+	
+	'Auto-Recover': 'misc_autoheal',
+	'Recover Bind': 'misc_bindclear',
+	'Enhanced Combo': 'misc_comboboost',
+	'Super Enhanced Combo': 'misc_super_comboboost',
+	'Guard Break': 'misc_guardbreak',
+	'Multi Boost': 'misc_multiboost',
+	'Additional Attack': 'misc_extraattack',
+	'Skill Boost': 'misc_sb',
+	'Extend Time': 'misc_te',
+	'Two-Pronged Attack': 'misc_tpa',
+	'Damage Void Shield Penetration': 'misc_voidshield',
+	'Awoken Assist': 'misc_assist',
+	
+	'Enhanced Fire Orbs': 'oe_fire',
+	'Enhanced Water Orbs': 'oe_water',
+	'Enhanced Wood Orbs': 'oe_wood',
+	'Enhanced Light Orbs': 'oe_light',
+	'Enhanced Dark Orbs': 'oe_dark',
+	'Enhanced Heal Orbs': 'oe_heart',
+	
+	'Reduce Fire Damage': 'reduce_fire',
+	'Reduce Water Damage': 'reduce_water',
+	'Reduce Wood Damage': 'reduce_wood',
+	'Reduce Light Damage': 'reduce_light',
+	'Reduce Dark Damage': 'reduce_dark',
+	
+	'Resistance-Bind': 'res_bind',
+	'Resistance-Dark': 'res_blind',
+	'Resistance-Jammers': 'res_jammer',
+	'Resistance-Poison': 'res_poison',
+	'Resistance-Skill Bind': 'res_skillbind',
+	
+	'Enhanced Fire Att.': 'row_fire',
+	'Enhanced Water Att.': 'row_water',
+	'Enhanced Wood Att.': 'row_wood',
+	'Enhanced Light Att.': 'row_light',
+	'Enhanced Dark Att.': 'row_dark',
+	
+	'Skill Charge': 'misc_skillcharge',
+	'Super Additional Attack': 'misc_super_extraattack',
+	'Resistance-Bind＋': 'res_bind_super',
+	'Extend Time＋': 'misc_te_super',
+	'Resistance-Cloud': 'res_cloud',
+	'Resistance-Board Restrict': 'res_seal',
+	'Skill Boost＋': 'misc_sb_super',
+	'L-Shape Attack': 'l_attack',
+	'L-Shape Damage Reduction': 'l_shield',
+	'Enhance when HP is below 50%': 'attack_boost_low',
+	'Enhance when HP is above 80%': 'attack_boost_high',
+	'Combo Orb': 'orb_combo',
+	'Skill Voice': 'misc_voice',
+	'Dungeon Bonus': 'misc_dungeonbonus',
 }
 
 AWAKENING_NAME_MAP = {
-    'Enhanced Fire Orbs': 'R-OE',
-    'Enhanced Water Orbs': 'B-OE',
-    'Enhanced Wood Orbs': 'G-OE',
-    'Enhanced Light Orbs': 'L-OE',
-    'Enhanced Dark Orbs': 'D-OE',
-    'Enhanced Heal Orbs': 'H-OE',
-    
-    'Enhanced Fire Att.': 'R-RE',
-    'Enhanced Water Att.': 'B-RE',
-    'Enhanced Wood Att.': 'G-RE',
-    'Enhanced Light Att.': 'L-RE',
-    'Enhanced Dark Att.': 'D-RE',
-    
-    'Enhanced HP': 'HP',
-    'Enhanced Attack': 'ATK',
-    'Enhanced Heal': 'RCV',
-    
-    'Enhanced Team HP': 'TEAM-HP',
-    'Enhanced Team Attack': 'TEAM-ATK',
-    'Enhanced Team RCV': 'TEAM-RCV',
-    
-    'Auto-Recover': 'AUTO-RECOVER',
-    'Skill Boost': 'SB',
-    'Resistance-Skill Bind': 'SBR',
-    'Two-Pronged Attack': 'TPA',
-    'Multi Boost': 'MULTI-BOOST',
-    'Recover Bind': 'RCV-BIND',
-    'Extend Time': 'TE',
-    'Enhanced Combo': 'COMBO-BOOST',
-    'Guard Break': 'DEF-BREAK',
-    'Additional Attack': 'EXTRA-ATK',
-    'Damage Void Shield Penetration': 'VOID-BREAK',
-    'Awoken Assist': 'ASSIST',
-    
-    'Resistance-Bind': 'RES-BIND',
-    'Resistance-Dark': 'RES-BLIND',
-    'Resistance-Poison': 'RES-POISON',
-    'Resistance-Jammers': 'RES-JAMMER',
-    
-    'Reduce Fire Damage': 'R-RES',
-    'Reduce Water Damage': 'B-RES',
-    'Reduce Wood Damage': 'G-RES',
-    'Reduce Light Damage': 'L-RES',
-    'Reduce Dark Damage': 'D-RES',
-    
-    'Healer Killer': 'K-HEALER',
-    'Machine Killer': 'K-MACHINE',
-    'Dragon Killer': 'K-DRAGON',
-    'Attacker Killer': 'K-ATTACKER',
-    'Physical Killer': 'K-PHYSICAL',
-    'God Killer': 'K-GOD',
-    'Devil Killer': 'K-DEVIL',
-    'Balance Killer': 'K-BALANCE',
+	'Enhanced Fire Orbs': 'R-OE',
+	'Enhanced Water Orbs': 'B-OE',
+	'Enhanced Wood Orbs': 'G-OE',
+	'Enhanced Light Orbs': 'L-OE',
+	'Enhanced Dark Orbs': 'D-OE',
+	'Enhanced Heal Orbs': 'H-OE',
+	
+	'Enhanced Fire Att.': 'R-RE',
+	'Enhanced Water Att.': 'B-RE',
+	'Enhanced Wood Att.': 'G-RE',
+	'Enhanced Light Att.': 'L-RE',
+	'Enhanced Dark Att.': 'D-RE',
+	
+	'Enhanced HP': 'HP',
+	'Enhanced Attack': 'ATK',
+	'Enhanced Heal': 'RCV',
+	
+	'Enhanced Team HP': 'TEAM-HP',
+	'Enhanced Team Attack': 'TEAM-ATK',
+	'Enhanced Team RCV': 'TEAM-RCV',
+	
+	'Auto-Recover': 'AUTO-RECOVER',
+	'Skill Boost': 'SB',
+	'Resistance-Skill Bind': 'SBR',
+	'Two-Pronged Attack': 'TPA',
+	'Multi Boost': 'MULTI-BOOST',
+	'Recover Bind': 'RCV-BIND',
+	'Extend Time': 'TE',
+	'Enhanced Combo': 'COMBO-BOOST',
+	'Guard Break': 'DEF-BREAK',
+	'Additional Attack': 'EXTRA-ATK',
+	'Damage Void Shield Penetration': 'VOID-BREAK',
+	'Awoken Assist': 'ASSIST',
+	
+	'Resistance-Bind': 'RES-BIND',
+	'Resistance-Dark': 'RES-BLIND',
+	'Resistance-Poison': 'RES-POISON',
+	'Resistance-Jammers': 'RES-JAMMER',
+	
+	'Reduce Fire Damage': 'R-RES',
+	'Reduce Water Damage': 'B-RES',
+	'Reduce Wood Damage': 'G-RES',
+	'Reduce Light Damage': 'L-RES',
+	'Reduce Dark Damage': 'D-RES',
+	
+	'Healer Killer': 'K-HEALER',
+	'Machine Killer': 'K-MACHINE',
+	'Dragon Killer': 'K-DRAGON',
+	'Attacker Killer': 'K-ATTACKER',
+	'Physical Killer': 'K-PHYSICAL',
+	'God Killer': 'K-GOD',
+	'Devil Killer': 'K-DEVIL',
+	'Balance Killer': 'K-BALANCE',
 }
 
 
 def createMultiplierText(hp1, atk1, rcv1, resist1, hp2=None, atk2=None, rcv2=None, resist2=None):
-    hp2, atk2, rcv2, resist2 = hp2 or hp1, atk2 or atk1, rcv2 or rcv1, resist2 or resist1
-    
-    def fmtNum(val):
-        return ('{:.2f}').format(val).strip('0').rstrip('.')
-    
-    text = "{}/{}/{}".format(fmtNum(hp1 * hp2), fmtNum(atk1 * atk2), fmtNum(rcv1 * rcv2))
-    if resist1 * resist2 < 1:
-        resist1 = resist1 if resist1 < 1 else 0
-        resist2 = resist2 if resist2 < 1 else 0
-        text += ' Resist {}%'.format(fmtNum(100 * (1 - (1 - resist1) * (1 - resist2))))
-    return text
+	hp2, atk2, rcv2, resist2 = hp2 or hp1, atk2 or atk1, rcv2 or rcv1, resist2 or resist1
+	
+	def fmtNum(val):
+		return ('{:.2f}').format(val).strip('0').rstrip('.')
+	
+	text = "{}/{}/{}".format(fmtNum(hp1 * hp2), fmtNum(atk1 * atk2), fmtNum(rcv1 * rcv2))
+	if resist1 * resist2 < 1:
+		resist1 = resist1 if resist1 < 1 else 0
+		resist2 = resist2 if resist2 < 1 else 0
+		text += ' Resist {}%'.format(fmtNum(100 * (1 - (1 - resist1) * (1 - resist2))))
+	return text
 
 
 def _map_awakenings_text(m: padguide2.PgMonster):
-    awakenings_row = ''
-    unique_awakenings = set(m.awakening_names)
-    for a in unique_awakenings:
-        count = m.awakening_names.count(a)
-        awakenings_row += ' {}x{}'.format(AWAKENING_NAME_MAP.get(a, a), count)
-    awakenings_row = awakenings_row.strip()
-    
-    if not len(awakenings_row):
-        awakenings_row = 'No Awakenings'
-    
-    return awakenings_row
+	awakenings_row = ''
+	unique_awakenings = set(m.awakening_names)
+	for a in unique_awakenings:
+		count = m.awakening_names.count(a)
+		awakenings_row += ' {}x{}'.format(AWAKENING_NAME_MAP.get(a, a), count)
+	awakenings_row = awakenings_row.strip()
+	
+	if not len(awakenings_row):
+		awakenings_row = 'No Awakenings'
+	
+	return awakenings_row
 
 
 # TODO: move to padguide2
 def compute_killers(*types):
-    if 'Balance' in types:
-        return ['Any']
-    killers = set()
-    for t in types:
-        killers.update(type_to_killers_map.get(t, []))
-    return sorted(killers)
+	if 'Balance' in types:
+		return ['Any']
+	killers = set()
+	for t in types:
+		killers.update(type_to_killers_map.get(t, []))
+	return sorted(killers)
 
 
 type_to_killers_map = {
-    'God': ['Devil'],
-    'Devil': ['God'],
-    'Machine': ['God', 'Balance'],
-    'Dragon': ['Machine', 'Healer'],
-    'Physical': ['Machine', 'Healer'],
-    'Attacker': ['Devil', 'Physical'],
-    'Healer': ['Dragon', 'Attacker'],
+	'God': ['Devil'],
+	'Devil': ['God'],
+	'Machine': ['God', 'Balance'],
+	'Dragon': ['Machine', 'Healer'],
+	'Physical': ['Machine', 'Healer'],
+	'Attacker': ['Devil', 'Physical'],
+	'Healer': ['Dragon', 'Attacker'],
 }

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -72,14 +72,14 @@ def get_pic_url(m):
 class PadInfo:
     def __init__(self, bot):
         self.bot = bot
-        
+
         self.settings = PadInfoSettings("padinfo")
-        
+
         self.index_all = padguide2.empty_index()
         self.index_na = padguide2.empty_index()
-        
+
         self.menu = Menu(bot)
-        
+
         # These emojis are the keys into the idmenu submenus
         self.id_emoji = '\N{INFORMATION SOURCE}'
         self.evo_emoji = char_to_emoji('e')
@@ -91,18 +91,18 @@ class PadInfo:
         self.skillups_emoji = '\N{MEAT ON BONE}'
         self.pic_emoji = '\N{FRAME WITH PICTURE}'
         self.other_info_emoji = '\N{SCROLL}'
-        
+
         self.historic_lookups_file_path = "data/padinfo/historic_lookups.json"
         self.historic_lookups_file_path_id2 = "data/padinfo/historic_lookups_id2.json"
-        
+
         if not dataIO.is_valid_json(self.historic_lookups_file_path):
             print("Creating empty historic_lookups.json...")
             dataIO.save_json(self.historic_lookups_file_path, {})
-        
+
         if not dataIO.is_valid_json(self.historic_lookups_file_path_id2):
             print("Creating empty historic_lookups_id2.json...")
             dataIO.save_json(self.historic_lookups_file_path_id2, {})
-        
+
         self.historic_lookups = dataIO.load_json(self.historic_lookups_file_path)
         self.historic_lookups_id2 = dataIO.load_json(self.historic_lookups_file_path_id2)
 
@@ -122,7 +122,7 @@ class PadInfo:
             except Exception as ex:
                 print("reload padinfo loop caught exception " + str(ex))
                 traceback.print_exc()
-            
+
             await asyncio.sleep(60 * 60 * 1)
 
     async def refresh_index(self):
@@ -143,10 +143,10 @@ class PadInfo:
         if server not in ['NA', 'JP']:
             await self.bot.say(inline('Supported servers are NA, JP'))
             return
-        
+
         pg_cog = self.bot.get_cog('PadGuide2')
         monsters = pg_cog.database.rotating_skillups(server)
-        
+
         for page in pagify(monsters_to_rotation_list(monsters, server, self.index_all)):
             await self.bot.say(box(page))
 
@@ -241,46 +241,46 @@ class PadInfo:
         animated = self.check_monster_animated(m.monster_no_jp)
         pic_embed = monsterToPicEmbed(m, animated=animated)
         other_info_embed = monsterToOtherInfoEmbed(m)
-        
+
         emoji_to_embed = OrderedDict()
         emoji_to_embed[self.id_emoji] = id_embed
         emoji_to_embed[self.evo_emoji] = evo_embed
         emoji_to_embed[self.mats_emoji] = mats_embed
         emoji_to_embed[self.pic_emoji] = pic_embed
-        
+
         pantheon_embed = monsterToPantheonEmbed(m)
         if pantheon_embed:
             emoji_to_embed[self.pantheon_emoji] = pantheon_embed
-        
+
         skillups_embed = monsterToSkillupsEmbed(m)
         if skillups_embed:
             emoji_to_embed[self.skillups_emoji] = skillups_embed
-        
+
         emoji_to_embed[self.other_info_emoji] = other_info_embed
-        
+
         return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed)
 
     async def _do_evolistmenu(self, ctx, sm):
         monsters = sm.alt_evos
         monsters.sort(key=lambda m: m.monster_no)
-        
+
         emoji_to_embed = OrderedDict()
         for idx, m in enumerate(monsters):
             emoji = char_to_emoji(str(idx))
             emoji_to_embed[emoji] = monsterToEmbed(m, self.get_emojis())
             if m == sm:
                 starting_menu_emoji = emoji
-        
+
         return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed, timeout=60)
 
     async def _do_menu(self, ctx, starting_menu_emoji, emoji_to_embed, timeout=30):
         if starting_menu_emoji not in emoji_to_embed:
             # Selected menu wasn't generated for this monster
             return EMBED_NOT_GENERATED
-        
+
         remove_emoji = self.menu.emoji['no']
         emoji_to_embed[remove_emoji] = self.menu.reaction_delete_message
-        
+
         try:
             result_msg, result_embed = await self.menu.custom_menu(ctx, emoji_to_embed, starting_menu_emoji,
                                                                    timeout=timeout)
@@ -338,7 +338,7 @@ class PadInfo:
         if bad:
             await self.bot.say(inline('Too many inputs. Try wrapping your queries in quotes.'))
             return
-        
+
         # Handle a very specific failure case, user typing something like "uuvo ragdra"
         if ' ' not in left_query and right_query is not None and ' ' not in right_query and bad is None:
             combined_query = left_query + ' ' + right_query
@@ -346,13 +346,13 @@ class PadInfo:
             if nm and left_query in nm.prefixes:
                 left_query = combined_query
                 right_query = None
-        
+
         left_m, left_err, _ = self.findMonster(left_query)
         if right_query:
             right_m, right_err, _ = self.findMonster(right_query)
         else:
             right_m, right_err, = left_m, left_err
-        
+
         err_msg = '{} query failed to match a monster: [ {} ]. If your query is multiple words, wrap it in quotes.'
         if left_err:
             await self.bot.say(inline(err_msg.format('Left', left_query)))
@@ -360,12 +360,12 @@ class PadInfo:
         if right_err:
             await self.bot.say(inline(err_msg.format('Right', right_query)))
             return
-        
+
         emoji_to_embed = OrderedDict()
         emoji_to_embed[self.ls_emoji] = monstersToLsEmbed(left_m, right_m)
         emoji_to_embed[self.left_emoji] = monsterToEmbed(left_m, self.get_emojis())
         emoji_to_embed[self.right_emoji] = monsterToEmbed(right_m, self.get_emojis())
-        
+
         await self._do_menu(ctx, self.ls_emoji, emoji_to_embed)
 
     @commands.command(name="helpid", pass_context=True, aliases=['helppic', 'helpimg'])
@@ -381,17 +381,17 @@ class PadInfo:
         if channel is None:
             await self.bot.say(inline('You must be in a voice channel to use this command'))
             return
-        
+
         speech_cog = self.bot.get_cog('Speech')
         if not speech_cog:
             await self.bot.say(inline('Speech seems to be offline'))
             return
-        
+
         if server.lower() not in ['na', 'jp']:
             query = server + ' ' + (query or '')
             server = 'na'
         query = query.strip().lower()
-        
+
         m, err, debug_info = self.findMonster(query)
         if m is not None:
             base_dir = '/home/tactical0retreat/pad_data/voices/fixed'
@@ -433,13 +433,13 @@ class PadInfo:
     def findMonster(self, query, na_only=False):
         query = rmdiacritics(query)
         nm, err, debug_info = self._findMonster(query, na_only)
-        
+
         monster_no = nm.monster_no if nm else -1
         self.historic_lookups[query] = monster_no
         dataIO.save_json(self.historic_lookups_file_path, self.historic_lookups)
-        
+
         m = self.get_monster_by_no(nm.monster_no) if nm else None
-        
+
         return m, err, debug_info
 
     def _findMonster(self, query, na_only=False):
@@ -449,13 +449,13 @@ class PadInfo:
     def findMonster2(self, query, na_only=False):
         query = rmdiacritics(query)
         nm, err, debug_info = self._findMonster2(query, na_only)
-        
+
         monster_no = nm.monster_no if nm else -1
         self.historic_lookups_id2[query] = monster_no
         dataIO.save_json(self.historic_lookups_file_path_id2, self.historic_lookups_id2)
-        
+
         m = self.get_monster_by_no(nm.monster_no) if nm else None
-        
+
         return m, err, debug_info
 
     def _findMonster2(self, query, na_only=False):
@@ -476,7 +476,7 @@ class PadInfo:
     def check_monster_animated(self, monster_id: int):
         if not self.settings.animationDir():
             return False
-        
+
         try:
             animated_ids = set()
             for f in os.listdir(self.settings.animationDir()):
@@ -485,7 +485,7 @@ class PadInfo:
                     return True
         except:
             pass
-        
+
         return False
 
 def setup(bot):
@@ -769,7 +769,7 @@ def monsterToEmbed(m: padguide2.PgMonster, emoji_list):
     if m.limitbreak_stats and m.limitbreak_stats > 1:
         def lb(x):
             return int(round(m.limitbreak_stats * x))
-        
+
         stats_row_1 = 'Weighted {} | LB {}'.format(m.weighted_stats, lb(m.weighted_stats))
         stats_row_2 = '**HP** {} ({})\n**ATK** {} ({})\n**RCV** {} ({})'.format(
             m.hp, lb(m.hp), m.atk, lb(m.atk), m.rcv, lb(m.rcv))
@@ -783,10 +783,10 @@ def monsterToEmbed(m: padguide2.PgMonster, emoji_list):
         a = a.get_name()
         mapped_awakening = AWAKENING_NAME_MAP_RPAD.get(a, a)
         mapped_awakening = match_emoji(emoji_list, mapped_awakening)
-        
+
         if mapped_awakening is None:
             mapped_awakening = AWAKENING_NAME_MAP.get(a, a)
-        
+
         # Wrap superawakenings to the next line
         if len(m.awakenings) - idx == m.superawakening_count:
             awakenings_row += '\n{}'.format(mapped_awakening)
@@ -909,17 +909,17 @@ def monsters_to_rotation_list(monster_list, server: str, index_all: padguide2.Mo
 
     for m in monster_list:
         skill = m.server_actives[server]
-        
+
         sm = skill.monsters_with_active
-        
+
         # Since some newer monsters like jewel of creation are being used as
         # skillups, exclude them from the list of skillup targets.
-        
+
         def is_bad_type(m):
             return set(['enhance', 'evolve', 'vendor']).intersection(set(m.types))
-        
+
         sm = max(sm, key=lambda x: (not is_bad_type(x), x.monster_no))
-        
+
         skillup_name = cell_name(m)
         if skillup_name in ignore_monsters:
             continue

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -186,7 +186,7 @@ class PadInfo:
         await self._do_id2(ctx, query, na_only=True)
     
     async def _do_id2(self, ctx, query: str, na_only=False):
-        m, err, debug_info = self.findMonster(query, na_only=na_only)
+        m, err, debug_info = self.findMonster2(query, na_only=na_only)
         if m is not None:
             await self._do_idmenu(ctx, m, self.id_emoji)
         else:

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -55,1060 +55,1060 @@ YT_SEARCH_TEMPLATE = 'https://www.youtube.com/results?search_query={}'
 SKYOZORA_TEMPLATE = 'http://pad.skyozora.com/pets/{}'
 
 def get_pdx_url(m):
-	return INFO_PDX_TEMPLATE.format(rpadutils.get_pdx_id(m))
+    return INFO_PDX_TEMPLATE.format(rpadutils.get_pdx_id(m))
 
 def get_portrait_url(m):
-	if int(m.monster_no) != m.monster_no_na:
-		return RPAD_PORTRAIT_TEMPLATE.format('na', m.monster_no_na)
-	else:
-		return RPAD_PORTRAIT_TEMPLATE.format('jp', m.monster_no_jp)
+    if int(m.monster_no) != m.monster_no_na:
+        return RPAD_PORTRAIT_TEMPLATE.format('na', m.monster_no_na)
+    else:
+        return RPAD_PORTRAIT_TEMPLATE.format('jp', m.monster_no_jp)
 
 def get_pic_url(m):
-	if int(m.monster_no) != m.monster_no_na:
-		return RPAD_PIC_TEMPLATE.format('na', m.monster_no_na)
-	else:
-		return RPAD_PIC_TEMPLATE.format('jp', m.monster_no_jp)
+    if int(m.monster_no) != m.monster_no_na:
+        return RPAD_PIC_TEMPLATE.format('na', m.monster_no_na)
+    else:
+        return RPAD_PIC_TEMPLATE.format('jp', m.monster_no_jp)
 
 class PadInfo:
-	def __init__(self, bot):
-		self.bot = bot
-		
-		self.settings = PadInfoSettings("padinfo")
-		
-		self.index_all = padguide2.empty_index()
-		self.index_na = padguide2.empty_index()
-		
-		self.menu = Menu(bot)
-		
-		# These emojis are the keys into the idmenu submenus
-		self.id_emoji = '\N{INFORMATION SOURCE}'
-		self.evo_emoji = char_to_emoji('e')
-		self.mats_emoji = char_to_emoji('m')
-		self.ls_emoji = '\N{INFORMATION SOURCE}'
-		self.left_emoji = char_to_emoji('l')
-		self.right_emoji = char_to_emoji('r')
-		self.pantheon_emoji = '\N{CLASSICAL BUILDING}'
-		self.skillups_emoji = '\N{MEAT ON BONE}'
-		self.pic_emoji = '\N{FRAME WITH PICTURE}'
-		self.other_info_emoji = '\N{SCROLL}'
-		
-		self.historic_lookups_file_path = "data/padinfo/historic_lookups.json"
-		self.historic_lookups_file_path_id2 = "data/padinfo/historic_lookups_id2.json"
-		
-		if not dataIO.is_valid_json(self.historic_lookups_file_path):
-			print("Creating empty historic_lookups.json...")
-			dataIO.save_json(self.historic_lookups_file_path, {})
-		
-		if not dataIO.is_valid_json(self.historic_lookups_file_path_id2):
-			print("Creating empty historic_lookups_id2.json...")
-			dataIO.save_json(self.historic_lookups_file_path_id2, {})
-		
-		self.historic_lookups = dataIO.load_json(self.historic_lookups_file_path)
-		self.historic_lookups_id2 = dataIO.load_json(self.historic_lookups_file_path_id2)
-	
-	def __unload(self):
-		# Manually nulling out database because the GC for cogs seems to be pretty shitty
-		self.index_all = padguide2.empty_index()
-		self.index_na = padguide2.empty_index()
-		self.historic_lookups = {}
-		self.historic_lookups_id2 = {}
-	
-	async def reload_nicknames(self):
-		await self.bot.wait_until_ready()
-		while self == self.bot.get_cog('PadInfo'):
-			try:
-				await self.refresh_index()
-				print('Done refreshing PadInfo')
-			except Exception as ex:
-				print("reload padinfo loop caught exception " + str(ex))
-				traceback.print_exc()
-			
-			await asyncio.sleep(60 * 60 * 1)
-	
-	async def refresh_index(self):
-		"""Refresh the monster indexes."""
-		pg_cog = self.bot.get_cog('PadGuide2')
-		await pg_cog.wait_until_ready()
-		self.index_all = pg_cog.create_index()
-		self.index_na = pg_cog.create_index(lambda m: m.on_na)
-	
-	def get_monster_by_no(self, monster_no: int):
-		pg_cog = self.bot.get_cog('PadGuide2')
-		return pg_cog.get_monster_by_no(monster_no)
-	
-	@commands.command(pass_context=True)
-	async def skillrotation(self, ctx, server: str = 'NA'):
-		"""Print the current rotating skillups for a server (NA/JP)"""
-		server = normalizeServer(server)
-		if server not in ['NA', 'JP']:
-			await self.bot.say(inline('Supported servers are NA, JP'))
-			return
-		
-		pg_cog = self.bot.get_cog('PadGuide2')
-		monsters = pg_cog.database.rotating_skillups(server)
-		
-		for page in pagify(monsters_to_rotation_list(monsters, server, self.index_all)):
-			await self.bot.say(box(page))
-	
-	@commands.command(pass_context=True)
-	async def jpname(self, ctx, *, query: str):
-		"""Print the Japanese name of a monster"""
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			await self.bot.say(monsterToHeader(m))
-			await self.bot.say(box(m.name_jp))
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(name="id", pass_context=True)
-	async def _do_id_all(self, ctx, *, query: str):
-		"""Monster info (main tab)"""
-		await self._do_id(ctx, query)
-	
-	@commands.command(name="idna", pass_context=True)
-	async def _do_id_na(self, ctx, *, query: str):
-		"""Monster info (limited to NA monsters ONLY)"""
-		await self._do_id(ctx, query, na_only=True)
-	
-	async def _do_id(self, ctx, query: str, na_only=False):
-		m, err, debug_info = self.findMonster(query, na_only=na_only)
-		if m is not None:
-			await self._do_idmenu(ctx, m, self.id_emoji)
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(name="id2", pass_context=True)
-	async def _do_id2_all(self, ctx, *, query: str):
-		"""Monster info (main tab)"""
-		await self._do_id2(ctx, query)
-	
-	@commands.command(name="id2na", pass_context=True)
-	async def _do_id2_na(self, ctx, *, query: str):
-		"""Monster info (limited to NA monsters ONLY)"""
-		await self._do_id2(ctx, query, na_only=True)
-	
-	async def _do_id2(self, ctx, query: str, na_only=False):
-		m, err, debug_info = self.findMonster2(query, na_only=na_only)
-		if m is not None:
-			await self._do_idmenu(ctx, m, self.id_emoji)
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(name="evos", pass_context=True)
-	async def evos(self, ctx, *, query: str):
-		"""Monster info (evolutions tab)"""
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			await self._do_idmenu(ctx, m, self.evo_emoji)
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(name="mats", pass_context=True, aliases=['evomats', 'evomat'])
-	async def evomats(self, ctx, *, query: str):
-		"""Monster info (evo materials tab)"""
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			await self._do_idmenu(ctx, m, self.mats_emoji)
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(pass_context=True)
-	async def pantheon(self, ctx, *, query: str):
-		"""Monster info (pantheon tab)"""
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			menu = await self._do_idmenu(ctx, m, self.pantheon_emoji)
-			if menu == EMBED_NOT_GENERATED:
-				await self.bot.say(inline('Not a pantheon monster'))
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(pass_context=True)
-	async def skillups(self, ctx, *, query: str):
-		"""Monster info (evolutions tab)"""
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			menu = await self._do_idmenu(ctx, m, self.skillups_emoji)
-			if menu == EMBED_NOT_GENERATED:
-				await self.bot.say(inline('No skillups available'))
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	async def _do_idmenu(self, ctx, m, starting_menu_emoji):
-		id_embed = monsterToEmbed(m, self.get_emojis())
-		evo_embed = monsterToEvoEmbed(m)
-		mats_embed = monsterToEvoMatsEmbed(m)
-		animated = self.check_monster_animated(m.monster_no_jp)
-		pic_embed = monsterToPicEmbed(m, animated=animated)
-		other_info_embed = monsterToOtherInfoEmbed(m)
-		
-		emoji_to_embed = OrderedDict()
-		emoji_to_embed[self.id_emoji] = id_embed
-		emoji_to_embed[self.evo_emoji] = evo_embed
-		emoji_to_embed[self.mats_emoji] = mats_embed
-		emoji_to_embed[self.pic_emoji] = pic_embed
-		
-		pantheon_embed = monsterToPantheonEmbed(m)
-		if pantheon_embed:
-			emoji_to_embed[self.pantheon_emoji] = pantheon_embed
-		
-		skillups_embed = monsterToSkillupsEmbed(m)
-		if skillups_embed:
-			emoji_to_embed[self.skillups_emoji] = skillups_embed
-		
-		emoji_to_embed[self.other_info_emoji] = other_info_embed
-		
-		return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed)
-	
-	async def _do_evolistmenu(self, ctx, sm):
-		monsters = sm.alt_evos
-		monsters.sort(key=lambda m: m.monster_no)
-		
-		emoji_to_embed = OrderedDict()
-		for idx, m in enumerate(monsters):
-			emoji = char_to_emoji(str(idx))
-			emoji_to_embed[emoji] = monsterToEmbed(m, self.get_emojis())
-			if m == sm:
-				starting_menu_emoji = emoji
-		
-		return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed, timeout=60)
-	
-	async def _do_menu(self, ctx, starting_menu_emoji, emoji_to_embed, timeout=30):
-		if starting_menu_emoji not in emoji_to_embed:
-			# Selected menu wasn't generated for this monster
-			return EMBED_NOT_GENERATED
-		
-		remove_emoji = self.menu.emoji['no']
-		emoji_to_embed[remove_emoji] = self.menu.reaction_delete_message
-		
-		try:
-			result_msg, result_embed = await self.menu.custom_menu(ctx, emoji_to_embed, starting_menu_emoji,
-																   timeout=timeout)
-			if result_msg and result_embed:
-				# Message is finished but not deleted, clear the footer
-				result_embed.set_footer(text=discord.Embed.Empty)
-				await self.bot.edit_message(result_msg, embed=result_embed)
-		except Exception as ex:
-			print('Menu failure', ex)
-	
-	@commands.command(pass_context=True, aliases=['img'])
-	async def pic(self, ctx, *, query: str):
-		"""Monster info (full image tab)"""
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			await self._do_idmenu(ctx, m, self.pic_emoji)
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(pass_context=True, aliases=['stats'])
-	async def otherinfo(self, ctx, *, query: str):
-		"""Monster info (misc info tab)"""
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			await self._do_idmenu(ctx, m, self.other_info_emoji)
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(pass_context=True)
-	async def lookup(self, ctx, *, query: str):
-		"""Short info results for a monster query"""
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			embed = monsterToHeaderEmbed(m)
-			await self.bot.say(embed=embed)
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(pass_context=True)
-	async def evolist(self, ctx, *, query):
-		"""Monster info (for all monsters in the evo tree)"""
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			await self._do_evolistmenu(ctx, m)
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(pass_context=True, aliases=['leaders', 'leaderskills', 'ls'])
-	async def leaderskill(self, ctx, left_query: str, right_query: str = None, *, bad=None):
-		"""Display the multiplier and leaderskills for two monsters
+    def __init__(self, bot):
+        self.bot = bot
+        
+        self.settings = PadInfoSettings("padinfo")
+        
+        self.index_all = padguide2.empty_index()
+        self.index_na = padguide2.empty_index()
+        
+        self.menu = Menu(bot)
+        
+        # These emojis are the keys into the idmenu submenus
+        self.id_emoji = '\N{INFORMATION SOURCE}'
+        self.evo_emoji = char_to_emoji('e')
+        self.mats_emoji = char_to_emoji('m')
+        self.ls_emoji = '\N{INFORMATION SOURCE}'
+        self.left_emoji = char_to_emoji('l')
+        self.right_emoji = char_to_emoji('r')
+        self.pantheon_emoji = '\N{CLASSICAL BUILDING}'
+        self.skillups_emoji = '\N{MEAT ON BONE}'
+        self.pic_emoji = '\N{FRAME WITH PICTURE}'
+        self.other_info_emoji = '\N{SCROLL}'
+        
+        self.historic_lookups_file_path = "data/padinfo/historic_lookups.json"
+        self.historic_lookups_file_path_id2 = "data/padinfo/historic_lookups_id2.json"
+        
+        if not dataIO.is_valid_json(self.historic_lookups_file_path):
+            print("Creating empty historic_lookups.json...")
+            dataIO.save_json(self.historic_lookups_file_path, {})
+        
+        if not dataIO.is_valid_json(self.historic_lookups_file_path_id2):
+            print("Creating empty historic_lookups_id2.json...")
+            dataIO.save_json(self.historic_lookups_file_path_id2, {})
+        
+        self.historic_lookups = dataIO.load_json(self.historic_lookups_file_path)
+        self.historic_lookups_id2 = dataIO.load_json(self.historic_lookups_file_path_id2)
+    
+    def __unload(self):
+        # Manually nulling out database because the GC for cogs seems to be pretty shitty
+        self.index_all = padguide2.empty_index()
+        self.index_na = padguide2.empty_index()
+        self.historic_lookups = {}
+        self.historic_lookups_id2 = {}
+    
+    async def reload_nicknames(self):
+        await self.bot.wait_until_ready()
+        while self == self.bot.get_cog('PadInfo'):
+            try:
+                await self.refresh_index()
+                print('Done refreshing PadInfo')
+            except Exception as ex:
+                print("reload padinfo loop caught exception " + str(ex))
+                traceback.print_exc()
+            
+            await asyncio.sleep(60 * 60 * 1)
+    
+    async def refresh_index(self):
+        """Refresh the monster indexes."""
+        pg_cog = self.bot.get_cog('PadGuide2')
+        await pg_cog.wait_until_ready()
+        self.index_all = pg_cog.create_index()
+        self.index_na = pg_cog.create_index(lambda m: m.on_na)
+    
+    def get_monster_by_no(self, monster_no: int):
+        pg_cog = self.bot.get_cog('PadGuide2')
+        return pg_cog.get_monster_by_no(monster_no)
+    
+    @commands.command(pass_context=True)
+    async def skillrotation(self, ctx, server: str = 'NA'):
+        """Print the current rotating skillups for a server (NA/JP)"""
+        server = normalizeServer(server)
+        if server not in ['NA', 'JP']:
+            await self.bot.say(inline('Supported servers are NA, JP'))
+            return
+        
+        pg_cog = self.bot.get_cog('PadGuide2')
+        monsters = pg_cog.database.rotating_skillups(server)
+        
+        for page in pagify(monsters_to_rotation_list(monsters, server, self.index_all)):
+            await self.bot.say(box(page))
+    
+    @commands.command(pass_context=True)
+    async def jpname(self, ctx, *, query: str):
+        """Print the Japanese name of a monster"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self.bot.say(monsterToHeader(m))
+            await self.bot.say(box(m.name_jp))
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    @commands.command(name="id", pass_context=True)
+    async def _do_id_all(self, ctx, *, query: str):
+        """Monster info (main tab)"""
+        await self._do_id(ctx, query)
+    
+    @commands.command(name="idna", pass_context=True)
+    async def _do_id_na(self, ctx, *, query: str):
+        """Monster info (limited to NA monsters ONLY)"""
+        await self._do_id(ctx, query, na_only=True)
+    
+    async def _do_id(self, ctx, query: str, na_only=False):
+        m, err, debug_info = self.findMonster(query, na_only=na_only)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.id_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    @commands.command(name="id2", pass_context=True)
+    async def _do_id2_all(self, ctx, *, query: str):
+        """Monster info (main tab)"""
+        await self._do_id2(ctx, query)
+    
+    @commands.command(name="id2na", pass_context=True)
+    async def _do_id2_na(self, ctx, *, query: str):
+        """Monster info (limited to NA monsters ONLY)"""
+        await self._do_id2(ctx, query, na_only=True)
+    
+    async def _do_id2(self, ctx, query: str, na_only=False):
+        m, err, debug_info = self.findMonster2(query, na_only=na_only)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.id_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    @commands.command(name="evos", pass_context=True)
+    async def evos(self, ctx, *, query: str):
+        """Monster info (evolutions tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.evo_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    @commands.command(name="mats", pass_context=True, aliases=['evomats', 'evomat'])
+    async def evomats(self, ctx, *, query: str):
+        """Monster info (evo materials tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.mats_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    @commands.command(pass_context=True)
+    async def pantheon(self, ctx, *, query: str):
+        """Monster info (pantheon tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            menu = await self._do_idmenu(ctx, m, self.pantheon_emoji)
+            if menu == EMBED_NOT_GENERATED:
+                await self.bot.say(inline('Not a pantheon monster'))
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    @commands.command(pass_context=True)
+    async def skillups(self, ctx, *, query: str):
+        """Monster info (evolutions tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            menu = await self._do_idmenu(ctx, m, self.skillups_emoji)
+            if menu == EMBED_NOT_GENERATED:
+                await self.bot.say(inline('No skillups available'))
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    async def _do_idmenu(self, ctx, m, starting_menu_emoji):
+        id_embed = monsterToEmbed(m, self.get_emojis())
+        evo_embed = monsterToEvoEmbed(m)
+        mats_embed = monsterToEvoMatsEmbed(m)
+        animated = self.check_monster_animated(m.monster_no_jp)
+        pic_embed = monsterToPicEmbed(m, animated=animated)
+        other_info_embed = monsterToOtherInfoEmbed(m)
+        
+        emoji_to_embed = OrderedDict()
+        emoji_to_embed[self.id_emoji] = id_embed
+        emoji_to_embed[self.evo_emoji] = evo_embed
+        emoji_to_embed[self.mats_emoji] = mats_embed
+        emoji_to_embed[self.pic_emoji] = pic_embed
+        
+        pantheon_embed = monsterToPantheonEmbed(m)
+        if pantheon_embed:
+            emoji_to_embed[self.pantheon_emoji] = pantheon_embed
+        
+        skillups_embed = monsterToSkillupsEmbed(m)
+        if skillups_embed:
+            emoji_to_embed[self.skillups_emoji] = skillups_embed
+        
+        emoji_to_embed[self.other_info_emoji] = other_info_embed
+        
+        return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed)
+    
+    async def _do_evolistmenu(self, ctx, sm):
+        monsters = sm.alt_evos
+        monsters.sort(key=lambda m: m.monster_no)
+        
+        emoji_to_embed = OrderedDict()
+        for idx, m in enumerate(monsters):
+            emoji = char_to_emoji(str(idx))
+            emoji_to_embed[emoji] = monsterToEmbed(m, self.get_emojis())
+            if m == sm:
+                starting_menu_emoji = emoji
+        
+        return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed, timeout=60)
+    
+    async def _do_menu(self, ctx, starting_menu_emoji, emoji_to_embed, timeout=30):
+        if starting_menu_emoji not in emoji_to_embed:
+            # Selected menu wasn't generated for this monster
+            return EMBED_NOT_GENERATED
+        
+        remove_emoji = self.menu.emoji['no']
+        emoji_to_embed[remove_emoji] = self.menu.reaction_delete_message
+        
+        try:
+            result_msg, result_embed = await self.menu.custom_menu(ctx, emoji_to_embed, starting_menu_emoji,
+                                                                   timeout=timeout)
+            if result_msg and result_embed:
+                # Message is finished but not deleted, clear the footer
+                result_embed.set_footer(text=discord.Embed.Empty)
+                await self.bot.edit_message(result_msg, embed=result_embed)
+        except Exception as ex:
+            print('Menu failure', ex)
+    
+    @commands.command(pass_context=True, aliases=['img'])
+    async def pic(self, ctx, *, query: str):
+        """Monster info (full image tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.pic_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    @commands.command(pass_context=True, aliases=['stats'])
+    async def otherinfo(self, ctx, *, query: str):
+        """Monster info (misc info tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.other_info_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    @commands.command(pass_context=True)
+    async def lookup(self, ctx, *, query: str):
+        """Short info results for a monster query"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            embed = monsterToHeaderEmbed(m)
+            await self.bot.say(embed=embed)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    @commands.command(pass_context=True)
+    async def evolist(self, ctx, *, query):
+        """Monster info (for all monsters in the evo tree)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self._do_evolistmenu(ctx, m)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    @commands.command(pass_context=True, aliases=['leaders', 'leaderskills', 'ls'])
+    async def leaderskill(self, ctx, left_query: str, right_query: str = None, *, bad=None):
+        """Display the multiplier and leaderskills for two monsters
 
         If either your left or right query contains spaces, wrap in quotes.
         e.g.: ^leaderskill "r sonia" "b sonia"
         """
-		if bad:
-			await self.bot.say(inline('Too many inputs. Try wrapping your queries in quotes.'))
-			return
-		
-		# Handle a very specific failure case, user typing something like "uuvo ragdra"
-		if ' ' not in left_query and right_query is not None and ' ' not in right_query and bad is None:
-			combined_query = left_query + ' ' + right_query
-			nm, err, debug_info = self._findMonster(combined_query)
-			if nm and left_query in nm.prefixes:
-				left_query = combined_query
-				right_query = None
-		
-		left_m, left_err, _ = self.findMonster(left_query)
-		if right_query:
-			right_m, right_err, _ = self.findMonster(right_query)
-		else:
-			right_m, right_err, = left_m, left_err
-		
-		err_msg = '{} query failed to match a monster: [ {} ]. If your query is multiple words, wrap it in quotes.'
-		if left_err:
-			await self.bot.say(inline(err_msg.format('Left', left_query)))
-			return
-		if right_err:
-			await self.bot.say(inline(err_msg.format('Right', right_query)))
-			return
-		
-		emoji_to_embed = OrderedDict()
-		emoji_to_embed[self.ls_emoji] = monstersToLsEmbed(left_m, right_m)
-		emoji_to_embed[self.left_emoji] = monsterToEmbed(left_m, self.get_emojis())
-		emoji_to_embed[self.right_emoji] = monsterToEmbed(right_m, self.get_emojis())
-		
-		await self._do_menu(ctx, self.ls_emoji, emoji_to_embed)
-	
-	@commands.command(name="helpid", pass_context=True, aliases=['helppic', 'helpimg'])
-	async def _helpid(self, ctx):
-		"""Whispers you info on how to craft monster queries for ^id"""
-		await self.bot.whisper(box(HELP_MSG))
-	
-	@commands.command(pass_context=True)
-	async def padsay(self, ctx, server, *, query: str = None):
-		"""Speak the voice line of a monster into your current chat"""
-		voice = ctx.message.author.voice
-		channel = voice.voice_channel
-		if channel is None:
-			await self.bot.say(inline('You must be in a voice channel to use this command'))
-			return
-		
-		speech_cog = self.bot.get_cog('Speech')
-		if not speech_cog:
-			await self.bot.say(inline('Speech seems to be offline'))
-			return
-		
-		if server.lower() not in ['na', 'jp']:
-			query = server + ' ' + (query or '')
-			server = 'na'
-		query = query.strip().lower()
-		
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			base_dir = '/home/tactical0retreat/pad_data/voices/fixed'
-			voice_file = os.path.join(base_dir, server, '{}.wav'.format(m.monster_no_na))
-			header = '{} ({})'.format(monsterToHeader(m), server)
-			if not os.path.exists(voice_file):
-				await self.bot.say(inline('Could not find voice for ' + header))
-				return
-			await self.bot.say('Speaking for ' + header)
-			await speech_cog.play_path(channel, voice_file)
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.group(pass_context=True)
-	@checks.is_owner()
-	async def padinfo(self, ctx):
-		"""PAD info management"""
-		if ctx.invoked_subcommand is None:
-			await send_cmd_help(ctx)
-	
-	@padinfo.command(pass_context=True)
-	@checks.is_owner()
-	async def setemojiservers(self, ctx, *, emoji_servers=''):
-		"""Set the emoji servers by ID (csv)"""
-		self.settings.emojiServers().clear()
-		if emoji_servers:
-			self.settings.setEmojiServers(emoji_servers.split(','))
-		await self.bot.say(inline('Set {} servers'.format(len(self.settings.emojiServers()))))
-	
-	def get_emojis(self):
-		server_ids = self.settings.emojiServers()
-		return [e for s in self.bot.servers if s.id in server_ids for e in s.emojis]
-	
-	def makeFailureMsg(self, err):
-		msg = 'Lookup failed: {}.\n'.format(err)
-		msg += 'Try one of <id>, <name>, [argbld]/[rgbld] <name>. Unexpected results? Use ^helpid for more info.'
-		return box(msg)
-	
-	def findMonster(self, query, na_only=False):
-		query = rmdiacritics(query)
-		nm, err, debug_info = self._findMonster(query, na_only)
-		
-		monster_no = nm.monster_no if nm else -1
-		self.historic_lookups[query] = monster_no
-		dataIO.save_json(self.historic_lookups_file_path, self.historic_lookups)
-		
-		m = self.get_monster_by_no(nm.monster_no) if nm else None
-		
-		return m, err, debug_info
-	
-	def _findMonster(self, query, na_only=False):
-		monster_index = self.index_na if na_only else self.index_all
-		return monster_index.find_monster(query)
-	
-	def findMonster2(self, query, na_only=False):
-		query = rmdiacritics(query)
-		nm, err, debug_info = self._findMonster2(query, na_only)
-		
-		monster_no = nm.monster_no if nm else -1
-		self.historic_lookups_id2[query] = monster_no
-		dataIO.save_json(self.historic_lookups_file_path_id2, self.historic_lookups_id2)
-		
-		m = self.get_monster_by_no(nm.monster_no) if nm else None
-		
-		return m, err, debug_info
-	
-	def _findMonster2(self, query, na_only=False):
-		monster_index = self.index_na if na_only else self.index_all
-		return monster_index.find_monster2(query)
-	
-	def map_awakenings_text(self, m):
-		"""Exported for use in other cogs"""
-		return _map_awakenings_text(m)
-	
-	@padinfo.command(pass_context=True)
-	@checks.is_owner()
-	async def setanimationdir(self, ctx, *, animation_dir=''):
-		"""Set a directory containing animated images"""
-		self.settings.setAnimationDir(animation_dir)
-		await self.bot.say(inline('Done'))
-	
-	def check_monster_animated(self, monster_id: int):
-		if not self.settings.animationDir():
-			return False
-		
-		try:
-			animated_ids = set()
-			for f in os.listdir(self.settings.animationDir()):
-				f = f.replace('.mp4', '')
-				if f.isdigit() and int(f) == monster_id:
-					return True
-		except:
-			pass
-		
-		return False
+        if bad:
+            await self.bot.say(inline('Too many inputs. Try wrapping your queries in quotes.'))
+            return
+        
+        # Handle a very specific failure case, user typing something like "uuvo ragdra"
+        if ' ' not in left_query and right_query is not None and ' ' not in right_query and bad is None:
+            combined_query = left_query + ' ' + right_query
+            nm, err, debug_info = self._findMonster(combined_query)
+            if nm and left_query in nm.prefixes:
+                left_query = combined_query
+                right_query = None
+        
+        left_m, left_err, _ = self.findMonster(left_query)
+        if right_query:
+            right_m, right_err, _ = self.findMonster(right_query)
+        else:
+            right_m, right_err, = left_m, left_err
+        
+        err_msg = '{} query failed to match a monster: [ {} ]. If your query is multiple words, wrap it in quotes.'
+        if left_err:
+            await self.bot.say(inline(err_msg.format('Left', left_query)))
+            return
+        if right_err:
+            await self.bot.say(inline(err_msg.format('Right', right_query)))
+            return
+        
+        emoji_to_embed = OrderedDict()
+        emoji_to_embed[self.ls_emoji] = monstersToLsEmbed(left_m, right_m)
+        emoji_to_embed[self.left_emoji] = monsterToEmbed(left_m, self.get_emojis())
+        emoji_to_embed[self.right_emoji] = monsterToEmbed(right_m, self.get_emojis())
+        
+        await self._do_menu(ctx, self.ls_emoji, emoji_to_embed)
+    
+    @commands.command(name="helpid", pass_context=True, aliases=['helppic', 'helpimg'])
+    async def _helpid(self, ctx):
+        """Whispers you info on how to craft monster queries for ^id"""
+        await self.bot.whisper(box(HELP_MSG))
+    
+    @commands.command(pass_context=True)
+    async def padsay(self, ctx, server, *, query: str = None):
+        """Speak the voice line of a monster into your current chat"""
+        voice = ctx.message.author.voice
+        channel = voice.voice_channel
+        if channel is None:
+            await self.bot.say(inline('You must be in a voice channel to use this command'))
+            return
+        
+        speech_cog = self.bot.get_cog('Speech')
+        if not speech_cog:
+            await self.bot.say(inline('Speech seems to be offline'))
+            return
+        
+        if server.lower() not in ['na', 'jp']:
+            query = server + ' ' + (query or '')
+            server = 'na'
+        query = query.strip().lower()
+        
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            base_dir = '/home/tactical0retreat/pad_data/voices/fixed'
+            voice_file = os.path.join(base_dir, server, '{}.wav'.format(m.monster_no_na))
+            header = '{} ({})'.format(monsterToHeader(m), server)
+            if not os.path.exists(voice_file):
+                await self.bot.say(inline('Could not find voice for ' + header))
+                return
+            await self.bot.say('Speaking for ' + header)
+            await speech_cog.play_path(channel, voice_file)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    @commands.group(pass_context=True)
+    @checks.is_owner()
+    async def padinfo(self, ctx):
+        """PAD info management"""
+        if ctx.invoked_subcommand is None:
+            await send_cmd_help(ctx)
+    
+    @padinfo.command(pass_context=True)
+    @checks.is_owner()
+    async def setemojiservers(self, ctx, *, emoji_servers=''):
+        """Set the emoji servers by ID (csv)"""
+        self.settings.emojiServers().clear()
+        if emoji_servers:
+            self.settings.setEmojiServers(emoji_servers.split(','))
+        await self.bot.say(inline('Set {} servers'.format(len(self.settings.emojiServers()))))
+    
+    def get_emojis(self):
+        server_ids = self.settings.emojiServers()
+        return [e for s in self.bot.servers if s.id in server_ids for e in s.emojis]
+    
+    def makeFailureMsg(self, err):
+        msg = 'Lookup failed: {}.\n'.format(err)
+        msg += 'Try one of <id>, <name>, [argbld]/[rgbld] <name>. Unexpected results? Use ^helpid for more info.'
+        return box(msg)
+    
+    def findMonster(self, query, na_only=False):
+        query = rmdiacritics(query)
+        nm, err, debug_info = self._findMonster(query, na_only)
+        
+        monster_no = nm.monster_no if nm else -1
+        self.historic_lookups[query] = monster_no
+        dataIO.save_json(self.historic_lookups_file_path, self.historic_lookups)
+        
+        m = self.get_monster_by_no(nm.monster_no) if nm else None
+        
+        return m, err, debug_info
+    
+    def _findMonster(self, query, na_only=False):
+        monster_index = self.index_na if na_only else self.index_all
+        return monster_index.find_monster(query)
+    
+    def findMonster2(self, query, na_only=False):
+        query = rmdiacritics(query)
+        nm, err, debug_info = self._findMonster2(query, na_only)
+        
+        monster_no = nm.monster_no if nm else -1
+        self.historic_lookups_id2[query] = monster_no
+        dataIO.save_json(self.historic_lookups_file_path_id2, self.historic_lookups_id2)
+        
+        m = self.get_monster_by_no(nm.monster_no) if nm else None
+        
+        return m, err, debug_info
+    
+    def _findMonster2(self, query, na_only=False):
+        monster_index = self.index_na if na_only else self.index_all
+        return monster_index.find_monster2(query)
+    
+    def map_awakenings_text(self, m):
+        """Exported for use in other cogs"""
+        return _map_awakenings_text(m)
+    
+    @padinfo.command(pass_context=True)
+    @checks.is_owner()
+    async def setanimationdir(self, ctx, *, animation_dir=''):
+        """Set a directory containing animated images"""
+        self.settings.setAnimationDir(animation_dir)
+        await self.bot.say(inline('Done'))
+    
+    def check_monster_animated(self, monster_id: int):
+        if not self.settings.animationDir():
+            return False
+        
+        try:
+            animated_ids = set()
+            for f in os.listdir(self.settings.animationDir()):
+                f = f.replace('.mp4', '')
+                if f.isdigit() and int(f) == monster_id:
+                    return True
+        except:
+            pass
+        
+        return False
 
 def setup(bot):
-	print('padinfo bot setup')
-	n = PadInfo(bot)
-	bot.add_cog(n)
-	bot.loop.create_task(n.reload_nicknames())
-	print('done adding padinfo bot')
+    print('padinfo bot setup')
+    n = PadInfo(bot)
+    bot.add_cog(n)
+    bot.loop.create_task(n.reload_nicknames())
+    print('done adding padinfo bot')
 
 class PadInfoSettings(CogSettings):
-	def make_default_settings(self):
-		config = {
-			'animation_dir': '',
-		}
-		return config
-	
-	def emojiServers(self):
-		key = 'emoji_servers'
-		if key not in self.bot_settings:
-			self.bot_settings[key] = []
-		return self.bot_settings[key]
-	
-	def setEmojiServers(self, emoji_servers):
-		es = self.emojiServers()
-		es.clear()
-		es.extend(emoji_servers)
-		self.save_settings()
-	
-	def animationDir(self):
-		return self.bot_settings['animation_dir']
-	
-	def setAnimationDir(self, animation_dir):
-		self.bot_settings['animation_dir'] = animation_dir
-		self.save_settings()
+    def make_default_settings(self):
+        config = {
+            'animation_dir': '',
+        }
+        return config
+    
+    def emojiServers(self):
+        key = 'emoji_servers'
+        if key not in self.bot_settings:
+            self.bot_settings[key] = []
+        return self.bot_settings[key]
+    
+    def setEmojiServers(self, emoji_servers):
+        es = self.emojiServers()
+        es.clear()
+        es.extend(emoji_servers)
+        self.save_settings()
+    
+    def animationDir(self):
+        return self.bot_settings['animation_dir']
+    
+    def setAnimationDir(self, animation_dir):
+        self.bot_settings['animation_dir'] = animation_dir
+        self.save_settings()
 
 def monsterToHeader(m: padguide2.PgMonster, link=False):
-	msg = 'No. {} {}'.format(m.monster_no_na, m.name_na)
-	return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
+    msg = 'No. {} {}'.format(m.monster_no_na, m.name_na)
+    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
 
 def monsterToJpSuffix(m: padguide2.PgMonster):
-	suffix = ""
-	if m.roma_subname:
-		suffix += ' [{}]'.format(m.roma_subname)
-	if not m.on_na:
-		suffix += ' (JP only)'
-	return suffix
+    suffix = ""
+    if m.roma_subname:
+        suffix += ' [{}]'.format(m.roma_subname)
+    if not m.on_na:
+        suffix += ' (JP only)'
+    return suffix
 
 def monsterToLongHeader(m: padguide2.PgMonster, link=False):
-	msg = monsterToHeader(m) + monsterToJpSuffix(m)
-	return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
+    msg = monsterToHeader(m) + monsterToJpSuffix(m)
+    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
 
 def monsterToLongHeaderWithAttr(m: padguide2.PgMonster, link=False):
-	header = 'No. {} {} {}'.format(
-		m.monster_no_na,
-		"({}{})".format(attr_prefix_map[m.attr1], "/" +
-												  attr_prefix_map[m.attr2] if m.attr2 else ""),
-		m.name_na)
-	msg = header + monsterToJpSuffix(m)
-	return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
+    header = 'No. {} {} {}'.format(
+        m.monster_no_na,
+        "({}{})".format(attr_prefix_map[m.attr1], "/" +
+                                                  attr_prefix_map[m.attr2] if m.attr2 else ""),
+        m.name_na)
+    msg = header + monsterToJpSuffix(m)
+    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
 
 def monsterToEvoText(m: padguide2.PgMonster):
-	output = monsterToLongHeader(m)
-	for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
-		output += "\n\t- {}".format(monsterToLongHeader(ae))
-	return output
+    output = monsterToLongHeader(m)
+    for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
+        output += "\n\t- {}".format(monsterToLongHeader(ae))
+    return output
 
 def monsterToThumbnailUrl(m: padguide2.PgMonster):
-	return get_portrait_url(m)
+    return get_portrait_url(m)
 
 def monsterToBaseEmbed(m: padguide2.PgMonster):
-	header = monsterToLongHeader(m)
-	embed = discord.Embed()
-	embed.set_thumbnail(url=monsterToThumbnailUrl(m))
-	embed.title = header
-	embed.url = get_pdx_url(m)
-	embed.set_footer(text='Requester may click the reactions below to switch tabs')
-	return embed
+    header = monsterToLongHeader(m)
+    embed = discord.Embed()
+    embed.set_thumbnail(url=monsterToThumbnailUrl(m))
+    embed.title = header
+    embed.url = get_pdx_url(m)
+    embed.set_footer(text='Requester may click the reactions below to switch tabs')
+    return embed
 
 def monsterToEvoEmbed(m: padguide2.PgMonster):
-	embed = monsterToBaseEmbed(m)
-	
-	if not len(m.alt_evos):
-		embed.description = 'No alternate evos'
-		return embed
-	
-	field_name = '{} alternate evos'.format(len(m.alt_evos))
-	field_data = ''
-	for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
-		field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
-	
-	embed.add_field(name=field_name, value=field_data)
-	
-	return embed
+    embed = monsterToBaseEmbed(m)
+    
+    if not len(m.alt_evos):
+        embed.description = 'No alternate evos'
+        return embed
+    
+    field_name = '{} alternate evos'.format(len(m.alt_evos))
+    field_data = ''
+    for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
+        field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
+    
+    embed.add_field(name=field_name, value=field_data)
+    
+    return embed
 
 def monsterToEvoMatsEmbed(m: padguide2.PgMonster):
-	embed = monsterToBaseEmbed(m)
-	
-	mats_for_evo_size = len(m.mats_for_evo)
-	material_of_size = len(m.material_of)
-	
-	field_name = 'Evo materials'
-	field_data = ''
-	if mats_for_evo_size:
-		for ae in m.mats_for_evo:
-			field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
-	else:
-		field_data = 'None'
-	embed.add_field(name=field_name, value=field_data)
-	
-	if not material_of_size:
-		return embed
-	
-	field_name = 'Material for'
-	field_data = ''
-	if material_of_size > 5:
-		field_data = '{} monsters'.format(material_of_size)
-	else:
-		item_count = min(material_of_size, 5)
-		for ae in sorted(m.material_of, key=lambda x: x.monster_no_na, reverse=True)[:item_count]:
-			field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
-	embed.add_field(name=field_name, value=field_data)
-	
-	return embed
+    embed = monsterToBaseEmbed(m)
+    
+    mats_for_evo_size = len(m.mats_for_evo)
+    material_of_size = len(m.material_of)
+    
+    field_name = 'Evo materials'
+    field_data = ''
+    if mats_for_evo_size:
+        for ae in m.mats_for_evo:
+            field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
+    else:
+        field_data = 'None'
+    embed.add_field(name=field_name, value=field_data)
+    
+    if not material_of_size:
+        return embed
+    
+    field_name = 'Material for'
+    field_data = ''
+    if material_of_size > 5:
+        field_data = '{} monsters'.format(material_of_size)
+    else:
+        item_count = min(material_of_size, 5)
+        for ae in sorted(m.material_of, key=lambda x: x.monster_no_na, reverse=True)[:item_count]:
+            field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
+    embed.add_field(name=field_name, value=field_data)
+    
+    return embed
 
 def monsterToPantheonEmbed(m: padguide2.PgMonster):
-	full_pantheon = m.series.monsters
-	pantheon_list = list(filter(lambda x: x.evo_from is None, full_pantheon))
-	if len(pantheon_list) == 0 or len(pantheon_list) > 6:
-		return None
-	
-	embed = monsterToBaseEmbed(m)
-	
-	field_name = 'Pantheon: ' + m.series.name
-	field_data = ''
-	for monster in sorted(pantheon_list, key=lambda x: x.monster_no_na):
-		field_data += '\n' + monsterToHeader(monster, link=True)
-	embed.add_field(name=field_name, value=field_data)
-	
-	return embed
+    full_pantheon = m.series.monsters
+    pantheon_list = list(filter(lambda x: x.evo_from is None, full_pantheon))
+    if len(pantheon_list) == 0 or len(pantheon_list) > 6:
+        return None
+    
+    embed = monsterToBaseEmbed(m)
+    
+    field_name = 'Pantheon: ' + m.series.name
+    field_data = ''
+    for monster in sorted(pantheon_list, key=lambda x: x.monster_no_na):
+        field_data += '\n' + monsterToHeader(monster, link=True)
+    embed.add_field(name=field_name, value=field_data)
+    
+    return embed
 
 def monsterToSkillupsEmbed(m: padguide2.PgMonster):
-	skillups_list = m.active_skill.monsters_with_active if m.active_skill else []
-	skillups_list = list(filter(lambda m: m.sell_mp < 3000, skillups_list))
-	server_skillups = m.active_skill.server_skillups if m.active_skill else []
-	
-	if len(skillups_list) + len(server_skillups) == 0:
-		return None
-	
-	embed = monsterToBaseEmbed(m)
-	
-	skillups_to_skip = []
-	for server, skillup in server_skillups.items():
-		skillup_header = 'Skillup in ' + server
-		skillup_body = monsterToHeader(skillup, link=True)
-		embed.add_field(name=skillup_header, value=skillup_body)
-		skillups_to_skip.append(skillup.monster_no_na)
-	
-	field_name = 'Skillups'
-	field_data = ''
-	
-	# Prevent huge skillup lists
-	if len(skillups_list) > 8:
-		field_data = '({} skillups omitted)'.format(len(skillups_list) - 8)
-		skillups_list = skillups_list[0:8]
-	
-	for monster in sorted(skillups_list, key=lambda x: x.monster_no_na):
-		if monster.monster_no_na in skillups_to_skip:
-			continue
-		field_data += '\n' + monsterToHeader(monster, link=True)
-	
-	if len(field_data.strip()):
-		embed.add_field(name=field_name, value=field_data)
-	
-	return embed
+    skillups_list = m.active_skill.monsters_with_active if m.active_skill else []
+    skillups_list = list(filter(lambda m: m.sell_mp < 3000, skillups_list))
+    server_skillups = m.active_skill.server_skillups if m.active_skill else []
+    
+    if len(skillups_list) + len(server_skillups) == 0:
+        return None
+    
+    embed = monsterToBaseEmbed(m)
+    
+    skillups_to_skip = []
+    for server, skillup in server_skillups.items():
+        skillup_header = 'Skillup in ' + server
+        skillup_body = monsterToHeader(skillup, link=True)
+        embed.add_field(name=skillup_header, value=skillup_body)
+        skillups_to_skip.append(skillup.monster_no_na)
+    
+    field_name = 'Skillups'
+    field_data = ''
+    
+    # Prevent huge skillup lists
+    if len(skillups_list) > 8:
+        field_data = '({} skillups omitted)'.format(len(skillups_list) - 8)
+        skillups_list = skillups_list[0:8]
+    
+    for monster in sorted(skillups_list, key=lambda x: x.monster_no_na):
+        if monster.monster_no_na in skillups_to_skip:
+            continue
+        field_data += '\n' + monsterToHeader(monster, link=True)
+    
+    if len(field_data.strip()):
+        embed.add_field(name=field_name, value=field_data)
+    
+    return embed
 
 def monsterToPicUrl(m: padguide2.PgMonster):
-	return get_pic_url(m)
+    return get_pic_url(m)
 
 def monsterToPicEmbed(m: padguide2.PgMonster, animated=False):
-	embed = monsterToBaseEmbed(m)
-	url = monsterToPicUrl(m)
-	embed.set_image(url=url)
-	# Clear the thumbnail, don't need it on pic
-	embed.set_thumbnail(url='')
-	if animated:
-		description = '[{}]({}) –– [{}]({})'.format(
-			'HQ (MP4)', monsterToVideoUrl(m), 'LQ (GIF)', monsterToGifUrl(m))
-		embed.add_field(name='Animated links', value=description)
-	
-	return embed
+    embed = monsterToBaseEmbed(m)
+    url = monsterToPicUrl(m)
+    embed.set_image(url=url)
+    # Clear the thumbnail, don't need it on pic
+    embed.set_thumbnail(url='')
+    if animated:
+        description = '[{}]({}) –– [{}]({})'.format(
+            'HQ (MP4)', monsterToVideoUrl(m), 'LQ (GIF)', monsterToGifUrl(m))
+        embed.add_field(name='Animated links', value=description)
+    
+    return embed
 
 def monsterToVideoUrl(m: padguide2.PgMonster):
-	return VIDEO_TEMPLATE.format(m.monster_no_jp)
+    return VIDEO_TEMPLATE.format(m.monster_no_jp)
 
 def monsterToGifUrl(m: padguide2.PgMonster):
-	return GIF_TEMPLATE.format(m.monster_no_jp)
+    return GIF_TEMPLATE.format(m.monster_no_jp)
 
 def monsterToGifEmbed(m: padguide2.PgMonster):
-	embed = monsterToBaseEmbed(m)
-	url = monsterToGifUrl(m)
-	embed.set_image(url=url)
-	# Clear the thumbnail, don't need it on pic
-	embed.set_thumbnail(url='')
-	return embed
+    embed = monsterToBaseEmbed(m)
+    url = monsterToGifUrl(m)
+    embed.set_image(url=url)
+    # Clear the thumbnail, don't need it on pic
+    embed.set_thumbnail(url='')
+    return embed
 
 def monstersToLsEmbed(left_m: padguide2.PgMonster, right_m: padguide2.PgMonster):
-	lhp, latk, lrcv, lresist = left_m.leader_skill_data.get_data()
-	rhp, ratk, rrcv, rresist = right_m.leader_skill_data.get_data()
-	multiplier_text = createMultiplierText(lhp, latk, lrcv, lresist, rhp, ratk, rrcv, rresist)
-	
-	embed = discord.Embed()
-	embed.title = 'Multiplier [{}]\n\n'.format(multiplier_text)
-	description = ''
-	description += '\n**{}**\n{}'.format(
-		monsterToHeader(left_m, link=True),
-		left_m.leader_skill.desc if left_m.leader_skill else 'None/Missing')
-	description += '\n**{}**\n{}'.format(
-		monsterToHeader(right_m, link=True),
-		right_m.leader_skill.desc if right_m.leader_skill else 'None/Missing')
-	embed.description = description
-	
-	return embed
+    lhp, latk, lrcv, lresist = left_m.leader_skill_data.get_data()
+    rhp, ratk, rrcv, rresist = right_m.leader_skill_data.get_data()
+    multiplier_text = createMultiplierText(lhp, latk, lrcv, lresist, rhp, ratk, rrcv, rresist)
+    
+    embed = discord.Embed()
+    embed.title = 'Multiplier [{}]\n\n'.format(multiplier_text)
+    description = ''
+    description += '\n**{}**\n{}'.format(
+        monsterToHeader(left_m, link=True),
+        left_m.leader_skill.desc if left_m.leader_skill else 'None/Missing')
+    description += '\n**{}**\n{}'.format(
+        monsterToHeader(right_m, link=True),
+        right_m.leader_skill.desc if right_m.leader_skill else 'None/Missing')
+    embed.description = description
+    
+    return embed
 
 def monsterToHeaderEmbed(m: padguide2.PgMonster):
-	header = monsterToLongHeader(m, link=True)
-	embed = discord.Embed()
-	embed.description = header
-	return embed
+    header = monsterToLongHeader(m, link=True)
+    embed = discord.Embed()
+    embed.description = header
+    return embed
 
 def monsterToTypeString(m: padguide2.PgMonster):
-	output = m.type1
-	if m.type2:
-		output += '/' + m.type2
-	if m.type3:
-		output += '/' + m.type3
-	return output
+    output = m.type1
+    if m.type2:
+        output += '/' + m.type2
+    if m.type3:
+        output += '/' + m.type3
+    return output
 
 def monsterToAcquireString(m: padguide2.PgMonster):
-	acquire_text = None
-	if m.farmable and not m.mp_evo:
-		# Some MP shop monsters 'drop' in PADR
-		acquire_text = 'Farmable'
-	elif m.farmable_evo and not m.mp_evo:
-		acquire_text = 'Farmable Evo'
-	elif m.in_pem:
-		acquire_text = 'In PEM'
-	elif m.pem_evo:
-		acquire_text = 'PEM Evo'
-	elif m.in_rem:
-		acquire_text = 'In REM'
-	elif m.rem_evo:
-		acquire_text = 'REM Evo'
-	elif m.in_mpshop:
-		acquire_text = 'MP Shop'
-	elif m.mp_evo:
-		acquire_text = 'MP Shop Evo'
-	return acquire_text
+    acquire_text = None
+    if m.farmable and not m.mp_evo:
+        # Some MP shop monsters 'drop' in PADR
+        acquire_text = 'Farmable'
+    elif m.farmable_evo and not m.mp_evo:
+        acquire_text = 'Farmable Evo'
+    elif m.in_pem:
+        acquire_text = 'In PEM'
+    elif m.pem_evo:
+        acquire_text = 'PEM Evo'
+    elif m.in_rem:
+        acquire_text = 'In REM'
+    elif m.rem_evo:
+        acquire_text = 'REM Evo'
+    elif m.in_mpshop:
+        acquire_text = 'MP Shop'
+    elif m.mp_evo:
+        acquire_text = 'MP Shop Evo'
+    return acquire_text
 
 def match_emoji(emoji_list, name):
-	for e in emoji_list:
-		if e.name == name:
-			return e
-	return None
+    for e in emoji_list:
+        if e.name == name:
+            return e
+    return None
 
 def monsterToEmbed(m: padguide2.PgMonster, emoji_list):
-	embed = monsterToBaseEmbed(m)
-	
-	info_row_1 = monsterToTypeString(m)
-	acquire_text = monsterToAcquireString(m)
-	
-	info_row_2 = '**Rarity** {}\n**Cost** {}'.format(m.rarity, m.cost)
-	if acquire_text:
-		info_row_2 += '\n**{}**'.format(acquire_text)
-	if m.is_inheritable:
-		info_row_2 += '\n**Inheritable**'
-	else:
-		info_row_2 += '\n**Not inheritable**'
-	
-	embed.add_field(name=info_row_1, value=info_row_2)
-	
-	if m.limitbreak_stats and m.limitbreak_stats > 1:
-		def lb(x):
-			return int(round(m.limitbreak_stats * x))
-		
-		stats_row_1 = 'Weighted {} | LB {}'.format(m.weighted_stats, lb(m.weighted_stats))
-		stats_row_2 = '**HP** {} ({})\n**ATK** {} ({})\n**RCV** {} ({})'.format(
-			m.hp, lb(m.hp), m.atk, lb(m.atk), m.rcv, lb(m.rcv))
-	else:
-		stats_row_1 = 'Weighted {}'.format(m.weighted_stats)
-		stats_row_2 = '**HP** {}\n**ATK** {}\n**RCV** {}'.format(m.hp, m.atk, m.rcv)
-	embed.add_field(name=stats_row_1, value=stats_row_2)
-	
-	awakenings_row = ''
-	for idx, a in enumerate(m.awakenings):
-		a = a.get_name()
-		mapped_awakening = AWAKENING_NAME_MAP_RPAD.get(a, a)
-		mapped_awakening = match_emoji(emoji_list, mapped_awakening)
-		
-		if mapped_awakening is None:
-			mapped_awakening = AWAKENING_NAME_MAP.get(a, a)
-		
-		# Wrap superawakenings to the next line
-		if len(m.awakenings) - idx == m.superawakening_count:
-			awakenings_row += '\n{}'.format(mapped_awakening)
-		else:
-			awakenings_row += ' {}'.format(mapped_awakening)
-	
-	awakenings_row = awakenings_row.strip()
-	
-	if not len(awakenings_row):
-		awakenings_row = 'No Awakenings'
-	
-	killers = compute_killers(m.type1, m.type2, m.type3)
-	killers_row = '**Available Killers:** {}'.format(' '.join(killers))
-	
-	embed.description = '{}\n{}'.format(awakenings_row, killers_row)
-	
-	if len(m.server_actives) >= 2:
-		for server, active in m.server_actives.items():
-			active_header = '({} Server) Active Skill ({} -> {})'.format(server,
-																		 active.turn_max, active.turn_min)
-			active_body = active.desc
-			embed.add_field(name=active_header, value=active_body, inline=False)
-	else:
-		active_header = 'Active Skill'
-		active_body = 'None/Missing'
-		if m.active_skill:
-			active_header = 'Active Skill ({} -> {})'.format(m.active_skill.turn_max,
-															 m.active_skill.turn_min)
-			active_body = m.active_skill.desc
-		embed.add_field(name=active_header, value=active_body, inline=False)
-	
-	ls_row = m.leader_skill.desc if m.leader_skill else 'None/Missing'
-	ls_header = 'Leader Skill'
-	if m.leader_skill_data:
-		hp, atk, rcv, resist = m.leader_skill_data.get_data()
-		multiplier_text = createMultiplierText(hp, atk, rcv, resist)
-		ls_header += " [ {} ]".format(multiplier_text)
-	embed.add_field(name=ls_header, value=ls_row, inline=False)
-	
-	return embed
+    embed = monsterToBaseEmbed(m)
+    
+    info_row_1 = monsterToTypeString(m)
+    acquire_text = monsterToAcquireString(m)
+    
+    info_row_2 = '**Rarity** {}\n**Cost** {}'.format(m.rarity, m.cost)
+    if acquire_text:
+        info_row_2 += '\n**{}**'.format(acquire_text)
+    if m.is_inheritable:
+        info_row_2 += '\n**Inheritable**'
+    else:
+        info_row_2 += '\n**Not inheritable**'
+    
+    embed.add_field(name=info_row_1, value=info_row_2)
+    
+    if m.limitbreak_stats and m.limitbreak_stats > 1:
+        def lb(x):
+            return int(round(m.limitbreak_stats * x))
+        
+        stats_row_1 = 'Weighted {} | LB {}'.format(m.weighted_stats, lb(m.weighted_stats))
+        stats_row_2 = '**HP** {} ({})\n**ATK** {} ({})\n**RCV** {} ({})'.format(
+            m.hp, lb(m.hp), m.atk, lb(m.atk), m.rcv, lb(m.rcv))
+    else:
+        stats_row_1 = 'Weighted {}'.format(m.weighted_stats)
+        stats_row_2 = '**HP** {}\n**ATK** {}\n**RCV** {}'.format(m.hp, m.atk, m.rcv)
+    embed.add_field(name=stats_row_1, value=stats_row_2)
+    
+    awakenings_row = ''
+    for idx, a in enumerate(m.awakenings):
+        a = a.get_name()
+        mapped_awakening = AWAKENING_NAME_MAP_RPAD.get(a, a)
+        mapped_awakening = match_emoji(emoji_list, mapped_awakening)
+        
+        if mapped_awakening is None:
+            mapped_awakening = AWAKENING_NAME_MAP.get(a, a)
+        
+        # Wrap superawakenings to the next line
+        if len(m.awakenings) - idx == m.superawakening_count:
+            awakenings_row += '\n{}'.format(mapped_awakening)
+        else:
+            awakenings_row += ' {}'.format(mapped_awakening)
+    
+    awakenings_row = awakenings_row.strip()
+    
+    if not len(awakenings_row):
+        awakenings_row = 'No Awakenings'
+    
+    killers = compute_killers(m.type1, m.type2, m.type3)
+    killers_row = '**Available Killers:** {}'.format(' '.join(killers))
+    
+    embed.description = '{}\n{}'.format(awakenings_row, killers_row)
+    
+    if len(m.server_actives) >= 2:
+        for server, active in m.server_actives.items():
+            active_header = '({} Server) Active Skill ({} -> {})'.format(server,
+                                                                         active.turn_max, active.turn_min)
+            active_body = active.desc
+            embed.add_field(name=active_header, value=active_body, inline=False)
+    else:
+        active_header = 'Active Skill'
+        active_body = 'None/Missing'
+        if m.active_skill:
+            active_header = 'Active Skill ({} -> {})'.format(m.active_skill.turn_max,
+                                                             m.active_skill.turn_min)
+            active_body = m.active_skill.desc
+        embed.add_field(name=active_header, value=active_body, inline=False)
+    
+    ls_row = m.leader_skill.desc if m.leader_skill else 'None/Missing'
+    ls_header = 'Leader Skill'
+    if m.leader_skill_data:
+        hp, atk, rcv, resist = m.leader_skill_data.get_data()
+        multiplier_text = createMultiplierText(hp, atk, rcv, resist)
+        ls_header += " [ {} ]".format(multiplier_text)
+    embed.add_field(name=ls_header, value=ls_row, inline=False)
+    
+    return embed
 
 def monsterToOtherInfoEmbed(m: padguide2.PgMonster):
-	embed = monsterToBaseEmbed(m)
-	# Clear the thumbnail, takes up too much space
-	embed.set_thumbnail(url='')
-	
-	stat_cols = ['', 'Max', 'M297', 'Inh', 'I297']
-	tbl = prettytable.PrettyTable(stat_cols)
-	tbl.hrules = prettytable.NONE
-	tbl.vrules = prettytable.NONE
-	tbl.align = "r"
-	hhp = m.hp + 99 * 10
-	hatk = m.atk + 99 * 5
-	hrcv = m.rcv + 99 * 3
-	tbl.add_row(['HP', m.hp, hhp, int(m.hp * .1), int(hhp * .1)])
-	tbl.add_row(['ATK', m.atk, hatk, int(m.atk * .05), int(hatk * .05)])
-	tbl.add_row(['RCV', m.rcv, hrcv, int(m.rcv * .15), int(hrcv * .15)])
-	
-	body_text = box(tbl.get_string())
-	
-	search_text = YT_SEARCH_TEMPLATE.format(m.name_jp)
-	skyozora_text = SKYOZORA_TEMPLATE.format(m.monster_no_jp)
-	body_text += "\n**JP Name**: {} | [YouTube]({}) | [Skyozora]({})".format(
-		m.name_jp, search_text, skyozora_text)
-	
-	if m.history_us:
-		body_text += '\n**History:** {}'.format(m.history_us)
-	
-	body_text += '\n**Series:** {}'.format(m.series.name)
-	body_text += '\n**Sell MP:** {:,}'.format(m.sell_mp)
-	if m.buy_mp > 0:
-		body_text += "  **Buy MP:** {:,}".format(m.buy_mp)
-	
-	if m.exp < 1000000:
-		xp_text = '{:,}'.format(m.exp)
-	else:
-		xp_text = '{:.1f}'.format(m.exp / 1000000).rstrip('0').rstrip('.') + 'M'
-	body_text += '\n**XP to Max:** {}'.format(xp_text)
-	body_text += '  **Max Level:**: {}'.format(m.max_level)
-	body_text += '\n**Rarity:** {} **Cost:** {}'.format(m.rarity, m.cost)
-	
-	if m.translated_jp_name:
-		body_text += '\n**Google Translated:** {}'.format(m.translated_jp_name)
-	
-	embed.description = body_text
-	
-	return embed
+    embed = monsterToBaseEmbed(m)
+    # Clear the thumbnail, takes up too much space
+    embed.set_thumbnail(url='')
+    
+    stat_cols = ['', 'Max', 'M297', 'Inh', 'I297']
+    tbl = prettytable.PrettyTable(stat_cols)
+    tbl.hrules = prettytable.NONE
+    tbl.vrules = prettytable.NONE
+    tbl.align = "r"
+    hhp = m.hp + 99 * 10
+    hatk = m.atk + 99 * 5
+    hrcv = m.rcv + 99 * 3
+    tbl.add_row(['HP', m.hp, hhp, int(m.hp * .1), int(hhp * .1)])
+    tbl.add_row(['ATK', m.atk, hatk, int(m.atk * .05), int(hatk * .05)])
+    tbl.add_row(['RCV', m.rcv, hrcv, int(m.rcv * .15), int(hrcv * .15)])
+    
+    body_text = box(tbl.get_string())
+    
+    search_text = YT_SEARCH_TEMPLATE.format(m.name_jp)
+    skyozora_text = SKYOZORA_TEMPLATE.format(m.monster_no_jp)
+    body_text += "\n**JP Name**: {} | [YouTube]({}) | [Skyozora]({})".format(
+        m.name_jp, search_text, skyozora_text)
+    
+    if m.history_us:
+        body_text += '\n**History:** {}'.format(m.history_us)
+    
+    body_text += '\n**Series:** {}'.format(m.series.name)
+    body_text += '\n**Sell MP:** {:,}'.format(m.sell_mp)
+    if m.buy_mp > 0:
+        body_text += "  **Buy MP:** {:,}".format(m.buy_mp)
+    
+    if m.exp < 1000000:
+        xp_text = '{:,}'.format(m.exp)
+    else:
+        xp_text = '{:.1f}'.format(m.exp / 1000000).rstrip('0').rstrip('.') + 'M'
+    body_text += '\n**XP to Max:** {}'.format(xp_text)
+    body_text += '  **Max Level:**: {}'.format(m.max_level)
+    body_text += '\n**Rarity:** {} **Cost:** {}'.format(m.rarity, m.cost)
+    
+    if m.translated_jp_name:
+        body_text += '\n**Google Translated:** {}'.format(m.translated_jp_name)
+    
+    embed.description = body_text
+    
+    return embed
 
 def monsters_to_rotation_list(monster_list, server: str, index_all: padguide2.MonsterIndex):
-	# Shorten some of the longer names
-	name_remap = {
-		'Extreme King Metal Tamadra': 'Fat Tama',
-		'Extreme King Metal Dragon': 'EKMD',
-		'Ancient Green Sacred Mask': 'Green Mask',
-		'Ancient Blue Sacred Mask': 'Blue Mask',
-	}
-	ignore_monsters = [
-		'Ancient Draggie Knight',
-	]
-	
-	monster_list.sort(key=lambda m: m.monster_no, reverse=True)
-	next_rotation_date = None
-	for m in monster_list:
-		if server in m.future_skillup_rotation:
-			next_rotation_date = m.future_skillup_rotation[server].rotation_date_str
-			break
-	
-	cols = [server + ' Skillup', 'Current']
-	if next_rotation_date:
-		cols.append(next_rotation_date)
-	tbl = prettytable.PrettyTable(cols)
-	tbl.hrules = prettytable.HEADER
-	tbl.vrules = prettytable.NONE
-	tbl.align = "l"
-	
-	def cell_name(m: padguide2.PgMonster):
-		nm = index_all.monster_no_to_named_monster[m.monster_no]
-		name = nm.group_computed_basename.title()
-		return name_remap.get(name, name)
-	
-	for m in monster_list:
-		skill = m.server_actives[server]
-		
-		sm = skill.monsters_with_active
-		
-		# Since some newer monsters like jewel of creation are being used as
-		# skillups, exclude them from the list of skillup targets.
-		
-		def is_bad_type(m):
-			return set(['enhance', 'evolve', 'vendor']).intersection(set(m.types))
-		
-		sm = max(sm, key=lambda x: (not is_bad_type(x), x.monster_no))
-		
-		skillup_name = cell_name(m)
-		if skillup_name in ignore_monsters:
-			continue
-		row = [skillup_name, cell_name(sm)]
-		if next_rotation_date:
-			if server in m.future_skillup_rotation:
-				next_skill = m.future_skillup_rotation[server].skill
-				nm = max(next_skill.monsters_with_active, key=lambda x: x.monster_no)
-				row.append(cell_name(nm))
-			else:
-				row.append('')
-		tbl.add_row(row)
-	
-	return tbl.get_string()
+    # Shorten some of the longer names
+    name_remap = {
+        'Extreme King Metal Tamadra': 'Fat Tama',
+        'Extreme King Metal Dragon': 'EKMD',
+        'Ancient Green Sacred Mask': 'Green Mask',
+        'Ancient Blue Sacred Mask': 'Blue Mask',
+    }
+    ignore_monsters = [
+        'Ancient Draggie Knight',
+    ]
+    
+    monster_list.sort(key=lambda m: m.monster_no, reverse=True)
+    next_rotation_date = None
+    for m in monster_list:
+        if server in m.future_skillup_rotation:
+            next_rotation_date = m.future_skillup_rotation[server].rotation_date_str
+            break
+    
+    cols = [server + ' Skillup', 'Current']
+    if next_rotation_date:
+        cols.append(next_rotation_date)
+    tbl = prettytable.PrettyTable(cols)
+    tbl.hrules = prettytable.HEADER
+    tbl.vrules = prettytable.NONE
+    tbl.align = "l"
+    
+    def cell_name(m: padguide2.PgMonster):
+        nm = index_all.monster_no_to_named_monster[m.monster_no]
+        name = nm.group_computed_basename.title()
+        return name_remap.get(name, name)
+    
+    for m in monster_list:
+        skill = m.server_actives[server]
+        
+        sm = skill.monsters_with_active
+        
+        # Since some newer monsters like jewel of creation are being used as
+        # skillups, exclude them from the list of skillup targets.
+        
+        def is_bad_type(m):
+            return set(['enhance', 'evolve', 'vendor']).intersection(set(m.types))
+        
+        sm = max(sm, key=lambda x: (not is_bad_type(x), x.monster_no))
+        
+        skillup_name = cell_name(m)
+        if skillup_name in ignore_monsters:
+            continue
+        row = [skillup_name, cell_name(sm)]
+        if next_rotation_date:
+            if server in m.future_skillup_rotation:
+                next_skill = m.future_skillup_rotation[server].skill
+                nm = max(next_skill.monsters_with_active, key=lambda x: x.monster_no)
+                row.append(cell_name(nm))
+            else:
+                row.append('')
+        tbl.add_row(row)
+    
+    return tbl.get_string()
 
 AWAKENING_NAME_MAP_RPAD = {
-	'Enhanced Attack': 'boost_atk',
-	'Enhanced HP': 'boost_hp',
-	'Enhanced Heal': 'boost_rcv',
-	
-	'Enhanced Team HP': 'teamboost_hp',
-	'Enhanced Team Attack': 'teamboost_atk',
-	'Enhanced Team RCV': 'teamboost_rcv',
-	
-	'God Killer': 'killer_god',
-	'Dragon Killer': 'killer_dragon',
-	'Devil Killer': 'killer_devil',
-	'Machine Killer': 'killer_machine',
-	'Balanced Killer': 'killer_balance',
-	'Attacker Killer': 'killer_attacker',
-	
-	'Physical Killer': 'killer_physical',
-	'Healer Killer': 'killer_healer',
-	'Evolve Material Killer': 'killer_evomat',
-	'Awaken Material Killer': 'killer_awoken',
-	'Enhance Material Killer': 'killer_enhancemat',
-	'Vendor Material Killer': 'killer_vendor',
-	
-	'Auto-Recover': 'misc_autoheal',
-	'Recover Bind': 'misc_bindclear',
-	'Enhanced Combo': 'misc_comboboost',
-	'Super Enhanced Combo': 'misc_super_comboboost',
-	'Guard Break': 'misc_guardbreak',
-	'Multi Boost': 'misc_multiboost',
-	'Additional Attack': 'misc_extraattack',
-	'Skill Boost': 'misc_sb',
-	'Extend Time': 'misc_te',
-	'Two-Pronged Attack': 'misc_tpa',
-	'Damage Void Shield Penetration': 'misc_voidshield',
-	'Awoken Assist': 'misc_assist',
-	
-	'Enhanced Fire Orbs': 'oe_fire',
-	'Enhanced Water Orbs': 'oe_water',
-	'Enhanced Wood Orbs': 'oe_wood',
-	'Enhanced Light Orbs': 'oe_light',
-	'Enhanced Dark Orbs': 'oe_dark',
-	'Enhanced Heal Orbs': 'oe_heart',
-	
-	'Reduce Fire Damage': 'reduce_fire',
-	'Reduce Water Damage': 'reduce_water',
-	'Reduce Wood Damage': 'reduce_wood',
-	'Reduce Light Damage': 'reduce_light',
-	'Reduce Dark Damage': 'reduce_dark',
-	
-	'Resistance-Bind': 'res_bind',
-	'Resistance-Dark': 'res_blind',
-	'Resistance-Jammers': 'res_jammer',
-	'Resistance-Poison': 'res_poison',
-	'Resistance-Skill Bind': 'res_skillbind',
-	
-	'Enhanced Fire Att.': 'row_fire',
-	'Enhanced Water Att.': 'row_water',
-	'Enhanced Wood Att.': 'row_wood',
-	'Enhanced Light Att.': 'row_light',
-	'Enhanced Dark Att.': 'row_dark',
-	
-	'Skill Charge': 'misc_skillcharge',
-	'Super Additional Attack': 'misc_super_extraattack',
-	'Resistance-Bind＋': 'res_bind_super',
-	'Extend Time＋': 'misc_te_super',
-	'Resistance-Cloud': 'res_cloud',
-	'Resistance-Board Restrict': 'res_seal',
-	'Skill Boost＋': 'misc_sb_super',
-	'L-Shape Attack': 'l_attack',
-	'L-Shape Damage Reduction': 'l_shield',
-	'Enhance when HP is below 50%': 'attack_boost_low',
-	'Enhance when HP is above 80%': 'attack_boost_high',
-	'Combo Orb': 'orb_combo',
-	'Skill Voice': 'misc_voice',
-	'Dungeon Bonus': 'misc_dungeonbonus',
+    'Enhanced Attack': 'boost_atk',
+    'Enhanced HP': 'boost_hp',
+    'Enhanced Heal': 'boost_rcv',
+    
+    'Enhanced Team HP': 'teamboost_hp',
+    'Enhanced Team Attack': 'teamboost_atk',
+    'Enhanced Team RCV': 'teamboost_rcv',
+    
+    'God Killer': 'killer_god',
+    'Dragon Killer': 'killer_dragon',
+    'Devil Killer': 'killer_devil',
+    'Machine Killer': 'killer_machine',
+    'Balanced Killer': 'killer_balance',
+    'Attacker Killer': 'killer_attacker',
+    
+    'Physical Killer': 'killer_physical',
+    'Healer Killer': 'killer_healer',
+    'Evolve Material Killer': 'killer_evomat',
+    'Awaken Material Killer': 'killer_awoken',
+    'Enhance Material Killer': 'killer_enhancemat',
+    'Vendor Material Killer': 'killer_vendor',
+    
+    'Auto-Recover': 'misc_autoheal',
+    'Recover Bind': 'misc_bindclear',
+    'Enhanced Combo': 'misc_comboboost',
+    'Super Enhanced Combo': 'misc_super_comboboost',
+    'Guard Break': 'misc_guardbreak',
+    'Multi Boost': 'misc_multiboost',
+    'Additional Attack': 'misc_extraattack',
+    'Skill Boost': 'misc_sb',
+    'Extend Time': 'misc_te',
+    'Two-Pronged Attack': 'misc_tpa',
+    'Damage Void Shield Penetration': 'misc_voidshield',
+    'Awoken Assist': 'misc_assist',
+    
+    'Enhanced Fire Orbs': 'oe_fire',
+    'Enhanced Water Orbs': 'oe_water',
+    'Enhanced Wood Orbs': 'oe_wood',
+    'Enhanced Light Orbs': 'oe_light',
+    'Enhanced Dark Orbs': 'oe_dark',
+    'Enhanced Heal Orbs': 'oe_heart',
+    
+    'Reduce Fire Damage': 'reduce_fire',
+    'Reduce Water Damage': 'reduce_water',
+    'Reduce Wood Damage': 'reduce_wood',
+    'Reduce Light Damage': 'reduce_light',
+    'Reduce Dark Damage': 'reduce_dark',
+    
+    'Resistance-Bind': 'res_bind',
+    'Resistance-Dark': 'res_blind',
+    'Resistance-Jammers': 'res_jammer',
+    'Resistance-Poison': 'res_poison',
+    'Resistance-Skill Bind': 'res_skillbind',
+    
+    'Enhanced Fire Att.': 'row_fire',
+    'Enhanced Water Att.': 'row_water',
+    'Enhanced Wood Att.': 'row_wood',
+    'Enhanced Light Att.': 'row_light',
+    'Enhanced Dark Att.': 'row_dark',
+    
+    'Skill Charge': 'misc_skillcharge',
+    'Super Additional Attack': 'misc_super_extraattack',
+    'Resistance-Bind＋': 'res_bind_super',
+    'Extend Time＋': 'misc_te_super',
+    'Resistance-Cloud': 'res_cloud',
+    'Resistance-Board Restrict': 'res_seal',
+    'Skill Boost＋': 'misc_sb_super',
+    'L-Shape Attack': 'l_attack',
+    'L-Shape Damage Reduction': 'l_shield',
+    'Enhance when HP is below 50%': 'attack_boost_low',
+    'Enhance when HP is above 80%': 'attack_boost_high',
+    'Combo Orb': 'orb_combo',
+    'Skill Voice': 'misc_voice',
+    'Dungeon Bonus': 'misc_dungeonbonus',
 }
 
 AWAKENING_NAME_MAP = {
-	'Enhanced Fire Orbs': 'R-OE',
-	'Enhanced Water Orbs': 'B-OE',
-	'Enhanced Wood Orbs': 'G-OE',
-	'Enhanced Light Orbs': 'L-OE',
-	'Enhanced Dark Orbs': 'D-OE',
-	'Enhanced Heal Orbs': 'H-OE',
-	
-	'Enhanced Fire Att.': 'R-RE',
-	'Enhanced Water Att.': 'B-RE',
-	'Enhanced Wood Att.': 'G-RE',
-	'Enhanced Light Att.': 'L-RE',
-	'Enhanced Dark Att.': 'D-RE',
-	
-	'Enhanced HP': 'HP',
-	'Enhanced Attack': 'ATK',
-	'Enhanced Heal': 'RCV',
-	
-	'Enhanced Team HP': 'TEAM-HP',
-	'Enhanced Team Attack': 'TEAM-ATK',
-	'Enhanced Team RCV': 'TEAM-RCV',
-	
-	'Auto-Recover': 'AUTO-RECOVER',
-	'Skill Boost': 'SB',
-	'Resistance-Skill Bind': 'SBR',
-	'Two-Pronged Attack': 'TPA',
-	'Multi Boost': 'MULTI-BOOST',
-	'Recover Bind': 'RCV-BIND',
-	'Extend Time': 'TE',
-	'Enhanced Combo': 'COMBO-BOOST',
-	'Guard Break': 'DEF-BREAK',
-	'Additional Attack': 'EXTRA-ATK',
-	'Damage Void Shield Penetration': 'VOID-BREAK',
-	'Awoken Assist': 'ASSIST',
-	
-	'Resistance-Bind': 'RES-BIND',
-	'Resistance-Dark': 'RES-BLIND',
-	'Resistance-Poison': 'RES-POISON',
-	'Resistance-Jammers': 'RES-JAMMER',
-	
-	'Reduce Fire Damage': 'R-RES',
-	'Reduce Water Damage': 'B-RES',
-	'Reduce Wood Damage': 'G-RES',
-	'Reduce Light Damage': 'L-RES',
-	'Reduce Dark Damage': 'D-RES',
-	
-	'Healer Killer': 'K-HEALER',
-	'Machine Killer': 'K-MACHINE',
-	'Dragon Killer': 'K-DRAGON',
-	'Attacker Killer': 'K-ATTACKER',
-	'Physical Killer': 'K-PHYSICAL',
-	'God Killer': 'K-GOD',
-	'Devil Killer': 'K-DEVIL',
-	'Balance Killer': 'K-BALANCE',
+    'Enhanced Fire Orbs': 'R-OE',
+    'Enhanced Water Orbs': 'B-OE',
+    'Enhanced Wood Orbs': 'G-OE',
+    'Enhanced Light Orbs': 'L-OE',
+    'Enhanced Dark Orbs': 'D-OE',
+    'Enhanced Heal Orbs': 'H-OE',
+    
+    'Enhanced Fire Att.': 'R-RE',
+    'Enhanced Water Att.': 'B-RE',
+    'Enhanced Wood Att.': 'G-RE',
+    'Enhanced Light Att.': 'L-RE',
+    'Enhanced Dark Att.': 'D-RE',
+    
+    'Enhanced HP': 'HP',
+    'Enhanced Attack': 'ATK',
+    'Enhanced Heal': 'RCV',
+    
+    'Enhanced Team HP': 'TEAM-HP',
+    'Enhanced Team Attack': 'TEAM-ATK',
+    'Enhanced Team RCV': 'TEAM-RCV',
+    
+    'Auto-Recover': 'AUTO-RECOVER',
+    'Skill Boost': 'SB',
+    'Resistance-Skill Bind': 'SBR',
+    'Two-Pronged Attack': 'TPA',
+    'Multi Boost': 'MULTI-BOOST',
+    'Recover Bind': 'RCV-BIND',
+    'Extend Time': 'TE',
+    'Enhanced Combo': 'COMBO-BOOST',
+    'Guard Break': 'DEF-BREAK',
+    'Additional Attack': 'EXTRA-ATK',
+    'Damage Void Shield Penetration': 'VOID-BREAK',
+    'Awoken Assist': 'ASSIST',
+    
+    'Resistance-Bind': 'RES-BIND',
+    'Resistance-Dark': 'RES-BLIND',
+    'Resistance-Poison': 'RES-POISON',
+    'Resistance-Jammers': 'RES-JAMMER',
+    
+    'Reduce Fire Damage': 'R-RES',
+    'Reduce Water Damage': 'B-RES',
+    'Reduce Wood Damage': 'G-RES',
+    'Reduce Light Damage': 'L-RES',
+    'Reduce Dark Damage': 'D-RES',
+    
+    'Healer Killer': 'K-HEALER',
+    'Machine Killer': 'K-MACHINE',
+    'Dragon Killer': 'K-DRAGON',
+    'Attacker Killer': 'K-ATTACKER',
+    'Physical Killer': 'K-PHYSICAL',
+    'God Killer': 'K-GOD',
+    'Devil Killer': 'K-DEVIL',
+    'Balance Killer': 'K-BALANCE',
 }
 
 def createMultiplierText(hp1, atk1, rcv1, resist1, hp2=None, atk2=None, rcv2=None, resist2=None):
-	hp2, atk2, rcv2, resist2 = hp2 or hp1, atk2 or atk1, rcv2 or rcv1, resist2 or resist1
-	
-	def fmtNum(val):
-		return ('{:.2f}').format(val).strip('0').rstrip('.')
-	
-	text = "{}/{}/{}".format(fmtNum(hp1 * hp2), fmtNum(atk1 * atk2), fmtNum(rcv1 * rcv2))
-	if resist1 * resist2 < 1:
-		resist1 = resist1 if resist1 < 1 else 0
-		resist2 = resist2 if resist2 < 1 else 0
-		text += ' Resist {}%'.format(fmtNum(100 * (1 - (1 - resist1) * (1 - resist2))))
-	return text
+    hp2, atk2, rcv2, resist2 = hp2 or hp1, atk2 or atk1, rcv2 or rcv1, resist2 or resist1
+    
+    def fmtNum(val):
+        return ('{:.2f}').format(val).strip('0').rstrip('.')
+    
+    text = "{}/{}/{}".format(fmtNum(hp1 * hp2), fmtNum(atk1 * atk2), fmtNum(rcv1 * rcv2))
+    if resist1 * resist2 < 1:
+        resist1 = resist1 if resist1 < 1 else 0
+        resist2 = resist2 if resist2 < 1 else 0
+        text += ' Resist {}%'.format(fmtNum(100 * (1 - (1 - resist1) * (1 - resist2))))
+    return text
 
 def _map_awakenings_text(m: padguide2.PgMonster):
-	awakenings_row = ''
-	unique_awakenings = set(m.awakening_names)
-	for a in unique_awakenings:
-		count = m.awakening_names.count(a)
-		awakenings_row += ' {}x{}'.format(AWAKENING_NAME_MAP.get(a, a), count)
-	awakenings_row = awakenings_row.strip()
-	
-	if not len(awakenings_row):
-		awakenings_row = 'No Awakenings'
-	
-	return awakenings_row
+    awakenings_row = ''
+    unique_awakenings = set(m.awakening_names)
+    for a in unique_awakenings:
+        count = m.awakening_names.count(a)
+        awakenings_row += ' {}x{}'.format(AWAKENING_NAME_MAP.get(a, a), count)
+    awakenings_row = awakenings_row.strip()
+    
+    if not len(awakenings_row):
+        awakenings_row = 'No Awakenings'
+    
+    return awakenings_row
 
 # TODO: move to padguide2
 def compute_killers(*types):
-	if 'Balance' in types:
-		return ['Any']
-	killers = set()
-	for t in types:
-		killers.update(type_to_killers_map.get(t, []))
-	return sorted(killers)
+    if 'Balance' in types:
+        return ['Any']
+    killers = set()
+    for t in types:
+        killers.update(type_to_killers_map.get(t, []))
+    return sorted(killers)
 
 type_to_killers_map = {
-	'God': ['Devil'],
-	'Devil': ['God'],
-	'Machine': ['God', 'Balance'],
-	'Dragon': ['Machine', 'Healer'],
-	'Physical': ['Machine', 'Healer'],
-	'Attacker': ['Devil', 'Physical'],
-	'Healer': ['Dragon', 'Attacker'],
+    'God': ['Devil'],
+    'Devil': ['God'],
+    'Machine': ['God', 'Balance'],
+    'Dragon': ['Machine', 'Healer'],
+    'Physical': ['Machine', 'Healer'],
+    'Attacker': ['Devil', 'Physical'],
+    'Healer': ['Dragon', 'Attacker'],
 }

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -56,1094 +56,1094 @@ SKYOZORA_TEMPLATE = 'http://pad.skyozora.com/pets/{}'
 
 
 def get_pdx_url(m):
-	return INFO_PDX_TEMPLATE.format(rpadutils.get_pdx_id(m))
+    return INFO_PDX_TEMPLATE.format(rpadutils.get_pdx_id(m))
 
 
 def get_portrait_url(m):
-	if int(m.monster_no) != m.monster_no_na:
-		return RPAD_PORTRAIT_TEMPLATE.format('na', m.monster_no_na)
-	else:
-		return RPAD_PORTRAIT_TEMPLATE.format('jp', m.monster_no_jp)
+    if int(m.monster_no) != m.monster_no_na:
+        return RPAD_PORTRAIT_TEMPLATE.format('na', m.monster_no_na)
+    else:
+        return RPAD_PORTRAIT_TEMPLATE.format('jp', m.monster_no_jp)
 
 
 def get_pic_url(m):
-	if int(m.monster_no) != m.monster_no_na:
-		return RPAD_PIC_TEMPLATE.format('na', m.monster_no_na)
-	else:
-		return RPAD_PIC_TEMPLATE.format('jp', m.monster_no_jp)
+    if int(m.monster_no) != m.monster_no_na:
+        return RPAD_PIC_TEMPLATE.format('na', m.monster_no_na)
+    else:
+        return RPAD_PIC_TEMPLATE.format('jp', m.monster_no_jp)
 
 
 class PadInfo:
-	def __init__(self, bot):
-		self.bot = bot
-		
-		self.settings = PadInfoSettings("padinfo")
-		
-		self.index_all = padguide2.empty_index()
-		self.index_na = padguide2.empty_index()
-		
-		self.menu = Menu(bot)
-		
-		# These emojis are the keys into the idmenu submenus
-		self.id_emoji = '\N{INFORMATION SOURCE}'
-		self.evo_emoji = char_to_emoji('e')
-		self.mats_emoji = char_to_emoji('m')
-		self.ls_emoji = '\N{INFORMATION SOURCE}'
-		self.left_emoji = char_to_emoji('l')
-		self.right_emoji = char_to_emoji('r')
-		self.pantheon_emoji = '\N{CLASSICAL BUILDING}'
-		self.skillups_emoji = '\N{MEAT ON BONE}'
-		self.pic_emoji = '\N{FRAME WITH PICTURE}'
-		self.other_info_emoji = '\N{SCROLL}'
-		
-		self.historic_lookups_file_path = "data/padinfo/historic_lookups.json"
-		self.historic_lookups_file_path_id2 = "data/padinfo/historic_lookups_id2.json"
+    def __init__(self, bot):
+        self.bot = bot
+        
+        self.settings = PadInfoSettings("padinfo")
+        
+        self.index_all = padguide2.empty_index()
+        self.index_na = padguide2.empty_index()
+        
+        self.menu = Menu(bot)
+        
+        # These emojis are the keys into the idmenu submenus
+        self.id_emoji = '\N{INFORMATION SOURCE}'
+        self.evo_emoji = char_to_emoji('e')
+        self.mats_emoji = char_to_emoji('m')
+        self.ls_emoji = '\N{INFORMATION SOURCE}'
+        self.left_emoji = char_to_emoji('l')
+        self.right_emoji = char_to_emoji('r')
+        self.pantheon_emoji = '\N{CLASSICAL BUILDING}'
+        self.skillups_emoji = '\N{MEAT ON BONE}'
+        self.pic_emoji = '\N{FRAME WITH PICTURE}'
+        self.other_info_emoji = '\N{SCROLL}'
+        
+        self.historic_lookups_file_path = "data/padinfo/historic_lookups.json"
+        self.historic_lookups_file_path_id2 = "data/padinfo/historic_lookups_id2.json"
   
-		if not dataIO.is_valid_json(self.historic_lookups_file_path):
-			print("Creating empty historic_lookups.json...")
-			dataIO.save_json(self.historic_lookups_file_path, {})
+        if not dataIO.is_valid_json(self.historic_lookups_file_path):
+            print("Creating empty historic_lookups.json...")
+            dataIO.save_json(self.historic_lookups_file_path, {})
 
-		if not dataIO.is_valid_json(self.historic_lookups_file_path_id2):
-			print("Creating empty historic_lookups_id2.json...")
-			dataIO.save_json(self.historic_lookups_file_path_id2, {})
+        if not dataIO.is_valid_json(self.historic_lookups_file_path_id2):
+            print("Creating empty historic_lookups_id2.json...")
+            dataIO.save_json(self.historic_lookups_file_path_id2, {})
 
-		self.historic_lookups = dataIO.load_json(self.historic_lookups_file_path)
-		self.historic_lookups_id2 = dataIO.load_json(self.historic_lookups_file_path_id2)
-	
-	def __unload(self):
-		# Manually nulling out database because the GC for cogs seems to be pretty shitty
-		self.index_all = padguide2.empty_index()
-		self.index_na = padguide2.empty_index()
-		self.historic_lookups = {}
-		self.historic_lookups_id2 = {}
-	
-	async def reload_nicknames(self):
-		await self.bot.wait_until_ready()
-		while self == self.bot.get_cog('PadInfo'):
-			try:
-				await self.refresh_index()
-				print('Done refreshing PadInfo')
-			except Exception as ex:
-				print("reload padinfo loop caught exception " + str(ex))
-				traceback.print_exc()
-			
-			await asyncio.sleep(60 * 60 * 1)
-	
-	async def refresh_index(self):
-		"""Refresh the monster indexes."""
-		pg_cog = self.bot.get_cog('PadGuide2')
-		await pg_cog.wait_until_ready()
-		self.index_all = pg_cog.create_index()
-		self.index_na = pg_cog.create_index(lambda m: m.on_na)
-	
-	def get_monster_by_no(self, monster_no: int):
-		pg_cog = self.bot.get_cog('PadGuide2')
-		return pg_cog.get_monster_by_no(monster_no)
-	
-	@commands.command(pass_context=True)
-	async def skillrotation(self, ctx, server: str = 'NA'):
-		"""Print the current rotating skillups for a server (NA/JP)"""
-		server = normalizeServer(server)
-		if server not in ['NA', 'JP']:
-			await self.bot.say(inline('Supported servers are NA, JP'))
-			return
-		
-		pg_cog = self.bot.get_cog('PadGuide2')
-		monsters = pg_cog.database.rotating_skillups(server)
-		
-		for page in pagify(monsters_to_rotation_list(monsters, server, self.index_all)):
-			await self.bot.say(box(page))
-	
-	@commands.command(pass_context=True)
-	async def jpname(self, ctx, *, query: str):
-		"""Print the Japanese name of a monster"""
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			await self.bot.say(monsterToHeader(m))
-			await self.bot.say(box(m.name_jp))
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(name="id", pass_context=True)
-	async def _do_id_all(self, ctx, *, query: str):
-		"""Monster info (main tab)"""
-		await self._do_id(ctx, query)
-	
-	@commands.command(name="idna", pass_context=True)
-	async def _do_id_na(self, ctx, *, query: str):
-		"""Monster info (limited to NA monsters ONLY)"""
-		await self._do_id(ctx, query, na_only=True)
-	
-	async def _do_id(self, ctx, query: str, na_only=False):
-		m, err, debug_info = self.findMonster(query, na_only=na_only)
-		if m is not None:
-			await self._do_idmenu(ctx, m, self.id_emoji)
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(name="id2", pass_context=True)
-	async def _do_id2_all(self, ctx, *, query: str):
-		"""Monster info (main tab)"""
-		await self._do_id2(ctx, query)
-	
-	@commands.command(name="id2na", pass_context=True)
-	async def _do_id2_na(self, ctx, *, query: str):
-		"""Monster info (limited to NA monsters ONLY)"""
-		await self._do_id2(ctx, query, na_only=True)
-	
-	async def _do_id2(self, ctx, query: str, na_only=False):
-		m, err, debug_info = self.findMonster2(query, na_only=na_only)
-		if m is not None:
-			await self._do_idmenu(ctx, m, self.id_emoji)
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(name="evos", pass_context=True)
-	async def evos(self, ctx, *, query: str):
-		"""Monster info (evolutions tab)"""
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			await self._do_idmenu(ctx, m, self.evo_emoji)
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(name="mats", pass_context=True, aliases=['evomats', 'evomat'])
-	async def evomats(self, ctx, *, query: str):
-		"""Monster info (evo materials tab)"""
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			await self._do_idmenu(ctx, m, self.mats_emoji)
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(pass_context=True)
-	async def pantheon(self, ctx, *, query: str):
-		"""Monster info (pantheon tab)"""
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			menu = await self._do_idmenu(ctx, m, self.pantheon_emoji)
-			if menu == EMBED_NOT_GENERATED:
-				await self.bot.say(inline('Not a pantheon monster'))
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(pass_context=True)
-	async def skillups(self, ctx, *, query: str):
-		"""Monster info (evolutions tab)"""
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			menu = await self._do_idmenu(ctx, m, self.skillups_emoji)
-			if menu == EMBED_NOT_GENERATED:
-				await self.bot.say(inline('No skillups available'))
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	async def _do_idmenu(self, ctx, m, starting_menu_emoji):
-		id_embed = monsterToEmbed(m, self.get_emojis())
-		evo_embed = monsterToEvoEmbed(m)
-		mats_embed = monsterToEvoMatsEmbed(m)
-		animated = self.check_monster_animated(m.monster_no_jp)
-		pic_embed = monsterToPicEmbed(m, animated=animated)
-		other_info_embed = monsterToOtherInfoEmbed(m)
-		
-		emoji_to_embed = OrderedDict()
-		emoji_to_embed[self.id_emoji] = id_embed
-		emoji_to_embed[self.evo_emoji] = evo_embed
-		emoji_to_embed[self.mats_emoji] = mats_embed
-		emoji_to_embed[self.pic_emoji] = pic_embed
-		
-		pantheon_embed = monsterToPantheonEmbed(m)
-		if pantheon_embed:
-			emoji_to_embed[self.pantheon_emoji] = pantheon_embed
-		
-		skillups_embed = monsterToSkillupsEmbed(m)
-		if skillups_embed:
-			emoji_to_embed[self.skillups_emoji] = skillups_embed
-		
-		emoji_to_embed[self.other_info_emoji] = other_info_embed
-		
-		return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed)
-	
-	async def _do_evolistmenu(self, ctx, sm):
-		monsters = sm.alt_evos
-		monsters.sort(key=lambda m: m.monster_no)
-		
-		emoji_to_embed = OrderedDict()
-		for idx, m in enumerate(monsters):
-			emoji = char_to_emoji(str(idx))
-			emoji_to_embed[emoji] = monsterToEmbed(m, self.get_emojis())
-			if m == sm:
-				starting_menu_emoji = emoji
-		
-		return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed, timeout=60)
-	
-	async def _do_menu(self, ctx, starting_menu_emoji, emoji_to_embed, timeout=30):
-		if starting_menu_emoji not in emoji_to_embed:
-			# Selected menu wasn't generated for this monster
-			return EMBED_NOT_GENERATED
-		
-		remove_emoji = self.menu.emoji['no']
-		emoji_to_embed[remove_emoji] = self.menu.reaction_delete_message
-		
-		try:
-			result_msg, result_embed = await self.menu.custom_menu(ctx, emoji_to_embed, starting_menu_emoji,
-																   timeout=timeout)
-			if result_msg and result_embed:
-				# Message is finished but not deleted, clear the footer
-				result_embed.set_footer(text=discord.Embed.Empty)
-				await self.bot.edit_message(result_msg, embed=result_embed)
-		except Exception as ex:
-			print('Menu failure', ex)
-	
-	@commands.command(pass_context=True, aliases=['img'])
-	async def pic(self, ctx, *, query: str):
-		"""Monster info (full image tab)"""
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			await self._do_idmenu(ctx, m, self.pic_emoji)
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(pass_context=True, aliases=['stats'])
-	async def otherinfo(self, ctx, *, query: str):
-		"""Monster info (misc info tab)"""
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			await self._do_idmenu(ctx, m, self.other_info_emoji)
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(pass_context=True)
-	async def lookup(self, ctx, *, query: str):
-		"""Short info results for a monster query"""
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			embed = monsterToHeaderEmbed(m)
-			await self.bot.say(embed=embed)
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(pass_context=True)
-	async def evolist(self, ctx, *, query):
-		"""Monster info (for all monsters in the evo tree)"""
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			await self._do_evolistmenu(ctx, m)
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.command(pass_context=True, aliases=['leaders', 'leaderskills', 'ls'])
-	async def leaderskill(self, ctx, left_query: str, right_query: str = None, *, bad=None):
-		"""Display the multiplier and leaderskills for two monsters
+        self.historic_lookups = dataIO.load_json(self.historic_lookups_file_path)
+        self.historic_lookups_id2 = dataIO.load_json(self.historic_lookups_file_path_id2)
+    
+    def __unload(self):
+        # Manually nulling out database because the GC for cogs seems to be pretty shitty
+        self.index_all = padguide2.empty_index()
+        self.index_na = padguide2.empty_index()
+        self.historic_lookups = {}
+        self.historic_lookups_id2 = {}
+    
+    async def reload_nicknames(self):
+        await self.bot.wait_until_ready()
+        while self == self.bot.get_cog('PadInfo'):
+            try:
+                await self.refresh_index()
+                print('Done refreshing PadInfo')
+            except Exception as ex:
+                print("reload padinfo loop caught exception " + str(ex))
+                traceback.print_exc()
+            
+            await asyncio.sleep(60 * 60 * 1)
+    
+    async def refresh_index(self):
+        """Refresh the monster indexes."""
+        pg_cog = self.bot.get_cog('PadGuide2')
+        await pg_cog.wait_until_ready()
+        self.index_all = pg_cog.create_index()
+        self.index_na = pg_cog.create_index(lambda m: m.on_na)
+    
+    def get_monster_by_no(self, monster_no: int):
+        pg_cog = self.bot.get_cog('PadGuide2')
+        return pg_cog.get_monster_by_no(monster_no)
+    
+    @commands.command(pass_context=True)
+    async def skillrotation(self, ctx, server: str = 'NA'):
+        """Print the current rotating skillups for a server (NA/JP)"""
+        server = normalizeServer(server)
+        if server not in ['NA', 'JP']:
+            await self.bot.say(inline('Supported servers are NA, JP'))
+            return
+        
+        pg_cog = self.bot.get_cog('PadGuide2')
+        monsters = pg_cog.database.rotating_skillups(server)
+        
+        for page in pagify(monsters_to_rotation_list(monsters, server, self.index_all)):
+            await self.bot.say(box(page))
+    
+    @commands.command(pass_context=True)
+    async def jpname(self, ctx, *, query: str):
+        """Print the Japanese name of a monster"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self.bot.say(monsterToHeader(m))
+            await self.bot.say(box(m.name_jp))
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    @commands.command(name="id", pass_context=True)
+    async def _do_id_all(self, ctx, *, query: str):
+        """Monster info (main tab)"""
+        await self._do_id(ctx, query)
+    
+    @commands.command(name="idna", pass_context=True)
+    async def _do_id_na(self, ctx, *, query: str):
+        """Monster info (limited to NA monsters ONLY)"""
+        await self._do_id(ctx, query, na_only=True)
+    
+    async def _do_id(self, ctx, query: str, na_only=False):
+        m, err, debug_info = self.findMonster(query, na_only=na_only)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.id_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    @commands.command(name="id2", pass_context=True)
+    async def _do_id2_all(self, ctx, *, query: str):
+        """Monster info (main tab)"""
+        await self._do_id2(ctx, query)
+    
+    @commands.command(name="id2na", pass_context=True)
+    async def _do_id2_na(self, ctx, *, query: str):
+        """Monster info (limited to NA monsters ONLY)"""
+        await self._do_id2(ctx, query, na_only=True)
+    
+    async def _do_id2(self, ctx, query: str, na_only=False):
+        m, err, debug_info = self.findMonster2(query, na_only=na_only)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.id_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    @commands.command(name="evos", pass_context=True)
+    async def evos(self, ctx, *, query: str):
+        """Monster info (evolutions tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.evo_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    @commands.command(name="mats", pass_context=True, aliases=['evomats', 'evomat'])
+    async def evomats(self, ctx, *, query: str):
+        """Monster info (evo materials tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.mats_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    @commands.command(pass_context=True)
+    async def pantheon(self, ctx, *, query: str):
+        """Monster info (pantheon tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            menu = await self._do_idmenu(ctx, m, self.pantheon_emoji)
+            if menu == EMBED_NOT_GENERATED:
+                await self.bot.say(inline('Not a pantheon monster'))
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    @commands.command(pass_context=True)
+    async def skillups(self, ctx, *, query: str):
+        """Monster info (evolutions tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            menu = await self._do_idmenu(ctx, m, self.skillups_emoji)
+            if menu == EMBED_NOT_GENERATED:
+                await self.bot.say(inline('No skillups available'))
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    async def _do_idmenu(self, ctx, m, starting_menu_emoji):
+        id_embed = monsterToEmbed(m, self.get_emojis())
+        evo_embed = monsterToEvoEmbed(m)
+        mats_embed = monsterToEvoMatsEmbed(m)
+        animated = self.check_monster_animated(m.monster_no_jp)
+        pic_embed = monsterToPicEmbed(m, animated=animated)
+        other_info_embed = monsterToOtherInfoEmbed(m)
+        
+        emoji_to_embed = OrderedDict()
+        emoji_to_embed[self.id_emoji] = id_embed
+        emoji_to_embed[self.evo_emoji] = evo_embed
+        emoji_to_embed[self.mats_emoji] = mats_embed
+        emoji_to_embed[self.pic_emoji] = pic_embed
+        
+        pantheon_embed = monsterToPantheonEmbed(m)
+        if pantheon_embed:
+            emoji_to_embed[self.pantheon_emoji] = pantheon_embed
+        
+        skillups_embed = monsterToSkillupsEmbed(m)
+        if skillups_embed:
+            emoji_to_embed[self.skillups_emoji] = skillups_embed
+        
+        emoji_to_embed[self.other_info_emoji] = other_info_embed
+        
+        return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed)
+    
+    async def _do_evolistmenu(self, ctx, sm):
+        monsters = sm.alt_evos
+        monsters.sort(key=lambda m: m.monster_no)
+        
+        emoji_to_embed = OrderedDict()
+        for idx, m in enumerate(monsters):
+            emoji = char_to_emoji(str(idx))
+            emoji_to_embed[emoji] = monsterToEmbed(m, self.get_emojis())
+            if m == sm:
+                starting_menu_emoji = emoji
+        
+        return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed, timeout=60)
+    
+    async def _do_menu(self, ctx, starting_menu_emoji, emoji_to_embed, timeout=30):
+        if starting_menu_emoji not in emoji_to_embed:
+            # Selected menu wasn't generated for this monster
+            return EMBED_NOT_GENERATED
+        
+        remove_emoji = self.menu.emoji['no']
+        emoji_to_embed[remove_emoji] = self.menu.reaction_delete_message
+        
+        try:
+            result_msg, result_embed = await self.menu.custom_menu(ctx, emoji_to_embed, starting_menu_emoji,
+                                                                   timeout=timeout)
+            if result_msg and result_embed:
+                # Message is finished but not deleted, clear the footer
+                result_embed.set_footer(text=discord.Embed.Empty)
+                await self.bot.edit_message(result_msg, embed=result_embed)
+        except Exception as ex:
+            print('Menu failure', ex)
+    
+    @commands.command(pass_context=True, aliases=['img'])
+    async def pic(self, ctx, *, query: str):
+        """Monster info (full image tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.pic_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    @commands.command(pass_context=True, aliases=['stats'])
+    async def otherinfo(self, ctx, *, query: str):
+        """Monster info (misc info tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.other_info_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    @commands.command(pass_context=True)
+    async def lookup(self, ctx, *, query: str):
+        """Short info results for a monster query"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            embed = monsterToHeaderEmbed(m)
+            await self.bot.say(embed=embed)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    @commands.command(pass_context=True)
+    async def evolist(self, ctx, *, query):
+        """Monster info (for all monsters in the evo tree)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self._do_evolistmenu(ctx, m)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    @commands.command(pass_context=True, aliases=['leaders', 'leaderskills', 'ls'])
+    async def leaderskill(self, ctx, left_query: str, right_query: str = None, *, bad=None):
+        """Display the multiplier and leaderskills for two monsters
 
         If either your left or right query contains spaces, wrap in quotes.
         e.g.: ^leaderskill "r sonia" "b sonia"
         """
-		if bad:
-			await self.bot.say(inline('Too many inputs. Try wrapping your queries in quotes.'))
-			return
-		
-		# Handle a very specific failure case, user typing something like "uuvo ragdra"
-		if ' ' not in left_query and right_query is not None and ' ' not in right_query and bad is None:
-			combined_query = left_query + ' ' + right_query
-			nm, err, debug_info = self._findMonster(combined_query)
-			if nm and left_query in nm.prefixes:
-				left_query = combined_query
-				right_query = None
-		
-		left_m, left_err, _ = self.findMonster(left_query)
-		if right_query:
-			right_m, right_err, _ = self.findMonster(right_query)
-		else:
-			right_m, right_err, = left_m, left_err
-		
-		err_msg = '{} query failed to match a monster: [ {} ]. If your query is multiple words, wrap it in quotes.'
-		if left_err:
-			await self.bot.say(inline(err_msg.format('Left', left_query)))
-			return
-		if right_err:
-			await self.bot.say(inline(err_msg.format('Right', right_query)))
-			return
-		
-		emoji_to_embed = OrderedDict()
-		emoji_to_embed[self.ls_emoji] = monstersToLsEmbed(left_m, right_m)
-		emoji_to_embed[self.left_emoji] = monsterToEmbed(left_m, self.get_emojis())
-		emoji_to_embed[self.right_emoji] = monsterToEmbed(right_m, self.get_emojis())
-		
-		await self._do_menu(ctx, self.ls_emoji, emoji_to_embed)
-	
-	@commands.command(name="helpid", pass_context=True, aliases=['helppic', 'helpimg'])
-	async def _helpid(self, ctx):
-		"""Whispers you info on how to craft monster queries for ^id"""
-		await self.bot.whisper(box(HELP_MSG))
-	
-	@commands.command(pass_context=True)
-	async def padsay(self, ctx, server, *, query: str = None):
-		"""Speak the voice line of a monster into your current chat"""
-		voice = ctx.message.author.voice
-		channel = voice.voice_channel
-		if channel is None:
-			await self.bot.say(inline('You must be in a voice channel to use this command'))
-			return
-		
-		speech_cog = self.bot.get_cog('Speech')
-		if not speech_cog:
-			await self.bot.say(inline('Speech seems to be offline'))
-			return
-		
-		if server.lower() not in ['na', 'jp']:
-			query = server + ' ' + (query or '')
-			server = 'na'
-		query = query.strip().lower()
-		
-		m, err, debug_info = self.findMonster(query)
-		if m is not None:
-			base_dir = '/home/tactical0retreat/pad_data/voices/fixed'
-			voice_file = os.path.join(base_dir, server, '{}.wav'.format(m.monster_no_na))
-			header = '{} ({})'.format(monsterToHeader(m), server)
-			if not os.path.exists(voice_file):
-				await self.bot.say(inline('Could not find voice for ' + header))
-				return
-			await self.bot.say('Speaking for ' + header)
-			await speech_cog.play_path(channel, voice_file)
-		else:
-			await self.bot.say(self.makeFailureMsg(err))
-	
-	@commands.group(pass_context=True)
-	@checks.is_owner()
-	async def padinfo(self, ctx):
-		"""PAD info management"""
-		if ctx.invoked_subcommand is None:
-			await send_cmd_help(ctx)
-	
-	@padinfo.command(pass_context=True)
-	@checks.is_owner()
-	async def setemojiservers(self, ctx, *, emoji_servers=''):
-		"""Set the emoji servers by ID (csv)"""
-		self.settings.emojiServers().clear()
-		if emoji_servers:
-			self.settings.setEmojiServers(emoji_servers.split(','))
-		await self.bot.say(inline('Set {} servers'.format(len(self.settings.emojiServers()))))
-	
-	def get_emojis(self):
-		server_ids = self.settings.emojiServers()
-		return [e for s in self.bot.servers if s.id in server_ids for e in s.emojis]
-	
-	def makeFailureMsg(self, err):
-		msg = 'Lookup failed: {}.\n'.format(err)
-		msg += 'Try one of <id>, <name>, [argbld]/[rgbld] <name>. Unexpected results? Use ^helpid for more info.'
-		return box(msg)
-	
-	def findMonster(self, query, na_only=False):
-		query = rmdiacritics(query)
-		nm, err, debug_info = self._findMonster(query, na_only)
-		
-		monster_no = nm.monster_no if nm else -1
-		self.historic_lookups[query] = monster_no
-		dataIO.save_json(self.historic_lookups_file_path, self.historic_lookups)
-		
-		m = self.get_monster_by_no(nm.monster_no) if nm else None
-		
-		return m, err, debug_info
-	
-	def _findMonster(self, query, na_only=False):
-		monster_index = self.index_na if na_only else self.index_all
-		return monster_index.find_monster(query)
-	
-	def findMonster2(self, query, na_only=False):
-		query = rmdiacritics(query)
-		nm, err, debug_info = self._findMonster2(query, na_only)
-		
-		monster_no = nm.monster_no if nm else -1
-		self.historic_lookups_id2[query] = monster_no
-		dataIO.save_json(self.historic_lookups_file_path_id2, self.historic_lookups_id2)
-		
-		m = self.get_monster_by_no(nm.monster_no) if nm else None
-		
-		return m, err, debug_info
-	
-	def _findMonster2(self, query, na_only=False):
-		monster_index = self.index_na if na_only else self.index_all
-		return monster_index.find_monster2(query)
-	
-	def map_awakenings_text(self, m):
-		"""Exported for use in other cogs"""
-		return _map_awakenings_text(m)
-	
-	@padinfo.command(pass_context=True)
-	@checks.is_owner()
-	async def setanimationdir(self, ctx, *, animation_dir=''):
-		"""Set a directory containing animated images"""
-		self.settings.setAnimationDir(animation_dir)
-		await self.bot.say(inline('Done'))
-	
-	def check_monster_animated(self, monster_id: int):
-		if not self.settings.animationDir():
-			return False
-		
-		try:
-			animated_ids = set()
-			for f in os.listdir(self.settings.animationDir()):
-				f = f.replace('.mp4', '')
-				if f.isdigit() and int(f) == monster_id:
-					return True
-		except:
-			pass
-		
-		return False
+        if bad:
+            await self.bot.say(inline('Too many inputs. Try wrapping your queries in quotes.'))
+            return
+        
+        # Handle a very specific failure case, user typing something like "uuvo ragdra"
+        if ' ' not in left_query and right_query is not None and ' ' not in right_query and bad is None:
+            combined_query = left_query + ' ' + right_query
+            nm, err, debug_info = self._findMonster(combined_query)
+            if nm and left_query in nm.prefixes:
+                left_query = combined_query
+                right_query = None
+        
+        left_m, left_err, _ = self.findMonster(left_query)
+        if right_query:
+            right_m, right_err, _ = self.findMonster(right_query)
+        else:
+            right_m, right_err, = left_m, left_err
+        
+        err_msg = '{} query failed to match a monster: [ {} ]. If your query is multiple words, wrap it in quotes.'
+        if left_err:
+            await self.bot.say(inline(err_msg.format('Left', left_query)))
+            return
+        if right_err:
+            await self.bot.say(inline(err_msg.format('Right', right_query)))
+            return
+        
+        emoji_to_embed = OrderedDict()
+        emoji_to_embed[self.ls_emoji] = monstersToLsEmbed(left_m, right_m)
+        emoji_to_embed[self.left_emoji] = monsterToEmbed(left_m, self.get_emojis())
+        emoji_to_embed[self.right_emoji] = monsterToEmbed(right_m, self.get_emojis())
+        
+        await self._do_menu(ctx, self.ls_emoji, emoji_to_embed)
+    
+    @commands.command(name="helpid", pass_context=True, aliases=['helppic', 'helpimg'])
+    async def _helpid(self, ctx):
+        """Whispers you info on how to craft monster queries for ^id"""
+        await self.bot.whisper(box(HELP_MSG))
+    
+    @commands.command(pass_context=True)
+    async def padsay(self, ctx, server, *, query: str = None):
+        """Speak the voice line of a monster into your current chat"""
+        voice = ctx.message.author.voice
+        channel = voice.voice_channel
+        if channel is None:
+            await self.bot.say(inline('You must be in a voice channel to use this command'))
+            return
+        
+        speech_cog = self.bot.get_cog('Speech')
+        if not speech_cog:
+            await self.bot.say(inline('Speech seems to be offline'))
+            return
+        
+        if server.lower() not in ['na', 'jp']:
+            query = server + ' ' + (query or '')
+            server = 'na'
+        query = query.strip().lower()
+        
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            base_dir = '/home/tactical0retreat/pad_data/voices/fixed'
+            voice_file = os.path.join(base_dir, server, '{}.wav'.format(m.monster_no_na))
+            header = '{} ({})'.format(monsterToHeader(m), server)
+            if not os.path.exists(voice_file):
+                await self.bot.say(inline('Could not find voice for ' + header))
+                return
+            await self.bot.say('Speaking for ' + header)
+            await speech_cog.play_path(channel, voice_file)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    @commands.group(pass_context=True)
+    @checks.is_owner()
+    async def padinfo(self, ctx):
+        """PAD info management"""
+        if ctx.invoked_subcommand is None:
+            await send_cmd_help(ctx)
+    
+    @padinfo.command(pass_context=True)
+    @checks.is_owner()
+    async def setemojiservers(self, ctx, *, emoji_servers=''):
+        """Set the emoji servers by ID (csv)"""
+        self.settings.emojiServers().clear()
+        if emoji_servers:
+            self.settings.setEmojiServers(emoji_servers.split(','))
+        await self.bot.say(inline('Set {} servers'.format(len(self.settings.emojiServers()))))
+    
+    def get_emojis(self):
+        server_ids = self.settings.emojiServers()
+        return [e for s in self.bot.servers if s.id in server_ids for e in s.emojis]
+    
+    def makeFailureMsg(self, err):
+        msg = 'Lookup failed: {}.\n'.format(err)
+        msg += 'Try one of <id>, <name>, [argbld]/[rgbld] <name>. Unexpected results? Use ^helpid for more info.'
+        return box(msg)
+    
+    def findMonster(self, query, na_only=False):
+        query = rmdiacritics(query)
+        nm, err, debug_info = self._findMonster(query, na_only)
+        
+        monster_no = nm.monster_no if nm else -1
+        self.historic_lookups[query] = monster_no
+        dataIO.save_json(self.historic_lookups_file_path, self.historic_lookups)
+        
+        m = self.get_monster_by_no(nm.monster_no) if nm else None
+        
+        return m, err, debug_info
+    
+    def _findMonster(self, query, na_only=False):
+        monster_index = self.index_na if na_only else self.index_all
+        return monster_index.find_monster(query)
+    
+    def findMonster2(self, query, na_only=False):
+        query = rmdiacritics(query)
+        nm, err, debug_info = self._findMonster2(query, na_only)
+        
+        monster_no = nm.monster_no if nm else -1
+        self.historic_lookups_id2[query] = monster_no
+        dataIO.save_json(self.historic_lookups_file_path_id2, self.historic_lookups_id2)
+        
+        m = self.get_monster_by_no(nm.monster_no) if nm else None
+        
+        return m, err, debug_info
+    
+    def _findMonster2(self, query, na_only=False):
+        monster_index = self.index_na if na_only else self.index_all
+        return monster_index.find_monster2(query)
+    
+    def map_awakenings_text(self, m):
+        """Exported for use in other cogs"""
+        return _map_awakenings_text(m)
+    
+    @padinfo.command(pass_context=True)
+    @checks.is_owner()
+    async def setanimationdir(self, ctx, *, animation_dir=''):
+        """Set a directory containing animated images"""
+        self.settings.setAnimationDir(animation_dir)
+        await self.bot.say(inline('Done'))
+    
+    def check_monster_animated(self, monster_id: int):
+        if not self.settings.animationDir():
+            return False
+        
+        try:
+            animated_ids = set()
+            for f in os.listdir(self.settings.animationDir()):
+                f = f.replace('.mp4', '')
+                if f.isdigit() and int(f) == monster_id:
+                    return True
+        except:
+            pass
+        
+        return False
 
 
 def setup(bot):
-	print('padinfo bot setup')
-	n = PadInfo(bot)
-	bot.add_cog(n)
-	bot.loop.create_task(n.reload_nicknames())
-	print('done adding padinfo bot')
+    print('padinfo bot setup')
+    n = PadInfo(bot)
+    bot.add_cog(n)
+    bot.loop.create_task(n.reload_nicknames())
+    print('done adding padinfo bot')
 
 
 class PadInfoSettings(CogSettings):
-	def make_default_settings(self):
-		config = {
-			'animation_dir': '',
-		}
-		return config
-	
-	def emojiServers(self):
-		key = 'emoji_servers'
-		if key not in self.bot_settings:
-			self.bot_settings[key] = []
-		return self.bot_settings[key]
-	
-	def setEmojiServers(self, emoji_servers):
-		es = self.emojiServers()
-		es.clear()
-		es.extend(emoji_servers)
-		self.save_settings()
-	
-	def animationDir(self):
-		return self.bot_settings['animation_dir']
-	
-	def setAnimationDir(self, animation_dir):
-		self.bot_settings['animation_dir'] = animation_dir
-		self.save_settings()
+    def make_default_settings(self):
+        config = {
+            'animation_dir': '',
+        }
+        return config
+    
+    def emojiServers(self):
+        key = 'emoji_servers'
+        if key not in self.bot_settings:
+            self.bot_settings[key] = []
+        return self.bot_settings[key]
+    
+    def setEmojiServers(self, emoji_servers):
+        es = self.emojiServers()
+        es.clear()
+        es.extend(emoji_servers)
+        self.save_settings()
+    
+    def animationDir(self):
+        return self.bot_settings['animation_dir']
+    
+    def setAnimationDir(self, animation_dir):
+        self.bot_settings['animation_dir'] = animation_dir
+        self.save_settings()
 
 
 def monsterToHeader(m: padguide2.PgMonster, link=False):
-	msg = 'No. {} {}'.format(m.monster_no_na, m.name_na)
-	return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
+    msg = 'No. {} {}'.format(m.monster_no_na, m.name_na)
+    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
 
 
 def monsterToJpSuffix(m: padguide2.PgMonster):
-	suffix = ""
-	if m.roma_subname:
-		suffix += ' [{}]'.format(m.roma_subname)
-	if not m.on_na:
-		suffix += ' (JP only)'
-	return suffix
+    suffix = ""
+    if m.roma_subname:
+        suffix += ' [{}]'.format(m.roma_subname)
+    if not m.on_na:
+        suffix += ' (JP only)'
+    return suffix
 
 
 def monsterToLongHeader(m: padguide2.PgMonster, link=False):
-	msg = monsterToHeader(m) + monsterToJpSuffix(m)
-	return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
+    msg = monsterToHeader(m) + monsterToJpSuffix(m)
+    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
 
 
 def monsterToLongHeaderWithAttr(m: padguide2.PgMonster, link=False):
-	header = 'No. {} {} {}'.format(
-		m.monster_no_na,
-		"({}{})".format(attr_prefix_map[m.attr1], "/" +
-												  attr_prefix_map[m.attr2] if m.attr2 else ""),
-		m.name_na)
-	msg = header + monsterToJpSuffix(m)
-	return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
+    header = 'No. {} {} {}'.format(
+        m.monster_no_na,
+        "({}{})".format(attr_prefix_map[m.attr1], "/" +
+                                                  attr_prefix_map[m.attr2] if m.attr2 else ""),
+        m.name_na)
+    msg = header + monsterToJpSuffix(m)
+    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
 
 
 def monsterToEvoText(m: padguide2.PgMonster):
-	output = monsterToLongHeader(m)
-	for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
-		output += "\n\t- {}".format(monsterToLongHeader(ae))
-	return output
+    output = monsterToLongHeader(m)
+    for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
+        output += "\n\t- {}".format(monsterToLongHeader(ae))
+    return output
 
 
 def monsterToThumbnailUrl(m: padguide2.PgMonster):
-	return get_portrait_url(m)
+    return get_portrait_url(m)
 
 
 def monsterToBaseEmbed(m: padguide2.PgMonster):
-	header = monsterToLongHeader(m)
-	embed = discord.Embed()
-	embed.set_thumbnail(url=monsterToThumbnailUrl(m))
-	embed.title = header
-	embed.url = get_pdx_url(m)
-	embed.set_footer(text='Requester may click the reactions below to switch tabs')
-	return embed
+    header = monsterToLongHeader(m)
+    embed = discord.Embed()
+    embed.set_thumbnail(url=monsterToThumbnailUrl(m))
+    embed.title = header
+    embed.url = get_pdx_url(m)
+    embed.set_footer(text='Requester may click the reactions below to switch tabs')
+    return embed
 
 
 def monsterToEvoEmbed(m: padguide2.PgMonster):
-	embed = monsterToBaseEmbed(m)
-	
-	if not len(m.alt_evos):
-		embed.description = 'No alternate evos'
-		return embed
-	
-	field_name = '{} alternate evos'.format(len(m.alt_evos))
-	field_data = ''
-	for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
-		field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
-	
-	embed.add_field(name=field_name, value=field_data)
-	
-	return embed
+    embed = monsterToBaseEmbed(m)
+    
+    if not len(m.alt_evos):
+        embed.description = 'No alternate evos'
+        return embed
+    
+    field_name = '{} alternate evos'.format(len(m.alt_evos))
+    field_data = ''
+    for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
+        field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
+    
+    embed.add_field(name=field_name, value=field_data)
+    
+    return embed
 
 
 def monsterToEvoMatsEmbed(m: padguide2.PgMonster):
-	embed = monsterToBaseEmbed(m)
-	
-	mats_for_evo_size = len(m.mats_for_evo)
-	material_of_size = len(m.material_of)
-	
-	field_name = 'Evo materials'
-	field_data = ''
-	if mats_for_evo_size:
-		for ae in m.mats_for_evo:
-			field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
-	else:
-		field_data = 'None'
-	embed.add_field(name=field_name, value=field_data)
-	
-	if not material_of_size:
-		return embed
-	
-	field_name = 'Material for'
-	field_data = ''
-	if material_of_size > 5:
-		field_data = '{} monsters'.format(material_of_size)
-	else:
-		item_count = min(material_of_size, 5)
-		for ae in sorted(m.material_of, key=lambda x: x.monster_no_na, reverse=True)[:item_count]:
-			field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
-	embed.add_field(name=field_name, value=field_data)
-	
-	return embed
+    embed = monsterToBaseEmbed(m)
+    
+    mats_for_evo_size = len(m.mats_for_evo)
+    material_of_size = len(m.material_of)
+    
+    field_name = 'Evo materials'
+    field_data = ''
+    if mats_for_evo_size:
+        for ae in m.mats_for_evo:
+            field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
+    else:
+        field_data = 'None'
+    embed.add_field(name=field_name, value=field_data)
+    
+    if not material_of_size:
+        return embed
+    
+    field_name = 'Material for'
+    field_data = ''
+    if material_of_size > 5:
+        field_data = '{} monsters'.format(material_of_size)
+    else:
+        item_count = min(material_of_size, 5)
+        for ae in sorted(m.material_of, key=lambda x: x.monster_no_na, reverse=True)[:item_count]:
+            field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
+    embed.add_field(name=field_name, value=field_data)
+    
+    return embed
 
 
 def monsterToPantheonEmbed(m: padguide2.PgMonster):
-	full_pantheon = m.series.monsters
-	pantheon_list = list(filter(lambda x: x.evo_from is None, full_pantheon))
-	if len(pantheon_list) == 0 or len(pantheon_list) > 6:
-		return None
-	
-	embed = monsterToBaseEmbed(m)
-	
-	field_name = 'Pantheon: ' + m.series.name
-	field_data = ''
-	for monster in sorted(pantheon_list, key=lambda x: x.monster_no_na):
-		field_data += '\n' + monsterToHeader(monster, link=True)
-	embed.add_field(name=field_name, value=field_data)
-	
-	return embed
+    full_pantheon = m.series.monsters
+    pantheon_list = list(filter(lambda x: x.evo_from is None, full_pantheon))
+    if len(pantheon_list) == 0 or len(pantheon_list) > 6:
+        return None
+    
+    embed = monsterToBaseEmbed(m)
+    
+    field_name = 'Pantheon: ' + m.series.name
+    field_data = ''
+    for monster in sorted(pantheon_list, key=lambda x: x.monster_no_na):
+        field_data += '\n' + monsterToHeader(monster, link=True)
+    embed.add_field(name=field_name, value=field_data)
+    
+    return embed
 
 
 def monsterToSkillupsEmbed(m: padguide2.PgMonster):
-	skillups_list = m.active_skill.monsters_with_active if m.active_skill else []
-	skillups_list = list(filter(lambda m: m.sell_mp < 3000, skillups_list))
-	server_skillups = m.active_skill.server_skillups if m.active_skill else []
-	
-	if len(skillups_list) + len(server_skillups) == 0:
-		return None
-	
-	embed = monsterToBaseEmbed(m)
-	
-	skillups_to_skip = []
-	for server, skillup in server_skillups.items():
-		skillup_header = 'Skillup in ' + server
-		skillup_body = monsterToHeader(skillup, link=True)
-		embed.add_field(name=skillup_header, value=skillup_body)
-		skillups_to_skip.append(skillup.monster_no_na)
-	
-	field_name = 'Skillups'
-	field_data = ''
-	
-	# Prevent huge skillup lists
-	if len(skillups_list) > 8:
-		field_data = '({} skillups omitted)'.format(len(skillups_list) - 8)
-		skillups_list = skillups_list[0:8]
-	
-	for monster in sorted(skillups_list, key=lambda x: x.monster_no_na):
-		if monster.monster_no_na in skillups_to_skip:
-			continue
-		field_data += '\n' + monsterToHeader(monster, link=True)
-	
-	if len(field_data.strip()):
-		embed.add_field(name=field_name, value=field_data)
-	
-	return embed
+    skillups_list = m.active_skill.monsters_with_active if m.active_skill else []
+    skillups_list = list(filter(lambda m: m.sell_mp < 3000, skillups_list))
+    server_skillups = m.active_skill.server_skillups if m.active_skill else []
+    
+    if len(skillups_list) + len(server_skillups) == 0:
+        return None
+    
+    embed = monsterToBaseEmbed(m)
+    
+    skillups_to_skip = []
+    for server, skillup in server_skillups.items():
+        skillup_header = 'Skillup in ' + server
+        skillup_body = monsterToHeader(skillup, link=True)
+        embed.add_field(name=skillup_header, value=skillup_body)
+        skillups_to_skip.append(skillup.monster_no_na)
+    
+    field_name = 'Skillups'
+    field_data = ''
+    
+    # Prevent huge skillup lists
+    if len(skillups_list) > 8:
+        field_data = '({} skillups omitted)'.format(len(skillups_list) - 8)
+        skillups_list = skillups_list[0:8]
+    
+    for monster in sorted(skillups_list, key=lambda x: x.monster_no_na):
+        if monster.monster_no_na in skillups_to_skip:
+            continue
+        field_data += '\n' + monsterToHeader(monster, link=True)
+    
+    if len(field_data.strip()):
+        embed.add_field(name=field_name, value=field_data)
+    
+    return embed
 
 
 def monsterToPicUrl(m: padguide2.PgMonster):
-	return get_pic_url(m)
+    return get_pic_url(m)
 
 
 def monsterToPicEmbed(m: padguide2.PgMonster, animated=False):
-	embed = monsterToBaseEmbed(m)
-	url = monsterToPicUrl(m)
-	embed.set_image(url=url)
-	# Clear the thumbnail, don't need it on pic
-	embed.set_thumbnail(url='')
-	if animated:
-		description = '[{}]({}) –– [{}]({})'.format(
-			'HQ (MP4)', monsterToVideoUrl(m), 'LQ (GIF)', monsterToGifUrl(m))
-		embed.add_field(name='Animated links', value=description)
-	
-	return embed
+    embed = monsterToBaseEmbed(m)
+    url = monsterToPicUrl(m)
+    embed.set_image(url=url)
+    # Clear the thumbnail, don't need it on pic
+    embed.set_thumbnail(url='')
+    if animated:
+        description = '[{}]({}) –– [{}]({})'.format(
+            'HQ (MP4)', monsterToVideoUrl(m), 'LQ (GIF)', monsterToGifUrl(m))
+        embed.add_field(name='Animated links', value=description)
+    
+    return embed
 
 
 def monsterToVideoUrl(m: padguide2.PgMonster):
-	return VIDEO_TEMPLATE.format(m.monster_no_jp)
+    return VIDEO_TEMPLATE.format(m.monster_no_jp)
 
 
 def monsterToGifUrl(m: padguide2.PgMonster):
-	return GIF_TEMPLATE.format(m.monster_no_jp)
+    return GIF_TEMPLATE.format(m.monster_no_jp)
 
 
 def monsterToGifEmbed(m: padguide2.PgMonster):
-	embed = monsterToBaseEmbed(m)
-	url = monsterToGifUrl(m)
-	embed.set_image(url=url)
-	# Clear the thumbnail, don't need it on pic
-	embed.set_thumbnail(url='')
-	return embed
+    embed = monsterToBaseEmbed(m)
+    url = monsterToGifUrl(m)
+    embed.set_image(url=url)
+    # Clear the thumbnail, don't need it on pic
+    embed.set_thumbnail(url='')
+    return embed
 
 
 def monstersToLsEmbed(left_m: padguide2.PgMonster, right_m: padguide2.PgMonster):
-	lhp, latk, lrcv, lresist = left_m.leader_skill_data.get_data()
-	rhp, ratk, rrcv, rresist = right_m.leader_skill_data.get_data()
-	multiplier_text = createMultiplierText(lhp, latk, lrcv, lresist, rhp, ratk, rrcv, rresist)
-	
-	embed = discord.Embed()
-	embed.title = 'Multiplier [{}]\n\n'.format(multiplier_text)
-	description = ''
-	description += '\n**{}**\n{}'.format(
-		monsterToHeader(left_m, link=True),
-		left_m.leader_skill.desc if left_m.leader_skill else 'None/Missing')
-	description += '\n**{}**\n{}'.format(
-		monsterToHeader(right_m, link=True),
-		right_m.leader_skill.desc if right_m.leader_skill else 'None/Missing')
-	embed.description = description
-	
-	return embed
+    lhp, latk, lrcv, lresist = left_m.leader_skill_data.get_data()
+    rhp, ratk, rrcv, rresist = right_m.leader_skill_data.get_data()
+    multiplier_text = createMultiplierText(lhp, latk, lrcv, lresist, rhp, ratk, rrcv, rresist)
+    
+    embed = discord.Embed()
+    embed.title = 'Multiplier [{}]\n\n'.format(multiplier_text)
+    description = ''
+    description += '\n**{}**\n{}'.format(
+        monsterToHeader(left_m, link=True),
+        left_m.leader_skill.desc if left_m.leader_skill else 'None/Missing')
+    description += '\n**{}**\n{}'.format(
+        monsterToHeader(right_m, link=True),
+        right_m.leader_skill.desc if right_m.leader_skill else 'None/Missing')
+    embed.description = description
+    
+    return embed
 
 
 def monsterToHeaderEmbed(m: padguide2.PgMonster):
-	header = monsterToLongHeader(m, link=True)
-	embed = discord.Embed()
-	embed.description = header
-	return embed
+    header = monsterToLongHeader(m, link=True)
+    embed = discord.Embed()
+    embed.description = header
+    return embed
 
 
 def monsterToTypeString(m: padguide2.PgMonster):
-	output = m.type1
-	if m.type2:
-		output += '/' + m.type2
-	if m.type3:
-		output += '/' + m.type3
-	return output
+    output = m.type1
+    if m.type2:
+        output += '/' + m.type2
+    if m.type3:
+        output += '/' + m.type3
+    return output
 
 
 def monsterToAcquireString(m: padguide2.PgMonster):
-	acquire_text = None
-	if m.farmable and not m.mp_evo:
-		# Some MP shop monsters 'drop' in PADR
-		acquire_text = 'Farmable'
-	elif m.farmable_evo and not m.mp_evo:
-		acquire_text = 'Farmable Evo'
-	elif m.in_pem:
-		acquire_text = 'In PEM'
-	elif m.pem_evo:
-		acquire_text = 'PEM Evo'
-	elif m.in_rem:
-		acquire_text = 'In REM'
-	elif m.rem_evo:
-		acquire_text = 'REM Evo'
-	elif m.in_mpshop:
-		acquire_text = 'MP Shop'
-	elif m.mp_evo:
-		acquire_text = 'MP Shop Evo'
-	return acquire_text
+    acquire_text = None
+    if m.farmable and not m.mp_evo:
+        # Some MP shop monsters 'drop' in PADR
+        acquire_text = 'Farmable'
+    elif m.farmable_evo and not m.mp_evo:
+        acquire_text = 'Farmable Evo'
+    elif m.in_pem:
+        acquire_text = 'In PEM'
+    elif m.pem_evo:
+        acquire_text = 'PEM Evo'
+    elif m.in_rem:
+        acquire_text = 'In REM'
+    elif m.rem_evo:
+        acquire_text = 'REM Evo'
+    elif m.in_mpshop:
+        acquire_text = 'MP Shop'
+    elif m.mp_evo:
+        acquire_text = 'MP Shop Evo'
+    return acquire_text
 
 
 def match_emoji(emoji_list, name):
-	for e in emoji_list:
-		if e.name == name:
-			return e
-	return None
+    for e in emoji_list:
+        if e.name == name:
+            return e
+    return None
 
 
 def monsterToEmbed(m: padguide2.PgMonster, emoji_list):
-	embed = monsterToBaseEmbed(m)
-	
-	info_row_1 = monsterToTypeString(m)
-	acquire_text = monsterToAcquireString(m)
-	
-	info_row_2 = '**Rarity** {}\n**Cost** {}'.format(m.rarity, m.cost)
-	if acquire_text:
-		info_row_2 += '\n**{}**'.format(acquire_text)
-	if m.is_inheritable:
-		info_row_2 += '\n**Inheritable**'
-	else:
-		info_row_2 += '\n**Not inheritable**'
-	
-	embed.add_field(name=info_row_1, value=info_row_2)
-	
-	if m.limitbreak_stats and m.limitbreak_stats > 1:
-		def lb(x):
-			return int(round(m.limitbreak_stats * x))
-		
-		stats_row_1 = 'Weighted {} | LB {}'.format(m.weighted_stats, lb(m.weighted_stats))
-		stats_row_2 = '**HP** {} ({})\n**ATK** {} ({})\n**RCV** {} ({})'.format(
-			m.hp, lb(m.hp), m.atk, lb(m.atk), m.rcv, lb(m.rcv))
-	else:
-		stats_row_1 = 'Weighted {}'.format(m.weighted_stats)
-		stats_row_2 = '**HP** {}\n**ATK** {}\n**RCV** {}'.format(m.hp, m.atk, m.rcv)
-	embed.add_field(name=stats_row_1, value=stats_row_2)
-	
-	awakenings_row = ''
-	for idx, a in enumerate(m.awakenings):
-		a = a.get_name()
-		mapped_awakening = AWAKENING_NAME_MAP_RPAD.get(a, a)
-		mapped_awakening = match_emoji(emoji_list, mapped_awakening)
-		
-		if mapped_awakening is None:
-			mapped_awakening = AWAKENING_NAME_MAP.get(a, a)
-		
-		# Wrap superawakenings to the next line
-		if len(m.awakenings) - idx == m.superawakening_count:
-			awakenings_row += '\n{}'.format(mapped_awakening)
-		else:
-			awakenings_row += ' {}'.format(mapped_awakening)
-	
-	awakenings_row = awakenings_row.strip()
-	
-	if not len(awakenings_row):
-		awakenings_row = 'No Awakenings'
-	
-	killers = compute_killers(m.type1, m.type2, m.type3)
-	killers_row = '**Available Killers:** {}'.format(' '.join(killers))
-	
-	embed.description = '{}\n{}'.format(awakenings_row, killers_row)
-	
-	if len(m.server_actives) >= 2:
-		for server, active in m.server_actives.items():
-			active_header = '({} Server) Active Skill ({} -> {})'.format(server,
-																		 active.turn_max, active.turn_min)
-			active_body = active.desc
-			embed.add_field(name=active_header, value=active_body, inline=False)
-	else:
-		active_header = 'Active Skill'
-		active_body = 'None/Missing'
-		if m.active_skill:
-			active_header = 'Active Skill ({} -> {})'.format(m.active_skill.turn_max,
-															 m.active_skill.turn_min)
-			active_body = m.active_skill.desc
-		embed.add_field(name=active_header, value=active_body, inline=False)
-	
-	ls_row = m.leader_skill.desc if m.leader_skill else 'None/Missing'
-	ls_header = 'Leader Skill'
-	if m.leader_skill_data:
-		hp, atk, rcv, resist = m.leader_skill_data.get_data()
-		multiplier_text = createMultiplierText(hp, atk, rcv, resist)
-		ls_header += " [ {} ]".format(multiplier_text)
-	embed.add_field(name=ls_header, value=ls_row, inline=False)
-	
-	return embed
+    embed = monsterToBaseEmbed(m)
+    
+    info_row_1 = monsterToTypeString(m)
+    acquire_text = monsterToAcquireString(m)
+    
+    info_row_2 = '**Rarity** {}\n**Cost** {}'.format(m.rarity, m.cost)
+    if acquire_text:
+        info_row_2 += '\n**{}**'.format(acquire_text)
+    if m.is_inheritable:
+        info_row_2 += '\n**Inheritable**'
+    else:
+        info_row_2 += '\n**Not inheritable**'
+    
+    embed.add_field(name=info_row_1, value=info_row_2)
+    
+    if m.limitbreak_stats and m.limitbreak_stats > 1:
+        def lb(x):
+            return int(round(m.limitbreak_stats * x))
+        
+        stats_row_1 = 'Weighted {} | LB {}'.format(m.weighted_stats, lb(m.weighted_stats))
+        stats_row_2 = '**HP** {} ({})\n**ATK** {} ({})\n**RCV** {} ({})'.format(
+            m.hp, lb(m.hp), m.atk, lb(m.atk), m.rcv, lb(m.rcv))
+    else:
+        stats_row_1 = 'Weighted {}'.format(m.weighted_stats)
+        stats_row_2 = '**HP** {}\n**ATK** {}\n**RCV** {}'.format(m.hp, m.atk, m.rcv)
+    embed.add_field(name=stats_row_1, value=stats_row_2)
+    
+    awakenings_row = ''
+    for idx, a in enumerate(m.awakenings):
+        a = a.get_name()
+        mapped_awakening = AWAKENING_NAME_MAP_RPAD.get(a, a)
+        mapped_awakening = match_emoji(emoji_list, mapped_awakening)
+        
+        if mapped_awakening is None:
+            mapped_awakening = AWAKENING_NAME_MAP.get(a, a)
+        
+        # Wrap superawakenings to the next line
+        if len(m.awakenings) - idx == m.superawakening_count:
+            awakenings_row += '\n{}'.format(mapped_awakening)
+        else:
+            awakenings_row += ' {}'.format(mapped_awakening)
+    
+    awakenings_row = awakenings_row.strip()
+    
+    if not len(awakenings_row):
+        awakenings_row = 'No Awakenings'
+    
+    killers = compute_killers(m.type1, m.type2, m.type3)
+    killers_row = '**Available Killers:** {}'.format(' '.join(killers))
+    
+    embed.description = '{}\n{}'.format(awakenings_row, killers_row)
+    
+    if len(m.server_actives) >= 2:
+        for server, active in m.server_actives.items():
+            active_header = '({} Server) Active Skill ({} -> {})'.format(server,
+                                                                         active.turn_max, active.turn_min)
+            active_body = active.desc
+            embed.add_field(name=active_header, value=active_body, inline=False)
+    else:
+        active_header = 'Active Skill'
+        active_body = 'None/Missing'
+        if m.active_skill:
+            active_header = 'Active Skill ({} -> {})'.format(m.active_skill.turn_max,
+                                                             m.active_skill.turn_min)
+            active_body = m.active_skill.desc
+        embed.add_field(name=active_header, value=active_body, inline=False)
+    
+    ls_row = m.leader_skill.desc if m.leader_skill else 'None/Missing'
+    ls_header = 'Leader Skill'
+    if m.leader_skill_data:
+        hp, atk, rcv, resist = m.leader_skill_data.get_data()
+        multiplier_text = createMultiplierText(hp, atk, rcv, resist)
+        ls_header += " [ {} ]".format(multiplier_text)
+    embed.add_field(name=ls_header, value=ls_row, inline=False)
+    
+    return embed
 
 
 def monsterToOtherInfoEmbed(m: padguide2.PgMonster):
-	embed = monsterToBaseEmbed(m)
-	# Clear the thumbnail, takes up too much space
-	embed.set_thumbnail(url='')
-	
-	stat_cols = ['', 'Max', 'M297', 'Inh', 'I297']
-	tbl = prettytable.PrettyTable(stat_cols)
-	tbl.hrules = prettytable.NONE
-	tbl.vrules = prettytable.NONE
-	tbl.align = "r"
-	hhp = m.hp + 99 * 10
-	hatk = m.atk + 99 * 5
-	hrcv = m.rcv + 99 * 3
-	tbl.add_row(['HP', m.hp, hhp, int(m.hp * .1), int(hhp * .1)])
-	tbl.add_row(['ATK', m.atk, hatk, int(m.atk * .05), int(hatk * .05)])
-	tbl.add_row(['RCV', m.rcv, hrcv, int(m.rcv * .15), int(hrcv * .15)])
-	
-	body_text = box(tbl.get_string())
-	
-	search_text = YT_SEARCH_TEMPLATE.format(m.name_jp)
-	skyozora_text = SKYOZORA_TEMPLATE.format(m.monster_no_jp)
-	body_text += "\n**JP Name**: {} | [YouTube]({}) | [Skyozora]({})".format(
-		m.name_jp, search_text, skyozora_text)
-	
-	if m.history_us:
-		body_text += '\n**History:** {}'.format(m.history_us)
-	
-	body_text += '\n**Series:** {}'.format(m.series.name)
-	body_text += '\n**Sell MP:** {:,}'.format(m.sell_mp)
-	if m.buy_mp > 0:
-		body_text += "  **Buy MP:** {:,}".format(m.buy_mp)
-	
-	if m.exp < 1000000:
-		xp_text = '{:,}'.format(m.exp)
-	else:
-		xp_text = '{:.1f}'.format(m.exp / 1000000).rstrip('0').rstrip('.') + 'M'
-	body_text += '\n**XP to Max:** {}'.format(xp_text)
-	body_text += '  **Max Level:**: {}'.format(m.max_level)
-	body_text += '\n**Rarity:** {} **Cost:** {}'.format(m.rarity, m.cost)
-	
-	if m.translated_jp_name:
-		body_text += '\n**Google Translated:** {}'.format(m.translated_jp_name)
-	
-	embed.description = body_text
-	
-	return embed
+    embed = monsterToBaseEmbed(m)
+    # Clear the thumbnail, takes up too much space
+    embed.set_thumbnail(url='')
+    
+    stat_cols = ['', 'Max', 'M297', 'Inh', 'I297']
+    tbl = prettytable.PrettyTable(stat_cols)
+    tbl.hrules = prettytable.NONE
+    tbl.vrules = prettytable.NONE
+    tbl.align = "r"
+    hhp = m.hp + 99 * 10
+    hatk = m.atk + 99 * 5
+    hrcv = m.rcv + 99 * 3
+    tbl.add_row(['HP', m.hp, hhp, int(m.hp * .1), int(hhp * .1)])
+    tbl.add_row(['ATK', m.atk, hatk, int(m.atk * .05), int(hatk * .05)])
+    tbl.add_row(['RCV', m.rcv, hrcv, int(m.rcv * .15), int(hrcv * .15)])
+    
+    body_text = box(tbl.get_string())
+    
+    search_text = YT_SEARCH_TEMPLATE.format(m.name_jp)
+    skyozora_text = SKYOZORA_TEMPLATE.format(m.monster_no_jp)
+    body_text += "\n**JP Name**: {} | [YouTube]({}) | [Skyozora]({})".format(
+        m.name_jp, search_text, skyozora_text)
+    
+    if m.history_us:
+        body_text += '\n**History:** {}'.format(m.history_us)
+    
+    body_text += '\n**Series:** {}'.format(m.series.name)
+    body_text += '\n**Sell MP:** {:,}'.format(m.sell_mp)
+    if m.buy_mp > 0:
+        body_text += "  **Buy MP:** {:,}".format(m.buy_mp)
+    
+    if m.exp < 1000000:
+        xp_text = '{:,}'.format(m.exp)
+    else:
+        xp_text = '{:.1f}'.format(m.exp / 1000000).rstrip('0').rstrip('.') + 'M'
+    body_text += '\n**XP to Max:** {}'.format(xp_text)
+    body_text += '  **Max Level:**: {}'.format(m.max_level)
+    body_text += '\n**Rarity:** {} **Cost:** {}'.format(m.rarity, m.cost)
+    
+    if m.translated_jp_name:
+        body_text += '\n**Google Translated:** {}'.format(m.translated_jp_name)
+    
+    embed.description = body_text
+    
+    return embed
 
 
 def monsters_to_rotation_list(monster_list, server: str, index_all: padguide2.MonsterIndex):
-	# Shorten some of the longer names
-	name_remap = {
-		'Extreme King Metal Tamadra': 'Fat Tama',
-		'Extreme King Metal Dragon': 'EKMD',
-		'Ancient Green Sacred Mask': 'Green Mask',
-		'Ancient Blue Sacred Mask': 'Blue Mask',
-	}
-	ignore_monsters = [
-		'Ancient Draggie Knight',
-	]
-	
-	monster_list.sort(key=lambda m: m.monster_no, reverse=True)
-	next_rotation_date = None
-	for m in monster_list:
-		if server in m.future_skillup_rotation:
-			next_rotation_date = m.future_skillup_rotation[server].rotation_date_str
-			break
-	
-	cols = [server + ' Skillup', 'Current']
-	if next_rotation_date:
-		cols.append(next_rotation_date)
-	tbl = prettytable.PrettyTable(cols)
-	tbl.hrules = prettytable.HEADER
-	tbl.vrules = prettytable.NONE
-	tbl.align = "l"
-	
-	def cell_name(m: padguide2.PgMonster):
-		nm = index_all.monster_no_to_named_monster[m.monster_no]
-		name = nm.group_computed_basename.title()
-		return name_remap.get(name, name)
-	
-	for m in monster_list:
-		skill = m.server_actives[server]
-		
-		sm = skill.monsters_with_active
-		
-		# Since some newer monsters like jewel of creation are being used as
-		# skillups, exclude them from the list of skillup targets.
-		
-		def is_bad_type(m):
-			return set(['enhance', 'evolve', 'vendor']).intersection(set(m.types))
-		
-		sm = max(sm, key=lambda x: (not is_bad_type(x), x.monster_no))
-		
-		skillup_name = cell_name(m)
-		if skillup_name in ignore_monsters:
-			continue
-		row = [skillup_name, cell_name(sm)]
-		if next_rotation_date:
-			if server in m.future_skillup_rotation:
-				next_skill = m.future_skillup_rotation[server].skill
-				nm = max(next_skill.monsters_with_active, key=lambda x: x.monster_no)
-				row.append(cell_name(nm))
-			else:
-				row.append('')
-		tbl.add_row(row)
-	
-	return tbl.get_string()
+    # Shorten some of the longer names
+    name_remap = {
+        'Extreme King Metal Tamadra': 'Fat Tama',
+        'Extreme King Metal Dragon': 'EKMD',
+        'Ancient Green Sacred Mask': 'Green Mask',
+        'Ancient Blue Sacred Mask': 'Blue Mask',
+    }
+    ignore_monsters = [
+        'Ancient Draggie Knight',
+    ]
+    
+    monster_list.sort(key=lambda m: m.monster_no, reverse=True)
+    next_rotation_date = None
+    for m in monster_list:
+        if server in m.future_skillup_rotation:
+            next_rotation_date = m.future_skillup_rotation[server].rotation_date_str
+            break
+    
+    cols = [server + ' Skillup', 'Current']
+    if next_rotation_date:
+        cols.append(next_rotation_date)
+    tbl = prettytable.PrettyTable(cols)
+    tbl.hrules = prettytable.HEADER
+    tbl.vrules = prettytable.NONE
+    tbl.align = "l"
+    
+    def cell_name(m: padguide2.PgMonster):
+        nm = index_all.monster_no_to_named_monster[m.monster_no]
+        name = nm.group_computed_basename.title()
+        return name_remap.get(name, name)
+    
+    for m in monster_list:
+        skill = m.server_actives[server]
+        
+        sm = skill.monsters_with_active
+        
+        # Since some newer monsters like jewel of creation are being used as
+        # skillups, exclude them from the list of skillup targets.
+        
+        def is_bad_type(m):
+            return set(['enhance', 'evolve', 'vendor']).intersection(set(m.types))
+        
+        sm = max(sm, key=lambda x: (not is_bad_type(x), x.monster_no))
+        
+        skillup_name = cell_name(m)
+        if skillup_name in ignore_monsters:
+            continue
+        row = [skillup_name, cell_name(sm)]
+        if next_rotation_date:
+            if server in m.future_skillup_rotation:
+                next_skill = m.future_skillup_rotation[server].skill
+                nm = max(next_skill.monsters_with_active, key=lambda x: x.monster_no)
+                row.append(cell_name(nm))
+            else:
+                row.append('')
+        tbl.add_row(row)
+    
+    return tbl.get_string()
 
 
 AWAKENING_NAME_MAP_RPAD = {
-	'Enhanced Attack': 'boost_atk',
-	'Enhanced HP': 'boost_hp',
-	'Enhanced Heal': 'boost_rcv',
-	
-	'Enhanced Team HP': 'teamboost_hp',
-	'Enhanced Team Attack': 'teamboost_atk',
-	'Enhanced Team RCV': 'teamboost_rcv',
-	
-	'God Killer': 'killer_god',
-	'Dragon Killer': 'killer_dragon',
-	'Devil Killer': 'killer_devil',
-	'Machine Killer': 'killer_machine',
-	'Balanced Killer': 'killer_balance',
-	'Attacker Killer': 'killer_attacker',
-	
-	'Physical Killer': 'killer_physical',
-	'Healer Killer': 'killer_healer',
-	'Evolve Material Killer': 'killer_evomat',
-	'Awaken Material Killer': 'killer_awoken',
-	'Enhance Material Killer': 'killer_enhancemat',
-	'Vendor Material Killer': 'killer_vendor',
-	
-	'Auto-Recover': 'misc_autoheal',
-	'Recover Bind': 'misc_bindclear',
-	'Enhanced Combo': 'misc_comboboost',
-	'Super Enhanced Combo': 'misc_super_comboboost',
-	'Guard Break': 'misc_guardbreak',
-	'Multi Boost': 'misc_multiboost',
-	'Additional Attack': 'misc_extraattack',
-	'Skill Boost': 'misc_sb',
-	'Extend Time': 'misc_te',
-	'Two-Pronged Attack': 'misc_tpa',
-	'Damage Void Shield Penetration': 'misc_voidshield',
-	'Awoken Assist': 'misc_assist',
-	
-	'Enhanced Fire Orbs': 'oe_fire',
-	'Enhanced Water Orbs': 'oe_water',
-	'Enhanced Wood Orbs': 'oe_wood',
-	'Enhanced Light Orbs': 'oe_light',
-	'Enhanced Dark Orbs': 'oe_dark',
-	'Enhanced Heal Orbs': 'oe_heart',
-	
-	'Reduce Fire Damage': 'reduce_fire',
-	'Reduce Water Damage': 'reduce_water',
-	'Reduce Wood Damage': 'reduce_wood',
-	'Reduce Light Damage': 'reduce_light',
-	'Reduce Dark Damage': 'reduce_dark',
-	
-	'Resistance-Bind': 'res_bind',
-	'Resistance-Dark': 'res_blind',
-	'Resistance-Jammers': 'res_jammer',
-	'Resistance-Poison': 'res_poison',
-	'Resistance-Skill Bind': 'res_skillbind',
-	
-	'Enhanced Fire Att.': 'row_fire',
-	'Enhanced Water Att.': 'row_water',
-	'Enhanced Wood Att.': 'row_wood',
-	'Enhanced Light Att.': 'row_light',
-	'Enhanced Dark Att.': 'row_dark',
-	
-	'Skill Charge': 'misc_skillcharge',
-	'Super Additional Attack': 'misc_super_extraattack',
-	'Resistance-Bind＋': 'res_bind_super',
-	'Extend Time＋': 'misc_te_super',
-	'Resistance-Cloud': 'res_cloud',
-	'Resistance-Board Restrict': 'res_seal',
-	'Skill Boost＋': 'misc_sb_super',
-	'L-Shape Attack': 'l_attack',
-	'L-Shape Damage Reduction': 'l_shield',
-	'Enhance when HP is below 50%': 'attack_boost_low',
-	'Enhance when HP is above 80%': 'attack_boost_high',
-	'Combo Orb': 'orb_combo',
-	'Skill Voice': 'misc_voice',
-	'Dungeon Bonus': 'misc_dungeonbonus',
+    'Enhanced Attack': 'boost_atk',
+    'Enhanced HP': 'boost_hp',
+    'Enhanced Heal': 'boost_rcv',
+    
+    'Enhanced Team HP': 'teamboost_hp',
+    'Enhanced Team Attack': 'teamboost_atk',
+    'Enhanced Team RCV': 'teamboost_rcv',
+    
+    'God Killer': 'killer_god',
+    'Dragon Killer': 'killer_dragon',
+    'Devil Killer': 'killer_devil',
+    'Machine Killer': 'killer_machine',
+    'Balanced Killer': 'killer_balance',
+    'Attacker Killer': 'killer_attacker',
+    
+    'Physical Killer': 'killer_physical',
+    'Healer Killer': 'killer_healer',
+    'Evolve Material Killer': 'killer_evomat',
+    'Awaken Material Killer': 'killer_awoken',
+    'Enhance Material Killer': 'killer_enhancemat',
+    'Vendor Material Killer': 'killer_vendor',
+    
+    'Auto-Recover': 'misc_autoheal',
+    'Recover Bind': 'misc_bindclear',
+    'Enhanced Combo': 'misc_comboboost',
+    'Super Enhanced Combo': 'misc_super_comboboost',
+    'Guard Break': 'misc_guardbreak',
+    'Multi Boost': 'misc_multiboost',
+    'Additional Attack': 'misc_extraattack',
+    'Skill Boost': 'misc_sb',
+    'Extend Time': 'misc_te',
+    'Two-Pronged Attack': 'misc_tpa',
+    'Damage Void Shield Penetration': 'misc_voidshield',
+    'Awoken Assist': 'misc_assist',
+    
+    'Enhanced Fire Orbs': 'oe_fire',
+    'Enhanced Water Orbs': 'oe_water',
+    'Enhanced Wood Orbs': 'oe_wood',
+    'Enhanced Light Orbs': 'oe_light',
+    'Enhanced Dark Orbs': 'oe_dark',
+    'Enhanced Heal Orbs': 'oe_heart',
+    
+    'Reduce Fire Damage': 'reduce_fire',
+    'Reduce Water Damage': 'reduce_water',
+    'Reduce Wood Damage': 'reduce_wood',
+    'Reduce Light Damage': 'reduce_light',
+    'Reduce Dark Damage': 'reduce_dark',
+    
+    'Resistance-Bind': 'res_bind',
+    'Resistance-Dark': 'res_blind',
+    'Resistance-Jammers': 'res_jammer',
+    'Resistance-Poison': 'res_poison',
+    'Resistance-Skill Bind': 'res_skillbind',
+    
+    'Enhanced Fire Att.': 'row_fire',
+    'Enhanced Water Att.': 'row_water',
+    'Enhanced Wood Att.': 'row_wood',
+    'Enhanced Light Att.': 'row_light',
+    'Enhanced Dark Att.': 'row_dark',
+    
+    'Skill Charge': 'misc_skillcharge',
+    'Super Additional Attack': 'misc_super_extraattack',
+    'Resistance-Bind＋': 'res_bind_super',
+    'Extend Time＋': 'misc_te_super',
+    'Resistance-Cloud': 'res_cloud',
+    'Resistance-Board Restrict': 'res_seal',
+    'Skill Boost＋': 'misc_sb_super',
+    'L-Shape Attack': 'l_attack',
+    'L-Shape Damage Reduction': 'l_shield',
+    'Enhance when HP is below 50%': 'attack_boost_low',
+    'Enhance when HP is above 80%': 'attack_boost_high',
+    'Combo Orb': 'orb_combo',
+    'Skill Voice': 'misc_voice',
+    'Dungeon Bonus': 'misc_dungeonbonus',
 }
 
 AWAKENING_NAME_MAP = {
-	'Enhanced Fire Orbs': 'R-OE',
-	'Enhanced Water Orbs': 'B-OE',
-	'Enhanced Wood Orbs': 'G-OE',
-	'Enhanced Light Orbs': 'L-OE',
-	'Enhanced Dark Orbs': 'D-OE',
-	'Enhanced Heal Orbs': 'H-OE',
-	
-	'Enhanced Fire Att.': 'R-RE',
-	'Enhanced Water Att.': 'B-RE',
-	'Enhanced Wood Att.': 'G-RE',
-	'Enhanced Light Att.': 'L-RE',
-	'Enhanced Dark Att.': 'D-RE',
-	
-	'Enhanced HP': 'HP',
-	'Enhanced Attack': 'ATK',
-	'Enhanced Heal': 'RCV',
-	
-	'Enhanced Team HP': 'TEAM-HP',
-	'Enhanced Team Attack': 'TEAM-ATK',
-	'Enhanced Team RCV': 'TEAM-RCV',
-	
-	'Auto-Recover': 'AUTO-RECOVER',
-	'Skill Boost': 'SB',
-	'Resistance-Skill Bind': 'SBR',
-	'Two-Pronged Attack': 'TPA',
-	'Multi Boost': 'MULTI-BOOST',
-	'Recover Bind': 'RCV-BIND',
-	'Extend Time': 'TE',
-	'Enhanced Combo': 'COMBO-BOOST',
-	'Guard Break': 'DEF-BREAK',
-	'Additional Attack': 'EXTRA-ATK',
-	'Damage Void Shield Penetration': 'VOID-BREAK',
-	'Awoken Assist': 'ASSIST',
-	
-	'Resistance-Bind': 'RES-BIND',
-	'Resistance-Dark': 'RES-BLIND',
-	'Resistance-Poison': 'RES-POISON',
-	'Resistance-Jammers': 'RES-JAMMER',
-	
-	'Reduce Fire Damage': 'R-RES',
-	'Reduce Water Damage': 'B-RES',
-	'Reduce Wood Damage': 'G-RES',
-	'Reduce Light Damage': 'L-RES',
-	'Reduce Dark Damage': 'D-RES',
-	
-	'Healer Killer': 'K-HEALER',
-	'Machine Killer': 'K-MACHINE',
-	'Dragon Killer': 'K-DRAGON',
-	'Attacker Killer': 'K-ATTACKER',
-	'Physical Killer': 'K-PHYSICAL',
-	'God Killer': 'K-GOD',
-	'Devil Killer': 'K-DEVIL',
-	'Balance Killer': 'K-BALANCE',
+    'Enhanced Fire Orbs': 'R-OE',
+    'Enhanced Water Orbs': 'B-OE',
+    'Enhanced Wood Orbs': 'G-OE',
+    'Enhanced Light Orbs': 'L-OE',
+    'Enhanced Dark Orbs': 'D-OE',
+    'Enhanced Heal Orbs': 'H-OE',
+    
+    'Enhanced Fire Att.': 'R-RE',
+    'Enhanced Water Att.': 'B-RE',
+    'Enhanced Wood Att.': 'G-RE',
+    'Enhanced Light Att.': 'L-RE',
+    'Enhanced Dark Att.': 'D-RE',
+    
+    'Enhanced HP': 'HP',
+    'Enhanced Attack': 'ATK',
+    'Enhanced Heal': 'RCV',
+    
+    'Enhanced Team HP': 'TEAM-HP',
+    'Enhanced Team Attack': 'TEAM-ATK',
+    'Enhanced Team RCV': 'TEAM-RCV',
+    
+    'Auto-Recover': 'AUTO-RECOVER',
+    'Skill Boost': 'SB',
+    'Resistance-Skill Bind': 'SBR',
+    'Two-Pronged Attack': 'TPA',
+    'Multi Boost': 'MULTI-BOOST',
+    'Recover Bind': 'RCV-BIND',
+    'Extend Time': 'TE',
+    'Enhanced Combo': 'COMBO-BOOST',
+    'Guard Break': 'DEF-BREAK',
+    'Additional Attack': 'EXTRA-ATK',
+    'Damage Void Shield Penetration': 'VOID-BREAK',
+    'Awoken Assist': 'ASSIST',
+    
+    'Resistance-Bind': 'RES-BIND',
+    'Resistance-Dark': 'RES-BLIND',
+    'Resistance-Poison': 'RES-POISON',
+    'Resistance-Jammers': 'RES-JAMMER',
+    
+    'Reduce Fire Damage': 'R-RES',
+    'Reduce Water Damage': 'B-RES',
+    'Reduce Wood Damage': 'G-RES',
+    'Reduce Light Damage': 'L-RES',
+    'Reduce Dark Damage': 'D-RES',
+    
+    'Healer Killer': 'K-HEALER',
+    'Machine Killer': 'K-MACHINE',
+    'Dragon Killer': 'K-DRAGON',
+    'Attacker Killer': 'K-ATTACKER',
+    'Physical Killer': 'K-PHYSICAL',
+    'God Killer': 'K-GOD',
+    'Devil Killer': 'K-DEVIL',
+    'Balance Killer': 'K-BALANCE',
 }
 
 
 def createMultiplierText(hp1, atk1, rcv1, resist1, hp2=None, atk2=None, rcv2=None, resist2=None):
-	hp2, atk2, rcv2, resist2 = hp2 or hp1, atk2 or atk1, rcv2 or rcv1, resist2 or resist1
-	
-	def fmtNum(val):
-		return ('{:.2f}').format(val).strip('0').rstrip('.')
-	
-	text = "{}/{}/{}".format(fmtNum(hp1 * hp2), fmtNum(atk1 * atk2), fmtNum(rcv1 * rcv2))
-	if resist1 * resist2 < 1:
-		resist1 = resist1 if resist1 < 1 else 0
-		resist2 = resist2 if resist2 < 1 else 0
-		text += ' Resist {}%'.format(fmtNum(100 * (1 - (1 - resist1) * (1 - resist2))))
-	return text
+    hp2, atk2, rcv2, resist2 = hp2 or hp1, atk2 or atk1, rcv2 or rcv1, resist2 or resist1
+    
+    def fmtNum(val):
+        return ('{:.2f}').format(val).strip('0').rstrip('.')
+    
+    text = "{}/{}/{}".format(fmtNum(hp1 * hp2), fmtNum(atk1 * atk2), fmtNum(rcv1 * rcv2))
+    if resist1 * resist2 < 1:
+        resist1 = resist1 if resist1 < 1 else 0
+        resist2 = resist2 if resist2 < 1 else 0
+        text += ' Resist {}%'.format(fmtNum(100 * (1 - (1 - resist1) * (1 - resist2))))
+    return text
 
 
 def _map_awakenings_text(m: padguide2.PgMonster):
-	awakenings_row = ''
-	unique_awakenings = set(m.awakening_names)
-	for a in unique_awakenings:
-		count = m.awakening_names.count(a)
-		awakenings_row += ' {}x{}'.format(AWAKENING_NAME_MAP.get(a, a), count)
-	awakenings_row = awakenings_row.strip()
-	
-	if not len(awakenings_row):
-		awakenings_row = 'No Awakenings'
-	
-	return awakenings_row
+    awakenings_row = ''
+    unique_awakenings = set(m.awakening_names)
+    for a in unique_awakenings:
+        count = m.awakening_names.count(a)
+        awakenings_row += ' {}x{}'.format(AWAKENING_NAME_MAP.get(a, a), count)
+    awakenings_row = awakenings_row.strip()
+    
+    if not len(awakenings_row):
+        awakenings_row = 'No Awakenings'
+    
+    return awakenings_row
 
 
 # TODO: move to padguide2
 def compute_killers(*types):
-	if 'Balance' in types:
-		return ['Any']
-	killers = set()
-	for t in types:
-		killers.update(type_to_killers_map.get(t, []))
-	return sorted(killers)
+    if 'Balance' in types:
+        return ['Any']
+    killers = set()
+    for t in types:
+        killers.update(type_to_killers_map.get(t, []))
+    return sorted(killers)
 
 
 type_to_killers_map = {
-	'God': ['Devil'],
-	'Devil': ['God'],
-	'Machine': ['God', 'Balance'],
-	'Dragon': ['Machine', 'Healer'],
-	'Physical': ['Machine', 'Healer'],
-	'Attacker': ['Devil', 'Physical'],
-	'Healer': ['Dragon', 'Attacker'],
+    'God': ['Devil'],
+    'Devil': ['God'],
+    'Machine': ['God', 'Balance'],
+    'Dragon': ['Machine', 'Healer'],
+    'Physical': ['Machine', 'Healer'],
+    'Attacker': ['Devil', 'Physical'],
+    'Healer': ['Dragon', 'Attacker'],
 }

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -106,6 +106,7 @@ class PadInfo:
         self.historic_lookups = dataIO.load_json(self.historic_lookups_file_path)
         self.historic_lookups_id2 = dataIO.load_json(self.historic_lookups_file_path_id2)
 
+
     def __unload(self):
         # Manually nulling out database because the GC for cogs seems to be pretty shitty
         self.index_all = padguide2.empty_index()
@@ -131,6 +132,7 @@ class PadInfo:
         await pg_cog.wait_until_ready()
         self.index_all = pg_cog.create_index()
         self.index_na = pg_cog.create_index(lambda m: m.on_na)
+
 
     def get_monster_by_no(self, monster_no: int):
         pg_cog = self.bot.get_cog('PadGuide2')
@@ -421,14 +423,17 @@ class PadInfo:
             self.settings.setEmojiServers(emoji_servers.split(','))
         await self.bot.say(inline('Set {} servers'.format(len(self.settings.emojiServers()))))
 
+
     def get_emojis(self):
         server_ids = self.settings.emojiServers()
         return [e for s in self.bot.servers if s.id in server_ids for e in s.emojis]
+
 
     def makeFailureMsg(self, err):
         msg = 'Lookup failed: {}.\n'.format(err)
         msg += 'Try one of <id>, <name>, [argbld]/[rgbld] <name>. Unexpected results? Use ^helpid for more info.'
         return box(msg)
+
 
     def findMonster(self, query, na_only=False):
         query = rmdiacritics(query)
@@ -442,9 +447,11 @@ class PadInfo:
 
         return m, err, debug_info
 
+
     def _findMonster(self, query, na_only=False):
         monster_index = self.index_na if na_only else self.index_all
         return monster_index.find_monster(query)
+
 
     def findMonster2(self, query, na_only=False):
         query = rmdiacritics(query)
@@ -458,9 +465,11 @@ class PadInfo:
 
         return m, err, debug_info
 
+
     def _findMonster2(self, query, na_only=False):
         monster_index = self.index_na if na_only else self.index_all
         return monster_index.find_monster2(query)
+
 
     def map_awakenings_text(self, m):
         """Exported for use in other cogs"""
@@ -472,6 +481,7 @@ class PadInfo:
         """Set a directory containing animated images"""
         self.settings.setAnimationDir(animation_dir)
         await self.bot.say(inline('Done'))
+
 
     def check_monster_animated(self, monster_id: int):
         if not self.settings.animationDir():
@@ -502,11 +512,13 @@ class PadInfoSettings(CogSettings):
         }
         return config
 
+
     def emojiServers(self):
         key = 'emoji_servers'
         if key not in self.bot_settings:
             self.bot_settings[key] = []
         return self.bot_settings[key]
+
 
     def setEmojiServers(self, emoji_servers):
         es = self.emojiServers()
@@ -514,8 +526,10 @@ class PadInfoSettings(CogSettings):
         es.extend(emoji_servers)
         self.save_settings()
 
+
     def animationDir(self):
         return self.bot_settings['animation_dir']
+
 
     def setAnimationDir(self, animation_dir):
         self.bot_settings['animation_dir'] = animation_dir
@@ -902,6 +916,7 @@ def monsters_to_rotation_list(monster_list, server: str, index_all: padguide2.Mo
     tbl.vrules = prettytable.NONE
     tbl.align = "l"
 
+
     def cell_name(m: padguide2.PgMonster):
         nm = index_all.monster_no_to_named_monster[m.monster_no]
         name = nm.group_computed_basename.title()
@@ -1070,6 +1085,7 @@ AWAKENING_NAME_MAP = {
 
 def createMultiplierText(hp1, atk1, rcv1, resist1, hp2=None, atk2=None, rcv2=None, resist2=None):
     hp2, atk2, rcv2, resist2 = hp2 or hp1, atk2 or atk1, rcv2 or rcv1, resist2 or resist1
+
 
     def fmtNum(val):
         return ('{:.2f}').format(val).strip('0').rstrip('.')

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -105,14 +105,14 @@ class PadInfo:
         
         self.historic_lookups = dataIO.load_json(self.historic_lookups_file_path)
         self.historic_lookups_id2 = dataIO.load_json(self.historic_lookups_file_path_id2)
-    
+
     def __unload(self):
         # Manually nulling out database because the GC for cogs seems to be pretty shitty
         self.index_all = padguide2.empty_index()
         self.index_na = padguide2.empty_index()
         self.historic_lookups = {}
         self.historic_lookups_id2 = {}
-    
+
     async def reload_nicknames(self):
         await self.bot.wait_until_ready()
         while self == self.bot.get_cog('PadInfo'):
@@ -124,18 +124,18 @@ class PadInfo:
                 traceback.print_exc()
             
             await asyncio.sleep(60 * 60 * 1)
-    
+
     async def refresh_index(self):
         """Refresh the monster indexes."""
         pg_cog = self.bot.get_cog('PadGuide2')
         await pg_cog.wait_until_ready()
         self.index_all = pg_cog.create_index()
         self.index_na = pg_cog.create_index(lambda m: m.on_na)
-    
+
     def get_monster_by_no(self, monster_no: int):
         pg_cog = self.bot.get_cog('PadGuide2')
         return pg_cog.get_monster_by_no(monster_no)
-    
+
     @commands.command(pass_context=True)
     async def skillrotation(self, ctx, server: str = 'NA'):
         """Print the current rotating skillups for a server (NA/JP)"""
@@ -149,7 +149,7 @@ class PadInfo:
         
         for page in pagify(monsters_to_rotation_list(monsters, server, self.index_all)):
             await self.bot.say(box(page))
-    
+
     @commands.command(pass_context=True)
     async def jpname(self, ctx, *, query: str):
         """Print the Japanese name of a monster"""
@@ -159,41 +159,41 @@ class PadInfo:
             await self.bot.say(box(m.name_jp))
         else:
             await self.bot.say(self.makeFailureMsg(err))
-    
+
     @commands.command(name="id", pass_context=True)
     async def _do_id_all(self, ctx, *, query: str):
         """Monster info (main tab)"""
         await self._do_id(ctx, query)
-    
+
     @commands.command(name="idna", pass_context=True)
     async def _do_id_na(self, ctx, *, query: str):
         """Monster info (limited to NA monsters ONLY)"""
         await self._do_id(ctx, query, na_only=True)
-    
+
     async def _do_id(self, ctx, query: str, na_only=False):
         m, err, debug_info = self.findMonster(query, na_only=na_only)
         if m is not None:
             await self._do_idmenu(ctx, m, self.id_emoji)
         else:
             await self.bot.say(self.makeFailureMsg(err))
-    
+
     @commands.command(name="id2", pass_context=True)
     async def _do_id2_all(self, ctx, *, query: str):
         """Monster info (main tab)"""
         await self._do_id2(ctx, query)
-    
+
     @commands.command(name="id2na", pass_context=True)
     async def _do_id2_na(self, ctx, *, query: str):
         """Monster info (limited to NA monsters ONLY)"""
         await self._do_id2(ctx, query, na_only=True)
-    
+
     async def _do_id2(self, ctx, query: str, na_only=False):
         m, err, debug_info = self.findMonster2(query, na_only=na_only)
         if m is not None:
             await self._do_idmenu(ctx, m, self.id_emoji)
         else:
             await self.bot.say(self.makeFailureMsg(err))
-    
+
     @commands.command(name="evos", pass_context=True)
     async def evos(self, ctx, *, query: str):
         """Monster info (evolutions tab)"""
@@ -202,7 +202,7 @@ class PadInfo:
             await self._do_idmenu(ctx, m, self.evo_emoji)
         else:
             await self.bot.say(self.makeFailureMsg(err))
-    
+
     @commands.command(name="mats", pass_context=True, aliases=['evomats', 'evomat'])
     async def evomats(self, ctx, *, query: str):
         """Monster info (evo materials tab)"""
@@ -211,7 +211,7 @@ class PadInfo:
             await self._do_idmenu(ctx, m, self.mats_emoji)
         else:
             await self.bot.say(self.makeFailureMsg(err))
-    
+
     @commands.command(pass_context=True)
     async def pantheon(self, ctx, *, query: str):
         """Monster info (pantheon tab)"""
@@ -222,7 +222,7 @@ class PadInfo:
                 await self.bot.say(inline('Not a pantheon monster'))
         else:
             await self.bot.say(self.makeFailureMsg(err))
-    
+
     @commands.command(pass_context=True)
     async def skillups(self, ctx, *, query: str):
         """Monster info (evolutions tab)"""
@@ -233,7 +233,7 @@ class PadInfo:
                 await self.bot.say(inline('No skillups available'))
         else:
             await self.bot.say(self.makeFailureMsg(err))
-    
+
     async def _do_idmenu(self, ctx, m, starting_menu_emoji):
         id_embed = monsterToEmbed(m, self.get_emojis())
         evo_embed = monsterToEvoEmbed(m)
@@ -259,7 +259,7 @@ class PadInfo:
         emoji_to_embed[self.other_info_emoji] = other_info_embed
         
         return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed)
-    
+
     async def _do_evolistmenu(self, ctx, sm):
         monsters = sm.alt_evos
         monsters.sort(key=lambda m: m.monster_no)
@@ -272,7 +272,7 @@ class PadInfo:
                 starting_menu_emoji = emoji
         
         return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed, timeout=60)
-    
+
     async def _do_menu(self, ctx, starting_menu_emoji, emoji_to_embed, timeout=30):
         if starting_menu_emoji not in emoji_to_embed:
             # Selected menu wasn't generated for this monster
@@ -290,7 +290,7 @@ class PadInfo:
                 await self.bot.edit_message(result_msg, embed=result_embed)
         except Exception as ex:
             print('Menu failure', ex)
-    
+
     @commands.command(pass_context=True, aliases=['img'])
     async def pic(self, ctx, *, query: str):
         """Monster info (full image tab)"""
@@ -299,7 +299,7 @@ class PadInfo:
             await self._do_idmenu(ctx, m, self.pic_emoji)
         else:
             await self.bot.say(self.makeFailureMsg(err))
-    
+
     @commands.command(pass_context=True, aliases=['stats'])
     async def otherinfo(self, ctx, *, query: str):
         """Monster info (misc info tab)"""
@@ -308,7 +308,7 @@ class PadInfo:
             await self._do_idmenu(ctx, m, self.other_info_emoji)
         else:
             await self.bot.say(self.makeFailureMsg(err))
-    
+
     @commands.command(pass_context=True)
     async def lookup(self, ctx, *, query: str):
         """Short info results for a monster query"""
@@ -318,7 +318,7 @@ class PadInfo:
             await self.bot.say(embed=embed)
         else:
             await self.bot.say(self.makeFailureMsg(err))
-    
+
     @commands.command(pass_context=True)
     async def evolist(self, ctx, *, query):
         """Monster info (for all monsters in the evo tree)"""
@@ -327,7 +327,7 @@ class PadInfo:
             await self._do_evolistmenu(ctx, m)
         else:
             await self.bot.say(self.makeFailureMsg(err))
-    
+
     @commands.command(pass_context=True, aliases=['leaders', 'leaderskills', 'ls'])
     async def leaderskill(self, ctx, left_query: str, right_query: str = None, *, bad=None):
         """Display the multiplier and leaderskills for two monsters
@@ -367,12 +367,12 @@ class PadInfo:
         emoji_to_embed[self.right_emoji] = monsterToEmbed(right_m, self.get_emojis())
         
         await self._do_menu(ctx, self.ls_emoji, emoji_to_embed)
-    
+
     @commands.command(name="helpid", pass_context=True, aliases=['helppic', 'helpimg'])
     async def _helpid(self, ctx):
         """Whispers you info on how to craft monster queries for ^id"""
         await self.bot.whisper(box(HELP_MSG))
-    
+
     @commands.command(pass_context=True)
     async def padsay(self, ctx, server, *, query: str = None):
         """Speak the voice line of a monster into your current chat"""
@@ -404,14 +404,14 @@ class PadInfo:
             await speech_cog.play_path(channel, voice_file)
         else:
             await self.bot.say(self.makeFailureMsg(err))
-    
+
     @commands.group(pass_context=True)
     @checks.is_owner()
     async def padinfo(self, ctx):
         """PAD info management"""
         if ctx.invoked_subcommand is None:
             await send_cmd_help(ctx)
-    
+
     @padinfo.command(pass_context=True)
     @checks.is_owner()
     async def setemojiservers(self, ctx, *, emoji_servers=''):
@@ -420,16 +420,16 @@ class PadInfo:
         if emoji_servers:
             self.settings.setEmojiServers(emoji_servers.split(','))
         await self.bot.say(inline('Set {} servers'.format(len(self.settings.emojiServers()))))
-    
+
     def get_emojis(self):
         server_ids = self.settings.emojiServers()
         return [e for s in self.bot.servers if s.id in server_ids for e in s.emojis]
-    
+
     def makeFailureMsg(self, err):
         msg = 'Lookup failed: {}.\n'.format(err)
         msg += 'Try one of <id>, <name>, [argbld]/[rgbld] <name>. Unexpected results? Use ^helpid for more info.'
         return box(msg)
-    
+
     def findMonster(self, query, na_only=False):
         query = rmdiacritics(query)
         nm, err, debug_info = self._findMonster(query, na_only)
@@ -441,11 +441,11 @@ class PadInfo:
         m = self.get_monster_by_no(nm.monster_no) if nm else None
         
         return m, err, debug_info
-    
+
     def _findMonster(self, query, na_only=False):
         monster_index = self.index_na if na_only else self.index_all
         return monster_index.find_monster(query)
-    
+
     def findMonster2(self, query, na_only=False):
         query = rmdiacritics(query)
         nm, err, debug_info = self._findMonster2(query, na_only)
@@ -457,22 +457,22 @@ class PadInfo:
         m = self.get_monster_by_no(nm.monster_no) if nm else None
         
         return m, err, debug_info
-    
+
     def _findMonster2(self, query, na_only=False):
         monster_index = self.index_na if na_only else self.index_all
         return monster_index.find_monster2(query)
-    
+
     def map_awakenings_text(self, m):
         """Exported for use in other cogs"""
         return _map_awakenings_text(m)
-    
+
     @padinfo.command(pass_context=True)
     @checks.is_owner()
     async def setanimationdir(self, ctx, *, animation_dir=''):
         """Set a directory containing animated images"""
         self.settings.setAnimationDir(animation_dir)
         await self.bot.say(inline('Done'))
-    
+
     def check_monster_animated(self, monster_id: int):
         if not self.settings.animationDir():
             return False
@@ -501,22 +501,22 @@ class PadInfoSettings(CogSettings):
             'animation_dir': '',
         }
         return config
-    
+
     def emojiServers(self):
         key = 'emoji_servers'
         if key not in self.bot_settings:
             self.bot_settings[key] = []
         return self.bot_settings[key]
-    
+
     def setEmojiServers(self, emoji_servers):
         es = self.emojiServers()
         es.clear()
         es.extend(emoji_servers)
         self.save_settings()
-    
+
     def animationDir(self):
         return self.bot_settings['animation_dir']
-    
+
     def setAnimationDir(self, animation_dir):
         self.bot_settings['animation_dir'] = animation_dir
         self.save_settings()
@@ -566,26 +566,26 @@ def monsterToBaseEmbed(m: padguide2.PgMonster):
 
 def monsterToEvoEmbed(m: padguide2.PgMonster):
     embed = monsterToBaseEmbed(m)
-    
+
     if not len(m.alt_evos):
         embed.description = 'No alternate evos'
         return embed
-    
+
     field_name = '{} alternate evos'.format(len(m.alt_evos))
     field_data = ''
     for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
         field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
-    
+
     embed.add_field(name=field_name, value=field_data)
-    
+
     return embed
 
 def monsterToEvoMatsEmbed(m: padguide2.PgMonster):
     embed = monsterToBaseEmbed(m)
-    
+
     mats_for_evo_size = len(m.mats_for_evo)
     material_of_size = len(m.material_of)
-    
+
     field_name = 'Evo materials'
     field_data = ''
     if mats_for_evo_size:
@@ -594,10 +594,10 @@ def monsterToEvoMatsEmbed(m: padguide2.PgMonster):
     else:
         field_data = 'None'
     embed.add_field(name=field_name, value=field_data)
-    
+
     if not material_of_size:
         return embed
-    
+
     field_name = 'Material for'
     field_data = ''
     if material_of_size > 5:
@@ -607,7 +607,7 @@ def monsterToEvoMatsEmbed(m: padguide2.PgMonster):
         for ae in sorted(m.material_of, key=lambda x: x.monster_no_na, reverse=True)[:item_count]:
             field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
     embed.add_field(name=field_name, value=field_data)
-    
+
     return embed
 
 def monsterToPantheonEmbed(m: padguide2.PgMonster):
@@ -615,50 +615,50 @@ def monsterToPantheonEmbed(m: padguide2.PgMonster):
     pantheon_list = list(filter(lambda x: x.evo_from is None, full_pantheon))
     if len(pantheon_list) == 0 or len(pantheon_list) > 6:
         return None
-    
+
     embed = monsterToBaseEmbed(m)
-    
+
     field_name = 'Pantheon: ' + m.series.name
     field_data = ''
     for monster in sorted(pantheon_list, key=lambda x: x.monster_no_na):
         field_data += '\n' + monsterToHeader(monster, link=True)
     embed.add_field(name=field_name, value=field_data)
-    
+
     return embed
 
 def monsterToSkillupsEmbed(m: padguide2.PgMonster):
     skillups_list = m.active_skill.monsters_with_active if m.active_skill else []
     skillups_list = list(filter(lambda m: m.sell_mp < 3000, skillups_list))
     server_skillups = m.active_skill.server_skillups if m.active_skill else []
-    
+
     if len(skillups_list) + len(server_skillups) == 0:
         return None
-    
+
     embed = monsterToBaseEmbed(m)
-    
+
     skillups_to_skip = []
     for server, skillup in server_skillups.items():
         skillup_header = 'Skillup in ' + server
         skillup_body = monsterToHeader(skillup, link=True)
         embed.add_field(name=skillup_header, value=skillup_body)
         skillups_to_skip.append(skillup.monster_no_na)
-    
+
     field_name = 'Skillups'
     field_data = ''
-    
+
     # Prevent huge skillup lists
     if len(skillups_list) > 8:
         field_data = '({} skillups omitted)'.format(len(skillups_list) - 8)
         skillups_list = skillups_list[0:8]
-    
+
     for monster in sorted(skillups_list, key=lambda x: x.monster_no_na):
         if monster.monster_no_na in skillups_to_skip:
             continue
         field_data += '\n' + monsterToHeader(monster, link=True)
-    
+
     if len(field_data.strip()):
         embed.add_field(name=field_name, value=field_data)
-    
+
     return embed
 
 def monsterToPicUrl(m: padguide2.PgMonster):
@@ -674,7 +674,7 @@ def monsterToPicEmbed(m: padguide2.PgMonster, animated=False):
         description = '[{}]({}) –– [{}]({})'.format(
             'HQ (MP4)', monsterToVideoUrl(m), 'LQ (GIF)', monsterToGifUrl(m))
         embed.add_field(name='Animated links', value=description)
-    
+
     return embed
 
 def monsterToVideoUrl(m: padguide2.PgMonster):
@@ -695,7 +695,7 @@ def monstersToLsEmbed(left_m: padguide2.PgMonster, right_m: padguide2.PgMonster)
     lhp, latk, lrcv, lresist = left_m.leader_skill_data.get_data()
     rhp, ratk, rrcv, rresist = right_m.leader_skill_data.get_data()
     multiplier_text = createMultiplierText(lhp, latk, lrcv, lresist, rhp, ratk, rrcv, rresist)
-    
+
     embed = discord.Embed()
     embed.title = 'Multiplier [{}]\n\n'.format(multiplier_text)
     description = ''
@@ -706,7 +706,7 @@ def monstersToLsEmbed(left_m: padguide2.PgMonster, right_m: padguide2.PgMonster)
         monsterToHeader(right_m, link=True),
         right_m.leader_skill.desc if right_m.leader_skill else 'None/Missing')
     embed.description = description
-    
+
     return embed
 
 def monsterToHeaderEmbed(m: padguide2.PgMonster):
@@ -752,10 +752,10 @@ def match_emoji(emoji_list, name):
 
 def monsterToEmbed(m: padguide2.PgMonster, emoji_list):
     embed = monsterToBaseEmbed(m)
-    
+
     info_row_1 = monsterToTypeString(m)
     acquire_text = monsterToAcquireString(m)
-    
+
     info_row_2 = '**Rarity** {}\n**Cost** {}'.format(m.rarity, m.cost)
     if acquire_text:
         info_row_2 += '\n**{}**'.format(acquire_text)
@@ -763,9 +763,9 @@ def monsterToEmbed(m: padguide2.PgMonster, emoji_list):
         info_row_2 += '\n**Inheritable**'
     else:
         info_row_2 += '\n**Not inheritable**'
-    
+
     embed.add_field(name=info_row_1, value=info_row_2)
-    
+
     if m.limitbreak_stats and m.limitbreak_stats > 1:
         def lb(x):
             return int(round(m.limitbreak_stats * x))
@@ -777,7 +777,7 @@ def monsterToEmbed(m: padguide2.PgMonster, emoji_list):
         stats_row_1 = 'Weighted {}'.format(m.weighted_stats)
         stats_row_2 = '**HP** {}\n**ATK** {}\n**RCV** {}'.format(m.hp, m.atk, m.rcv)
     embed.add_field(name=stats_row_1, value=stats_row_2)
-    
+
     awakenings_row = ''
     for idx, a in enumerate(m.awakenings):
         a = a.get_name()
@@ -792,17 +792,17 @@ def monsterToEmbed(m: padguide2.PgMonster, emoji_list):
             awakenings_row += '\n{}'.format(mapped_awakening)
         else:
             awakenings_row += ' {}'.format(mapped_awakening)
-    
+
     awakenings_row = awakenings_row.strip()
-    
+
     if not len(awakenings_row):
         awakenings_row = 'No Awakenings'
-    
+
     killers = compute_killers(m.type1, m.type2, m.type3)
     killers_row = '**Available Killers:** {}'.format(' '.join(killers))
-    
+
     embed.description = '{}\n{}'.format(awakenings_row, killers_row)
-    
+
     if len(m.server_actives) >= 2:
         for server, active in m.server_actives.items():
             active_header = '({} Server) Active Skill ({} -> {})'.format(server,
@@ -817,7 +817,7 @@ def monsterToEmbed(m: padguide2.PgMonster, emoji_list):
                                                              m.active_skill.turn_min)
             active_body = m.active_skill.desc
         embed.add_field(name=active_header, value=active_body, inline=False)
-    
+
     ls_row = m.leader_skill.desc if m.leader_skill else 'None/Missing'
     ls_header = 'Leader Skill'
     if m.leader_skill_data:
@@ -825,14 +825,14 @@ def monsterToEmbed(m: padguide2.PgMonster, emoji_list):
         multiplier_text = createMultiplierText(hp, atk, rcv, resist)
         ls_header += " [ {} ]".format(multiplier_text)
     embed.add_field(name=ls_header, value=ls_row, inline=False)
-    
+
     return embed
 
 def monsterToOtherInfoEmbed(m: padguide2.PgMonster):
     embed = monsterToBaseEmbed(m)
     # Clear the thumbnail, takes up too much space
     embed.set_thumbnail(url='')
-    
+
     stat_cols = ['', 'Max', 'M297', 'Inh', 'I297']
     tbl = prettytable.PrettyTable(stat_cols)
     tbl.hrules = prettytable.NONE
@@ -844,22 +844,22 @@ def monsterToOtherInfoEmbed(m: padguide2.PgMonster):
     tbl.add_row(['HP', m.hp, hhp, int(m.hp * .1), int(hhp * .1)])
     tbl.add_row(['ATK', m.atk, hatk, int(m.atk * .05), int(hatk * .05)])
     tbl.add_row(['RCV', m.rcv, hrcv, int(m.rcv * .15), int(hrcv * .15)])
-    
+
     body_text = box(tbl.get_string())
-    
+
     search_text = YT_SEARCH_TEMPLATE.format(m.name_jp)
     skyozora_text = SKYOZORA_TEMPLATE.format(m.monster_no_jp)
     body_text += "\n**JP Name**: {} | [YouTube]({}) | [Skyozora]({})".format(
         m.name_jp, search_text, skyozora_text)
-    
+
     if m.history_us:
         body_text += '\n**History:** {}'.format(m.history_us)
-    
+
     body_text += '\n**Series:** {}'.format(m.series.name)
     body_text += '\n**Sell MP:** {:,}'.format(m.sell_mp)
     if m.buy_mp > 0:
         body_text += "  **Buy MP:** {:,}".format(m.buy_mp)
-    
+
     if m.exp < 1000000:
         xp_text = '{:,}'.format(m.exp)
     else:
@@ -867,12 +867,12 @@ def monsterToOtherInfoEmbed(m: padguide2.PgMonster):
     body_text += '\n**XP to Max:** {}'.format(xp_text)
     body_text += '  **Max Level:**: {}'.format(m.max_level)
     body_text += '\n**Rarity:** {} **Cost:** {}'.format(m.rarity, m.cost)
-    
+
     if m.translated_jp_name:
         body_text += '\n**Google Translated:** {}'.format(m.translated_jp_name)
-    
+
     embed.description = body_text
-    
+
     return embed
 
 def monsters_to_rotation_list(monster_list, server: str, index_all: padguide2.MonsterIndex):
@@ -886,14 +886,14 @@ def monsters_to_rotation_list(monster_list, server: str, index_all: padguide2.Mo
     ignore_monsters = [
         'Ancient Draggie Knight',
     ]
-    
+
     monster_list.sort(key=lambda m: m.monster_no, reverse=True)
     next_rotation_date = None
     for m in monster_list:
         if server in m.future_skillup_rotation:
             next_rotation_date = m.future_skillup_rotation[server].rotation_date_str
             break
-    
+
     cols = [server + ' Skillup', 'Current']
     if next_rotation_date:
         cols.append(next_rotation_date)
@@ -901,12 +901,12 @@ def monsters_to_rotation_list(monster_list, server: str, index_all: padguide2.Mo
     tbl.hrules = prettytable.HEADER
     tbl.vrules = prettytable.NONE
     tbl.align = "l"
-    
+
     def cell_name(m: padguide2.PgMonster):
         nm = index_all.monster_no_to_named_monster[m.monster_no]
         name = nm.group_computed_basename.title()
         return name_remap.get(name, name)
-    
+
     for m in monster_list:
         skill = m.server_actives[server]
         
@@ -932,32 +932,32 @@ def monsters_to_rotation_list(monster_list, server: str, index_all: padguide2.Mo
             else:
                 row.append('')
         tbl.add_row(row)
-    
+
     return tbl.get_string()
 
 AWAKENING_NAME_MAP_RPAD = {
     'Enhanced Attack': 'boost_atk',
     'Enhanced HP': 'boost_hp',
     'Enhanced Heal': 'boost_rcv',
-    
+
     'Enhanced Team HP': 'teamboost_hp',
     'Enhanced Team Attack': 'teamboost_atk',
     'Enhanced Team RCV': 'teamboost_rcv',
-    
+
     'God Killer': 'killer_god',
     'Dragon Killer': 'killer_dragon',
     'Devil Killer': 'killer_devil',
     'Machine Killer': 'killer_machine',
     'Balanced Killer': 'killer_balance',
     'Attacker Killer': 'killer_attacker',
-    
+
     'Physical Killer': 'killer_physical',
     'Healer Killer': 'killer_healer',
     'Evolve Material Killer': 'killer_evomat',
     'Awaken Material Killer': 'killer_awoken',
     'Enhance Material Killer': 'killer_enhancemat',
     'Vendor Material Killer': 'killer_vendor',
-    
+
     'Auto-Recover': 'misc_autoheal',
     'Recover Bind': 'misc_bindclear',
     'Enhanced Combo': 'misc_comboboost',
@@ -970,32 +970,32 @@ AWAKENING_NAME_MAP_RPAD = {
     'Two-Pronged Attack': 'misc_tpa',
     'Damage Void Shield Penetration': 'misc_voidshield',
     'Awoken Assist': 'misc_assist',
-    
+
     'Enhanced Fire Orbs': 'oe_fire',
     'Enhanced Water Orbs': 'oe_water',
     'Enhanced Wood Orbs': 'oe_wood',
     'Enhanced Light Orbs': 'oe_light',
     'Enhanced Dark Orbs': 'oe_dark',
     'Enhanced Heal Orbs': 'oe_heart',
-    
+
     'Reduce Fire Damage': 'reduce_fire',
     'Reduce Water Damage': 'reduce_water',
     'Reduce Wood Damage': 'reduce_wood',
     'Reduce Light Damage': 'reduce_light',
     'Reduce Dark Damage': 'reduce_dark',
-    
+
     'Resistance-Bind': 'res_bind',
     'Resistance-Dark': 'res_blind',
     'Resistance-Jammers': 'res_jammer',
     'Resistance-Poison': 'res_poison',
     'Resistance-Skill Bind': 'res_skillbind',
-    
+
     'Enhanced Fire Att.': 'row_fire',
     'Enhanced Water Att.': 'row_water',
     'Enhanced Wood Att.': 'row_wood',
     'Enhanced Light Att.': 'row_light',
     'Enhanced Dark Att.': 'row_dark',
-    
+
     'Skill Charge': 'misc_skillcharge',
     'Super Additional Attack': 'misc_super_extraattack',
     'Resistance-Bind＋': 'res_bind_super',
@@ -1019,21 +1019,21 @@ AWAKENING_NAME_MAP = {
     'Enhanced Light Orbs': 'L-OE',
     'Enhanced Dark Orbs': 'D-OE',
     'Enhanced Heal Orbs': 'H-OE',
-    
+
     'Enhanced Fire Att.': 'R-RE',
     'Enhanced Water Att.': 'B-RE',
     'Enhanced Wood Att.': 'G-RE',
     'Enhanced Light Att.': 'L-RE',
     'Enhanced Dark Att.': 'D-RE',
-    
+
     'Enhanced HP': 'HP',
     'Enhanced Attack': 'ATK',
     'Enhanced Heal': 'RCV',
-    
+
     'Enhanced Team HP': 'TEAM-HP',
     'Enhanced Team Attack': 'TEAM-ATK',
     'Enhanced Team RCV': 'TEAM-RCV',
-    
+
     'Auto-Recover': 'AUTO-RECOVER',
     'Skill Boost': 'SB',
     'Resistance-Skill Bind': 'SBR',
@@ -1046,18 +1046,18 @@ AWAKENING_NAME_MAP = {
     'Additional Attack': 'EXTRA-ATK',
     'Damage Void Shield Penetration': 'VOID-BREAK',
     'Awoken Assist': 'ASSIST',
-    
+
     'Resistance-Bind': 'RES-BIND',
     'Resistance-Dark': 'RES-BLIND',
     'Resistance-Poison': 'RES-POISON',
     'Resistance-Jammers': 'RES-JAMMER',
-    
+
     'Reduce Fire Damage': 'R-RES',
     'Reduce Water Damage': 'B-RES',
     'Reduce Wood Damage': 'G-RES',
     'Reduce Light Damage': 'L-RES',
     'Reduce Dark Damage': 'D-RES',
-    
+
     'Healer Killer': 'K-HEALER',
     'Machine Killer': 'K-MACHINE',
     'Dragon Killer': 'K-DRAGON',
@@ -1070,10 +1070,10 @@ AWAKENING_NAME_MAP = {
 
 def createMultiplierText(hp1, atk1, rcv1, resist1, hp2=None, atk2=None, rcv2=None, resist2=None):
     hp2, atk2, rcv2, resist2 = hp2 or hp1, atk2 or atk1, rcv2 or rcv1, resist2 or resist1
-    
+
     def fmtNum(val):
         return ('{:.2f}').format(val).strip('0').rstrip('.')
-    
+
     text = "{}/{}/{}".format(fmtNum(hp1 * hp2), fmtNum(atk1 * atk2), fmtNum(rcv1 * rcv2))
     if resist1 * resist2 < 1:
         resist1 = resist1 if resist1 < 1 else 0
@@ -1088,10 +1088,10 @@ def _map_awakenings_text(m: padguide2.PgMonster):
         count = m.awakening_names.count(a)
         awakenings_row += ' {}x{}'.format(AWAKENING_NAME_MAP.get(a, a), count)
     awakenings_row = awakenings_row.strip()
-    
+
     if not len(awakenings_row):
         awakenings_row = 'No Awakenings'
-    
+
     return awakenings_row
 
 # TODO: move to padguide2

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -1,2524 +1,1134 @@
-"""
-Provides access to PadGuide data.
-
-Loads every PadGuide related JSON into a simple data structure, and then
-combines them into a an in-memory interconnected database.
-
-Don't hold on to any of the dastructures exported from here, or the
-entire database could be leaked when the module is reloaded.
-"""
-from _collections import defaultdict
 import asyncio
-import csv
-from datetime import datetime
-from datetime import timedelta
-import difflib
-from itertools import groupby
+from builtins import filter, map
+from collections import OrderedDict
+from collections import defaultdict
+import io
 import json
-from operator import itemgetter
-import os
 import re
-import time
 import traceback
 
-import aiohttp
+from dateutil import tz
 import discord
 from discord.ext import commands
 from enum import Enum
-import pytz
-import romkan
+import prettytable
 
-from __main__ import send_cmd_help
+from __main__ import user_allowed, send_cmd_help
 
+from . import padguide2
 from . import rpadutils
+from .rpadutils import *
 from .rpadutils import CogSettings
 from .utils import checks
-from .utils.chat_formatting import box, inline
+from .utils.chat_formatting import *
 from .utils.dataIO import dataIO
 
-DUMMY_FILE_PATTERN = 'data/padguide2/{}.dummy'
-JSON_FILE_PATTERN = 'data/padguide2/{}.json'
-CSV_FILE_PATTERN = 'data/padguide2/{}.csv'
-ATTR_EXPORT_PATH = 'data/padguide2/card_data.csv'
-NAMES_EXPORT_PATH = 'data/padguide2/computed_names.json'
-BASENAMES_EXPORT_PATH = 'data/padguide2/base_names.json'
-TRANSLATEDNAMES_EXPORT_PATH = 'data/padguide2/translated_names.json'
+HELP_MSG = """
+^helpid : shows this message
+^id <query> : look up a monster and print a link to puzzledragonx
+^pic <query> : Look up a monster and display its image inline
 
-SHEETS_PATTERN = 'https://docs.google.com/spreadsheets/d/1EoZJ3w5xsXZ67kmarLE4vfrZSIIIAfj04HXeZVST3eY/pub?gid={}&single=true&output=csv'
-GROUP_BASENAMES_OVERRIDES_SHEET = SHEETS_PATTERN.format('2070615818')
-NICKNAME_OVERRIDES_SHEET = SHEETS_PATTERN.format('0')
+Options for <query>
+    <id> : Find a monster by ID
+        ^id 1234 (picks sun quan)
+    <name> : Take the best guess for a monster, picks the most recent monster
+        ^id kali (picks uvo d kali)
+    <prefix> <name> : Limit by element or awoken, e.g.
+        ^id ares  (selects the most recent, awoken ares)
+        ^id aares (explicitly selects awoken ares)
+        ^id a ares (spaces work too)
+        ^id rd ares (select a specific evo for ares, the red/dark one)
+        ^id r/d ares (slashes, spaces work too)
 
-NICKNAME_FILE_PATTERN = CSV_FILE_PATTERN.format('nicknames')
-BASENAME_FILE_PATTERN = CSV_FILE_PATTERN.format('basenames')
+computed nickname list and overrides: https://docs.google.com/spreadsheets/d/1EyzMjvf8ZCQ4K-gJYnNkiZlCEsT9YYI9dUd-T5qCirc/pubhtml
+submit an override suggestion: https://docs.google.com/forms/d/1kJH9Q0S8iqqULwrRqB9dSxMOMebZj6uZjECqi4t9_z0/edit"""
+
+EMBED_NOT_GENERATED = -1
+
+INFO_PDX_TEMPLATE = 'http://www.puzzledragonx.com/en/monster.asp?n={}'
+RPAD_PIC_TEMPLATE = 'https://f002.backblazeb2.com/file/miru-data/padimages/{}/full/{}.png'
+RPAD_PORTRAIT_TEMPLATE = 'https://f002.backblazeb2.com/file/miru-data/padimages/{}/portrait/{}.png'
+VIDEO_TEMPLATE = 'https://f002.backblazeb2.com/file/miru-data/padimages/animated/{}.mp4'
+GIF_TEMPLATE = 'https://f002.backblazeb2.com/file/miru-data/padimages/animated/{}.gif'
+
+YT_SEARCH_TEMPLATE = 'https://www.youtube.com/results?search_query={}'
+SKYOZORA_TEMPLATE = 'http://pad.skyozora.com/pets/{}'
 
 
-class PadGuide2(object):
+def get_pdx_url(m):
+    return INFO_PDX_TEMPLATE.format(rpadutils.get_pdx_id(m))
+
+
+def get_portrait_url(m):
+    if int(m.monster_no) != m.monster_no_na:
+        return RPAD_PORTRAIT_TEMPLATE.format('na', m.monster_no_na)
+    else:
+        return RPAD_PORTRAIT_TEMPLATE.format('jp', m.monster_no_jp)
+
+
+def get_pic_url(m):
+    if int(m.monster_no) != m.monster_no_na:
+        return RPAD_PIC_TEMPLATE.format('na', m.monster_no_na)
+    else:
+        return RPAD_PIC_TEMPLATE.format('jp', m.monster_no_jp)
+
+
+class PadInfo:
     def __init__(self, bot):
         self.bot = bot
-        self._is_ready = asyncio.Event(loop=self.bot.loop)
         
-        self.settings = PadGuide2Settings("padguide2")
-        self.reload_task = None
+        self.settings = PadInfoSettings("padinfo")
         
-        self._standard_refresh = [
-            PgAttribute,
-            PgAwakening,
-            PgDungeon,
-            # PgDungeonDamage,
-            PgDungeonMonsterDrop,
-            PgDungeonMonster,
-            # PgDungeonSkill,
-            # PgDungeonType,
-            PgEggInstance,
-            PgEggMonster,
-            PgEggName,
-            PgEvent,
-            PgEvolution,
-            PgEvolutionMaterial,
-            PgMonster,
-            PgMonsterAddInfo,
-            PgMonsterInfo,
-            PgMonsterPrice,
-            PgSeries,
-            PgSkillLeaderData,
-            PgSkill,
-            PgSkillRotation,
-            PgSkillRotationDated,
-            # PgSubDungeon,
-            PgType,
-        ]
+        self.index_all = padguide2.empty_index()
+        self.index_na = padguide2.empty_index()
         
-        self._quick_refresh = [
-            PgScheduledEvent,
-        ]
+        self.menu = Menu(bot)
         
-        # A string -> int mapping, nicknames to monster_id_na
-        self.nickname_overrides = {}
+        # These emojis are the keys into the idmenu submenus
+        self.id_emoji = '\N{INFORMATION SOURCE}'
+        self.evo_emoji = char_to_emoji('e')
+        self.mats_emoji = char_to_emoji('m')
+        self.ls_emoji = '\N{INFORMATION SOURCE}'
+        self.left_emoji = char_to_emoji('l')
+        self.right_emoji = char_to_emoji('r')
+        self.pantheon_emoji = '\N{CLASSICAL BUILDING}'
+        self.skillups_emoji = '\N{MEAT ON BONE}'
+        self.pic_emoji = '\N{FRAME WITH PICTURE}'
+        self.other_info_emoji = '\N{SCROLL}'
         
-        # An int -> set(string), monster_id_na to set of basename overrides
-        self.basename_overrides = defaultdict(set)
-        
-        self.database = PgRawDatabase(skip_load=True)
-        
-        # Map of google-translated JP names to EN names
-        self.translated_names = {}
-    
-    @asyncio.coroutine
-    def wait_until_ready(self):
-        """Wait until the PadGuide2 cog is ready.
+        self.historic_lookups_file_path = "data/padinfo/historic_lookups.json"
+        self.historic_lookups_file_path_id2 = "data/padinfo/historic_lookups_id2.json"
+  
+        if not dataIO.is_valid_json(self.historic_lookups_file_path):
+            print("Creating empty historic_lookups.json...")
+            dataIO.save_json(self.historic_lookups_file_path, {})
 
-        Call this from other cogs to wait until PadGuide2 finishes refreshing its database
-        for the first time.
-        """
-        yield from self._is_ready.wait()
-    
-    def create_index(self, accept_filter=None):
-        """Exported function that allows a client cog to create a monster index"""
-        return MonsterIndex(self.database, self.nickname_overrides, self.basename_overrides,
-                            accept_filter=accept_filter)
-    
-    def get_monster_by_no(self, monster_no: int):
-        """Exported function that allows a client cog to get a full PgMonster by monster_no"""
-        return self.database.getMonster(monster_no)
-    
-    def get_translated_jp_name(self, jp_name):
-        return self.translate_names.get(jp_name, None)
-    
-    def register_tasks(self):
-        self.reload_task = self.bot.loop.create_task(self.reload_data_task())
+        if not dataIO.is_valid_json(self.historic_lookups_file_path_id2):
+            print("Creating empty historic_lookups_id2.json...")
+            dataIO.save_json(self.historic_lookups_file_path_id2, {})
+
+        self.historic_lookups = dataIO.load_json(self.historic_lookups_file_path)
+        self.historic_lookups_id2 = dataIO.load_json(self.historic_lookups_file_path_id2)
     
     def __unload(self):
         # Manually nulling out database because the GC for cogs seems to be pretty shitty
-        self.database = None
-        self._is_ready.clear()
+        self.index_all = padguide2.empty_index()
+        self.index_na = padguide2.empty_index()
+        self.historic_lookups = {}
+        self.historic_lookups_id2 = {}
     
-    async def reload_data_task(self):
+    async def reload_nicknames(self):
         await self.bot.wait_until_ready()
+        while self == self.bot.get_cog('PadInfo'):
+            try:
+                await self.refresh_index()
+                print('Done refreshing PadInfo')
+            except Exception as ex:
+                print("reload padinfo loop caught exception " + str(ex))
+                traceback.print_exc()
+            
+            await asyncio.sleep(60 * 60 * 1)
+    
+    async def refresh_index(self):
+        """Refresh the monster indexes."""
+        pg_cog = self.bot.get_cog('PadGuide2')
+        await pg_cog.wait_until_ready()
+        self.index_all = pg_cog.create_index()
+        self.index_na = pg_cog.create_index(lambda m: m.on_na)
+    
+    def get_monster_by_no(self, monster_no: int):
+        pg_cog = self.bot.get_cog('PadGuide2')
+        return pg_cog.get_monster_by_no(monster_no)
+    
+    @commands.command(pass_context=True)
+    async def skillrotation(self, ctx, server: str = 'NA'):
+        """Print the current rotating skillups for a server (NA/JP)"""
+        server = normalizeServer(server)
+        if server not in ['NA', 'JP']:
+            await self.bot.say(inline('Supported servers are NA, JP'))
+            return
+        
+        pg_cog = self.bot.get_cog('PadGuide2')
+        monsters = pg_cog.database.rotating_skillups(server)
+        
+        for page in pagify(monsters_to_rotation_list(monsters, server, self.index_all)):
+            await self.bot.say(box(page))
+    
+    @commands.command(pass_context=True)
+    async def jpname(self, ctx, *, query: str):
+        """Print the Japanese name of a monster"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self.bot.say(monsterToHeader(m))
+            await self.bot.say(box(m.name_jp))
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    @commands.command(name="id", pass_context=True)
+    async def _do_id_all(self, ctx, *, query: str):
+        """Monster info (main tab)"""
+        await self._do_id(ctx, query)
+    
+    @commands.command(name="idna", pass_context=True)
+    async def _do_id_na(self, ctx, *, query: str):
+        """Monster info (limited to NA monsters ONLY)"""
+        await self._do_id(ctx, query, na_only=True)
+    
+    async def _do_id(self, ctx, query: str, na_only=False):
+        m, err, debug_info = self.findMonster(query, na_only=na_only)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.id_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    @commands.command(name="id2", pass_context=True)
+    async def _do_id2_all(self, ctx, *, query: str):
+        """Monster info (main tab)"""
+        await self._do_id2(ctx, query)
+    
+    @commands.command(name="id2na", pass_context=True)
+    async def _do_id2_na(self, ctx, *, query: str):
+        """Monster info (limited to NA monsters ONLY)"""
+        await self._do_id2(ctx, query, na_only=True)
+    
+    async def _do_id2(self, ctx, query: str, na_only=False):
+        m, err, debug_info = self.findMonster2(query, na_only=na_only)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.id_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    @commands.command(name="evos", pass_context=True)
+    async def evos(self, ctx, *, query: str):
+        """Monster info (evolutions tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.evo_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    @commands.command(name="mats", pass_context=True, aliases=['evomats', 'evomat'])
+    async def evomats(self, ctx, *, query: str):
+        """Monster info (evo materials tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.mats_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    @commands.command(pass_context=True)
+    async def pantheon(self, ctx, *, query: str):
+        """Monster info (pantheon tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            menu = await self._do_idmenu(ctx, m, self.pantheon_emoji)
+            if menu == EMBED_NOT_GENERATED:
+                await self.bot.say(inline('Not a pantheon monster'))
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    @commands.command(pass_context=True)
+    async def skillups(self, ctx, *, query: str):
+        """Monster info (evolutions tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            menu = await self._do_idmenu(ctx, m, self.skillups_emoji)
+            if menu == EMBED_NOT_GENERATED:
+                await self.bot.say(inline('No skillups available'))
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
+    async def _do_idmenu(self, ctx, m, starting_menu_emoji):
+        id_embed = monsterToEmbed(m, self.get_emojis())
+        evo_embed = monsterToEvoEmbed(m)
+        mats_embed = monsterToEvoMatsEmbed(m)
+        animated = self.check_monster_animated(m.monster_no_jp)
+        pic_embed = monsterToPicEmbed(m, animated=animated)
+        other_info_embed = monsterToOtherInfoEmbed(m)
+        
+        emoji_to_embed = OrderedDict()
+        emoji_to_embed[self.id_emoji] = id_embed
+        emoji_to_embed[self.evo_emoji] = evo_embed
+        emoji_to_embed[self.mats_emoji] = mats_embed
+        emoji_to_embed[self.pic_emoji] = pic_embed
+        
+        pantheon_embed = monsterToPantheonEmbed(m)
+        if pantheon_embed:
+            emoji_to_embed[self.pantheon_emoji] = pantheon_embed
+        
+        skillups_embed = monsterToSkillupsEmbed(m)
+        if skillups_embed:
+            emoji_to_embed[self.skillups_emoji] = skillups_embed
+        
+        emoji_to_embed[self.other_info_emoji] = other_info_embed
+        
+        return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed)
+    
+    async def _do_evolistmenu(self, ctx, sm):
+        monsters = sm.alt_evos
+        monsters.sort(key=lambda m: m.monster_no)
+        
+        emoji_to_embed = OrderedDict()
+        for idx, m in enumerate(monsters):
+            emoji = char_to_emoji(str(idx))
+            emoji_to_embed[emoji] = monsterToEmbed(m, self.get_emojis())
+            if m == sm:
+                starting_menu_emoji = emoji
+        
+        return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed, timeout=60)
+    
+    async def _do_menu(self, ctx, starting_menu_emoji, emoji_to_embed, timeout=30):
+        if starting_menu_emoji not in emoji_to_embed:
+            # Selected menu wasn't generated for this monster
+            return EMBED_NOT_GENERATED
+        
+        remove_emoji = self.menu.emoji['no']
+        emoji_to_embed[remove_emoji] = self.menu.reaction_delete_message
         
         try:
-            # Try and load the PadGuide database the first time with existing files
-            self.database = PgRawDatabase(data_dir=self.settings.dataDir())
-            self._is_ready.set()
-            print('Finished initial PadGuide2 load with existing database')
+            result_msg, result_embed = await self.menu.custom_menu(ctx, emoji_to_embed, starting_menu_emoji,
+                                                                   timeout=timeout)
+            if result_msg and result_embed:
+                # Message is finished but not deleted, clear the footer
+                result_embed.set_footer(text=discord.Embed.Empty)
+                await self.bot.edit_message(result_msg, embed=result_embed)
         except Exception as ex:
-            print(ex)
-            print('Initial PadGuide2 database load failed, waiting for download')
-        
-        while self == self.bot.get_cog('PadGuide2'):
-            short_wait = False
-            try:
-                await self.download_and_refresh_nicknames()
-                print('Done refreshing PadGuide2, triggering ready')
-                self._is_ready.set()
-            except Exception as ex:
-                short_wait = True
-                print("padguide2 data download/refresh failed", ex)
-                traceback.print_exc()
-            
-            try:
-                await self.translate_names()
-            except Exception as ex:
-                print("translations failed", ex)
-                traceback.print_exc()
-            
-            try:
-                wait_time = 60 if short_wait else 60 * 60 * 4
-                await asyncio.sleep(wait_time)
-            except Exception as ex:
-                print("padguide2 data wait loop failed", ex)
-                traceback.print_exc()
-                raise ex
+            print('Menu failure', ex)
     
-    async def reload_config_files(self):
-        os.remove(NICKNAME_FILE_PATTERN)
-        os.remove(BASENAME_FILE_PATTERN)
-        await self.download_and_refresh_nicknames()
+    @commands.command(pass_context=True, aliases=['img'])
+    async def pic(self, ctx, *, query: str):
+        """Monster info (full image tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.pic_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
     
-    async def translate_names(self):
-        if os.path.exists(TRANSLATEDNAMES_EXPORT_PATH):
-            with open(TRANSLATEDNAMES_EXPORT_PATH) as f:
-                self.translated_names = json.load(f)
-        
-        for m in self.database.all_monsters():
-            name_jp = m.name_jp
-            if rpadutils.containsJp(name_jp) and name_jp not in self.translated_names:
-                self.translated_names[name_jp] = await rpadutils.translate_jp_en(self.bot, name_jp)
-            m.translated_jp_name = self.translated_names.get(name_jp, None)
-        
-        with open(TRANSLATEDNAMES_EXPORT_PATH, 'w', encoding='utf-8') as f:
-            json.dump(self.translated_names, f, sort_keys=True, indent=4)
+    @commands.command(pass_context=True, aliases=['stats'])
+    async def otherinfo(self, ctx, *, query: str):
+        """Monster info (misc info tab)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.other_info_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
     
-    async def download_and_refresh_nicknames(self):
-        if not self.settings.dataDir():
-            await self._download_files()
-        await self._download_override_files()
-        
-        nickname_overrides = self._csv_to_tuples(NICKNAME_FILE_PATTERN)
-        basename_overrides = self._csv_to_tuples(BASENAME_FILE_PATTERN)
-        
-        self.nickname_overrides = {x[0].lower(): int(x[1])
-                                   for x in nickname_overrides if x[1].isdigit()}
-        
-        self.basename_overrides = defaultdict(set)
-        for x in basename_overrides:
-            k, v = x
-            if k.isdigit():
-                self.basename_overrides[int(k)].add(v.lower())
-        
-        self.database = PgRawDatabase(data_dir=self.settings.dataDir())
-        self.index = MonsterIndex(self.database, self.nickname_overrides, self.basename_overrides)
-        
-        self.write_monster_attr_data()
-        self.write_monster_computed_names()
+    @commands.command(pass_context=True)
+    async def lookup(self, ctx, *, query: str):
+        """Short info results for a monster query"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            embed = monsterToHeaderEmbed(m)
+            await self.bot.say(embed=embed)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
     
-    def write_monster_computed_names(self):
-        results = {}
-        for name, nm in self.index.all_entries.items():
-            results[name] = int(rpadutils.get_pdx_id(nm))
-        
-        with open(NAMES_EXPORT_PATH, 'w', encoding='utf-8') as f:
-            json.dump(results, f, sort_keys=True)
-        
-        results = {}
-        for nm in self.index.all_monsters:
-            entry = {'bn': list(nm.group_basenames)}
-            if nm.extra_nicknames:
-                entry['nn'] = list(nm.extra_nicknames)
-            results[int(rpadutils.get_pdx_id(nm))] = entry
-        
-        with open(BASENAMES_EXPORT_PATH, 'w', encoding='utf-8') as f:
-            json.dump(results, f, sort_keys=True)
+    @commands.command(pass_context=True)
+    async def evolist(self, ctx, *, query):
+        """Monster info (for all monsters in the evo tree)"""
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            await self._do_evolistmenu(ctx, m)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
     
-    def write_monster_attr_data(self):
-        """Write id,server,attr1,attr2 to be used by the portrait generation process."""
-        attr_short_prefix_map = {
-            Attribute.Fire: 'r',
-            Attribute.Water: 'b',
-            Attribute.Wood: 'g',
-            Attribute.Light: 'l',
-            Attribute.Dark: 'd',
-        }
+    @commands.command(pass_context=True, aliases=['leaders', 'leaderskills', 'ls'])
+    async def leaderskill(self, ctx, left_query: str, right_query: str = None, *, bad=None):
+        """Display the multiplier and leaderskills for two monsters
+
+        If either your left or right query contains spaces, wrap in quotes.
+        e.g.: ^leaderskill "r sonia" "b sonia"
+        """
+        if bad:
+            await self.bot.say(inline('Too many inputs. Try wrapping your queries in quotes.'))
+            return
         
-        # Monsters who exist only in na have the same na/jp id but differing monster_no
-        na_only = [x for x in self.database._monster_map.values() if x.monster_no !=
-                   x.monster_no_na and x.monster_no_na == x.monster_no_jp]
+        # Handle a very specific failure case, user typing something like "uuvo ragdra"
+        if ' ' not in left_query and right_query is not None and ' ' not in right_query and bad is None:
+            combined_query = left_query + ' ' + right_query
+            nm, err, debug_info = self._findMonster(combined_query)
+            if nm and left_query in nm.prefixes:
+                left_query = combined_query
+                right_query = None
         
-        na_only_base_no = [x.monster_no for x in na_only]
-        na_only_server_no = [x.monster_no_na for x in na_only]
+        left_m, left_err, _ = self.findMonster(left_query)
+        if right_query:
+            right_m, right_err, _ = self.findMonster(right_query)
+        else:
+            right_m, right_err, = left_m, left_err
         
-        with open(ATTR_EXPORT_PATH, 'w') as csvfile:
-            writer = csv.writer(csvfile, delimiter=',', lineterminator='\n')
-            for m in self.database._monster_map.values():
-                attr1 = attr_short_prefix_map[m.attr1]
-                attr2 = attr_short_prefix_map[m.attr2] if m.attr2 else ''
-                if m.monster_no in na_only_base_no:
-                    # Writes stuff like voltron
-                    writer.writerow([m.monster_no_na, 'na', attr1, attr2])
-                elif m.monster_no_jp in na_only_server_no:
-                    # Writes stuff like crows
-                    writer.writerow([m.monster_no_jp, 'jp', attr1, attr2])
-                else:
-                    # writes everything else
-                    writer.writerow([m.monster_no_na, 'na', attr1, attr2])
-                    writer.writerow([m.monster_no_jp, 'jp', attr1, attr2])
+        err_msg = '{} query failed to match a monster: [ {} ]. If your query is multiple words, wrap it in quotes.'
+        if left_err:
+            await self.bot.say(inline(err_msg.format('Left', left_query)))
+            return
+        if right_err:
+            await self.bot.say(inline(err_msg.format('Right', right_query)))
+            return
+        
+        emoji_to_embed = OrderedDict()
+        emoji_to_embed[self.ls_emoji] = monstersToLsEmbed(left_m, right_m)
+        emoji_to_embed[self.left_emoji] = monsterToEmbed(left_m, self.get_emojis())
+        emoji_to_embed[self.right_emoji] = monsterToEmbed(right_m, self.get_emojis())
+        
+        await self._do_menu(ctx, self.ls_emoji, emoji_to_embed)
     
-    def _csv_to_tuples(self, file_path: str, cols: int = 2):
-        # Loads a two-column CSV into an array of tuples.
-        results = []
-        with open(file_path, encoding='utf-8') as f:
-            file_reader = csv.reader(f, delimiter=',')
-            for row in file_reader:
-                if len(row) < 2:
-                    continue
-                
-                data = [None] * cols
-                for i in range(0, min(cols, len(row))):
-                    data[i] = row[i].strip()
-                
-                if not len(data[0]):
-                    continue
-                
-                results.append(data)
-        return results
+    @commands.command(name="helpid", pass_context=True, aliases=['helppic', 'helpimg'])
+    async def _helpid(self, ctx):
+        """Whispers you info on how to craft monster queries for ^id"""
+        await self.bot.whisper(box(HELP_MSG))
     
-    async def _download_files(self):
-        # twelve hours expiry
-        standard_expiry_secs = 12 * 60 * 60
-        # four hours expiry
-        quick_expiry_secs = 4 * 60 * 60
+    @commands.command(pass_context=True)
+    async def padsay(self, ctx, server, *, query: str = None):
+        """Speak the voice line of a monster into your current chat"""
+        voice = ctx.message.author.voice
+        channel = voice.voice_channel
+        if channel is None:
+            await self.bot.say(inline('You must be in a voice channel to use this command'))
+            return
         
-        # Use a dummy file to proxy for the entire database being out of date
-        general_dummy_file = DUMMY_FILE_PATTERN.format('general')
-        download_all = rpadutils.checkPadguideCacheFile(general_dummy_file, quick_expiry_secs)
+        speech_cog = self.bot.get_cog('Speech')
+        if not speech_cog:
+            await self.bot.say(inline('Speech seems to be offline'))
+            return
         
-        async with aiohttp.ClientSession() as client_session:
-            for type in self._standard_refresh:
-                endpoint = type.file_name()
-                result_file = JSON_FILE_PATTERN.format(endpoint)
-                if download_all or rpadutils.should_download(result_file, quick_expiry_secs):
-                    await rpadutils.async_cached_padguide_request(client_session, endpoint, result_file)
-                    # Sleep to avoid overwhelming with requests
-                    await asyncio.sleep(1)
-            
-            for type in self._quick_refresh:
-                cur_time = int(round(time.time() * 1000))
-                three_weeks_ago = cur_time - 3 * 7 * 24 * 60 * 60 * 1000
-                endpoint = type.file_name()
-                result_file = JSON_FILE_PATTERN.format(endpoint)
-                if download_all or rpadutils.should_download(result_file, quick_expiry_secs):
-                    await rpadutils.async_cached_padguide_request(client_session, endpoint, result_file,
-                                                                  time_ms=three_weeks_ago)
-    
-    async def _download_override_files(self):
-        overrides_expiry_secs = 1 * 60 * 60
-        await rpadutils.makeAsyncCachedPlainRequest(
-            NICKNAME_FILE_PATTERN, NICKNAME_OVERRIDES_SHEET, overrides_expiry_secs)
-        await rpadutils.makeAsyncCachedPlainRequest(
-            BASENAME_FILE_PATTERN, GROUP_BASENAMES_OVERRIDES_SHEET, overrides_expiry_secs)
+        if server.lower() not in ['na', 'jp']:
+            query = server + ' ' + (query or '')
+            server = 'na'
+        query = query.strip().lower()
+        
+        m, err, debug_info = self.findMonster(query)
+        if m is not None:
+            base_dir = '/home/tactical0retreat/pad_data/voices/fixed'
+            voice_file = os.path.join(base_dir, server, '{}.wav'.format(m.monster_no_na))
+            header = '{} ({})'.format(monsterToHeader(m), server)
+            if not os.path.exists(voice_file):
+                await self.bot.say(inline('Could not find voice for ' + header))
+                return
+            await self.bot.say('Speaking for ' + header)
+            await speech_cog.play_path(channel, voice_file)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
     
     @commands.group(pass_context=True)
     @checks.is_owner()
-    async def padguide2(self, ctx):
-        """PAD database management"""
+    async def padinfo(self, ctx):
+        """PAD info management"""
         if ctx.invoked_subcommand is None:
             await send_cmd_help(ctx)
     
-    @padguide2.command(pass_context=True)
+    @padinfo.command(pass_context=True)
     @checks.is_owner()
-    async def setdatadir(self, ctx, *, data_dir):
-        """Set a local path to padguide data instead of downloading it."""
-        self.settings.setDataDir(data_dir)
+    async def setemojiservers(self, ctx, *, emoji_servers=''):
+        """Set the emoji servers by ID (csv)"""
+        self.settings.emojiServers().clear()
+        if emoji_servers:
+            self.settings.setEmojiServers(emoji_servers.split(','))
+        await self.bot.say(inline('Set {} servers'.format(len(self.settings.emojiServers()))))
+    
+    def get_emojis(self):
+        server_ids = self.settings.emojiServers()
+        return [e for s in self.bot.servers if s.id in server_ids for e in s.emojis]
+    
+    def makeFailureMsg(self, err):
+        msg = 'Lookup failed: {}.\n'.format(err)
+        msg += 'Try one of <id>, <name>, [argbld]/[rgbld] <name>. Unexpected results? Use ^helpid for more info.'
+        return box(msg)
+    
+    def findMonster(self, query, na_only=False):
+        query = rmdiacritics(query)
+        nm, err, debug_info = self._findMonster(query, na_only)
+        
+        monster_no = nm.monster_no if nm else -1
+        self.historic_lookups[query] = monster_no
+        dataIO.save_json(self.historic_lookups_file_path, self.historic_lookups)
+        
+        m = self.get_monster_by_no(nm.monster_no) if nm else None
+        
+        return m, err, debug_info
+    
+    def _findMonster(self, query, na_only=False):
+        monster_index = self.index_na if na_only else self.index_all
+        return monster_index.find_monster(query)
+    
+    def findMonster2(self, query, na_only=False):
+        query = rmdiacritics(query)
+        nm, err, debug_info = self._findMonster2(query, na_only)
+        
+        monster_no = nm.monster_no if nm else -1
+        self.historic_lookups_id2[query] = monster_no
+        dataIO.save_json(self.historic_lookups_file_path_id2, self.historic_lookups_id2)
+        
+        m = self.get_monster_by_no(nm.monster_no) if nm else None
+        
+        return m, err, debug_info
+    
+    def _findMonster2(self, query, na_only=False):
+        monster_index = self.index_na if na_only else self.index_all
+        return monster_index.find_monster2(query)
+    
+    def map_awakenings_text(self, m):
+        """Exported for use in other cogs"""
+        return _map_awakenings_text(m)
+    
+    @padinfo.command(pass_context=True)
+    @checks.is_owner()
+    async def setanimationdir(self, ctx, *, animation_dir=''):
+        """Set a directory containing animated images"""
+        self.settings.setAnimationDir(animation_dir)
         await self.bot.say(inline('Done'))
-
-
-class PadGuide2Settings(CogSettings):
-    def make_default_settings(self):
-        config = {
-            'data_dir': '',
-        }
-        return config
     
-    def dataDir(self):
-        return self.bot_settings['data_dir']
-    
-    def setDataDir(self, data_dir):
-        self.bot_settings['data_dir'] = data_dir
-        self.save_settings()
+    def check_monster_animated(self, monster_id: int):
+        if not self.settings.animationDir():
+            return False
+        
+        try:
+            animated_ids = set()
+            for f in os.listdir(self.settings.animationDir()):
+                f = f.replace('.mp4', '')
+                if f.isdigit() and int(f) == monster_id:
+                    return True
+        except:
+            pass
+        
+        return False
 
 
 def setup(bot):
-    n = PadGuide2(bot)
+    print('padinfo bot setup')
+    n = PadInfo(bot)
     bot.add_cog(n)
-    n.register_tasks()
+    bot.loop.create_task(n.reload_nicknames())
+    print('done adding padinfo bot')
 
 
-class PgRawDatabase(object):
-    def __init__(self, skip_load=False, data_dir=None):
-        self._skip_load = skip_load
-        self._data_dir = data_dir
-        self._all_pg_items = []
-        
-        # Load raw data items into id->value maps
-        self._attribute_map = self._load(PgAttribute)
-        self._awakening_map = self._load(PgAwakening)
-        self._dungeon_map = self._load(PgDungeon)
-        # self._dungeon_damage_map = self._load(PgDungeonDamage)
-        self._dungeon_monster_drop_map = self._load(PgDungeonMonsterDrop)
-        self._dungeon_monster_map = self._load(PgDungeonMonster)
-        # self._dungeon_skill_map = self._load(PgDungeonSkill)
-        # self._dungeon_type_map = self._load(PgDungeonType)
-        self._event_map = self._load(PgEvent)
-        self._evolution_map = self._load(PgEvolution)
-        self._evolution_material_map = self._load(PgEvolutionMaterial)
-        self._monster_map = self._load(PgMonster)
-        self._monster_add_info_map = self._load(PgMonsterAddInfo)
-        self._monster_info_map = self._load(PgMonsterInfo)
-        self._monster_price_map = self._load(PgMonsterPrice)
-        self._series_map = self._load(PgSeries)
-        self._scheduled_event_map = self._load(PgScheduledEvent)
-        self._skill_leader_data_map = self._load(PgSkillLeaderData)
-        self._skill_map = self._load(PgSkill)
-        self._skill_rotation_map = self._load(PgSkillRotation)
-        self._skill_rotation_dated_map = self._load(PgSkillRotationDated)
-        # self._sub_dungeon_map = self._load(PgSubDungeon)
-        self._type_map = self._load(PgType)
-        
-        self._egg_instance_map = self._load(PgEggInstance)
-        self._egg_monster_map = self._load(PgEggMonster)
-        self._egg_name_map = self._load(PgEggName)
-        
-        # Ensure that every item has loaded its dependencies
-        for i in self._all_pg_items:
-            self._ensure_loaded(i)
-        
-        # Finish loading now that all the dependencies are resolved
-        for i in self._all_pg_items:
-            i.finalize()
-        
-        # Stick the monsters into groups so that we can calculate info across
-        # the entire group
-        self.grouped_monsters = list()
-        for m in self._monster_map.values():
-            if m.cur_evo_type != EvoType.Base:
-                continue
-            self.grouped_monsters.append(MonsterGroup(m))
-        
-        # Used to normalize from monster NA values back to monster number
-        self.monster_no_na_to_monster_no = {
-            m.monster_no_na: m.monster_no for m in self._monster_map.values()}
-        
-        # Skill rotation map
-        self._server_to_rotating_skillups = {
-            'NA': [],
-            'JP': [],
+class PadInfoSettings(CogSettings):
+    def make_default_settings(self):
+        config = {
+            'animation_dir': '',
         }
-        for m in self._monster_map.values():
-            for server in m.server_actives:
-                self._server_to_rotating_skillups[server].append(m)
+        return config
     
-    def _load(self, itemtype):
-        if self._skip_load:
-            return {}
+    def emojiServers(self):
+        key = 'emoji_servers'
+        if key not in self.bot_settings:
+            self.bot_settings[key] = []
+        return self.bot_settings[key]
+    
+    def setEmojiServers(self, emoji_servers):
+        es = self.emojiServers()
+        es.clear()
+        es.extend(emoji_servers)
+        self.save_settings()
+    
+    def animationDir(self):
+        return self.bot_settings['animation_dir']
+    
+    def setAnimationDir(self, animation_dir):
+        self.bot_settings['animation_dir'] = animation_dir
+        self.save_settings()
+
+
+def monsterToHeader(m: padguide2.PgMonster, link=False):
+    msg = 'No. {} {}'.format(m.monster_no_na, m.name_na)
+    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
+
+
+def monsterToJpSuffix(m: padguide2.PgMonster):
+    suffix = ""
+    if m.roma_subname:
+        suffix += ' [{}]'.format(m.roma_subname)
+    if not m.on_na:
+        suffix += ' (JP only)'
+    return suffix
+
+
+def monsterToLongHeader(m: padguide2.PgMonster, link=False):
+    msg = monsterToHeader(m) + monsterToJpSuffix(m)
+    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
+
+
+def monsterToLongHeaderWithAttr(m: padguide2.PgMonster, link=False):
+    header = 'No. {} {} {}'.format(
+        m.monster_no_na,
+        "({}{})".format(attr_prefix_map[m.attr1], "/" +
+                                                  attr_prefix_map[m.attr2] if m.attr2 else ""),
+        m.name_na)
+    msg = header + monsterToJpSuffix(m)
+    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
+
+
+def monsterToEvoText(m: padguide2.PgMonster):
+    output = monsterToLongHeader(m)
+    for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
+        output += "\n\t- {}".format(monsterToLongHeader(ae))
+    return output
+
+
+def monsterToThumbnailUrl(m: padguide2.PgMonster):
+    return get_portrait_url(m)
+
+
+def monsterToBaseEmbed(m: padguide2.PgMonster):
+    header = monsterToLongHeader(m)
+    embed = discord.Embed()
+    embed.set_thumbnail(url=monsterToThumbnailUrl(m))
+    embed.title = header
+    embed.url = get_pdx_url(m)
+    embed.set_footer(text='Requester may click the reactions below to switch tabs')
+    return embed
+
+
+def monsterToEvoEmbed(m: padguide2.PgMonster):
+    embed = monsterToBaseEmbed(m)
+    
+    if not len(m.alt_evos):
+        embed.description = 'No alternate evos'
+        return embed
+    
+    field_name = '{} alternate evos'.format(len(m.alt_evos))
+    field_data = ''
+    for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
+        field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
+    
+    embed.add_field(name=field_name, value=field_data)
+    
+    return embed
+
+
+def monsterToEvoMatsEmbed(m: padguide2.PgMonster):
+    embed = monsterToBaseEmbed(m)
+    
+    mats_for_evo_size = len(m.mats_for_evo)
+    material_of_size = len(m.material_of)
+    
+    field_name = 'Evo materials'
+    field_data = ''
+    if mats_for_evo_size:
+        for ae in m.mats_for_evo:
+            field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
+    else:
+        field_data = 'None'
+    embed.add_field(name=field_name, value=field_data)
+    
+    if not material_of_size:
+        return embed
+    
+    field_name = 'Material for'
+    field_data = ''
+    if material_of_size > 5:
+        field_data = '{} monsters'.format(material_of_size)
+    else:
+        item_count = min(material_of_size, 5)
+        for ae in sorted(m.material_of, key=lambda x: x.monster_no_na, reverse=True)[:item_count]:
+            field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
+    embed.add_field(name=field_name, value=field_data)
+    
+    return embed
+
+
+def monsterToPantheonEmbed(m: padguide2.PgMonster):
+    full_pantheon = m.series.monsters
+    pantheon_list = list(filter(lambda x: x.evo_from is None, full_pantheon))
+    if len(pantheon_list) == 0 or len(pantheon_list) > 6:
+        return None
+    
+    embed = monsterToBaseEmbed(m)
+    
+    field_name = 'Pantheon: ' + m.series.name
+    field_data = ''
+    for monster in sorted(pantheon_list, key=lambda x: x.monster_no_na):
+        field_data += '\n' + monsterToHeader(monster, link=True)
+    embed.add_field(name=field_name, value=field_data)
+    
+    return embed
+
+
+def monsterToSkillupsEmbed(m: padguide2.PgMonster):
+    skillups_list = m.active_skill.monsters_with_active if m.active_skill else []
+    skillups_list = list(filter(lambda m: m.sell_mp < 3000, skillups_list))
+    server_skillups = m.active_skill.server_skillups if m.active_skill else []
+    
+    if len(skillups_list) + len(server_skillups) == 0:
+        return None
+    
+    embed = monsterToBaseEmbed(m)
+    
+    skillups_to_skip = []
+    for server, skillup in server_skillups.items():
+        skillup_header = 'Skillup in ' + server
+        skillup_body = monsterToHeader(skillup, link=True)
+        embed.add_field(name=skillup_header, value=skillup_body)
+        skillups_to_skip.append(skillup.monster_no_na)
+    
+    field_name = 'Skillups'
+    field_data = ''
+    
+    # Prevent huge skillup lists
+    if len(skillups_list) > 8:
+        field_data = '({} skillups omitted)'.format(len(skillups_list) - 8)
+        skillups_list = skillups_list[0:8]
+    
+    for monster in sorted(skillups_list, key=lambda x: x.monster_no_na):
+        if monster.monster_no_na in skillups_to_skip:
+            continue
+        field_data += '\n' + monsterToHeader(monster, link=True)
+    
+    if len(field_data.strip()):
+        embed.add_field(name=field_name, value=field_data)
+    
+    return embed
+
+
+def monsterToPicUrl(m: padguide2.PgMonster):
+    return get_pic_url(m)
+
+
+def monsterToPicEmbed(m: padguide2.PgMonster, animated=False):
+    embed = monsterToBaseEmbed(m)
+    url = monsterToPicUrl(m)
+    embed.set_image(url=url)
+    # Clear the thumbnail, don't need it on pic
+    embed.set_thumbnail(url='')
+    if animated:
+        description = '[{}]({}) –– [{}]({})'.format(
+            'HQ (MP4)', monsterToVideoUrl(m), 'LQ (GIF)', monsterToGifUrl(m))
+        embed.add_field(name='Animated links', value=description)
+    
+    return embed
+
+
+def monsterToVideoUrl(m: padguide2.PgMonster):
+    return VIDEO_TEMPLATE.format(m.monster_no_jp)
+
+
+def monsterToGifUrl(m: padguide2.PgMonster):
+    return GIF_TEMPLATE.format(m.monster_no_jp)
+
+
+def monsterToGifEmbed(m: padguide2.PgMonster):
+    embed = monsterToBaseEmbed(m)
+    url = monsterToGifUrl(m)
+    embed.set_image(url=url)
+    # Clear the thumbnail, don't need it on pic
+    embed.set_thumbnail(url='')
+    return embed
+
+
+def monstersToLsEmbed(left_m: padguide2.PgMonster, right_m: padguide2.PgMonster):
+    lhp, latk, lrcv, lresist = left_m.leader_skill_data.get_data()
+    rhp, ratk, rrcv, rresist = right_m.leader_skill_data.get_data()
+    multiplier_text = createMultiplierText(lhp, latk, lrcv, lresist, rhp, ratk, rrcv, rresist)
+    
+    embed = discord.Embed()
+    embed.title = 'Multiplier [{}]\n\n'.format(multiplier_text)
+    description = ''
+    description += '\n**{}**\n{}'.format(
+        monsterToHeader(left_m, link=True),
+        left_m.leader_skill.desc if left_m.leader_skill else 'None/Missing')
+    description += '\n**{}**\n{}'.format(
+        monsterToHeader(right_m, link=True),
+        right_m.leader_skill.desc if right_m.leader_skill else 'None/Missing')
+    embed.description = description
+    
+    return embed
+
+
+def monsterToHeaderEmbed(m: padguide2.PgMonster):
+    header = monsterToLongHeader(m, link=True)
+    embed = discord.Embed()
+    embed.description = header
+    return embed
+
+
+def monsterToTypeString(m: padguide2.PgMonster):
+    output = m.type1
+    if m.type2:
+        output += '/' + m.type2
+    if m.type3:
+        output += '/' + m.type3
+    return output
+
+
+def monsterToAcquireString(m: padguide2.PgMonster):
+    acquire_text = None
+    if m.farmable and not m.mp_evo:
+        # Some MP shop monsters 'drop' in PADR
+        acquire_text = 'Farmable'
+    elif m.farmable_evo and not m.mp_evo:
+        acquire_text = 'Farmable Evo'
+    elif m.in_pem:
+        acquire_text = 'In PEM'
+    elif m.pem_evo:
+        acquire_text = 'PEM Evo'
+    elif m.in_rem:
+        acquire_text = 'In REM'
+    elif m.rem_evo:
+        acquire_text = 'REM Evo'
+    elif m.in_mpshop:
+        acquire_text = 'MP Shop'
+    elif m.mp_evo:
+        acquire_text = 'MP Shop Evo'
+    return acquire_text
+
+
+def match_emoji(emoji_list, name):
+    for e in emoji_list:
+        if e.name == name:
+            return e
+    return None
+
+
+def monsterToEmbed(m: padguide2.PgMonster, emoji_list):
+    embed = monsterToBaseEmbed(m)
+    
+    info_row_1 = monsterToTypeString(m)
+    acquire_text = monsterToAcquireString(m)
+    
+    info_row_2 = '**Rarity** {}\n**Cost** {}'.format(m.rarity, m.cost)
+    if acquire_text:
+        info_row_2 += '\n**{}**'.format(acquire_text)
+    if m.is_inheritable:
+        info_row_2 += '\n**Inheritable**'
+    else:
+        info_row_2 += '\n**Not inheritable**'
+    
+    embed.add_field(name=info_row_1, value=info_row_2)
+    
+    if m.limitbreak_stats and m.limitbreak_stats > 1:
+        def lb(x):
+            return int(round(m.limitbreak_stats * x))
         
-        if self._data_dir:
-            file_path = os.path.join(self._data_dir, '{}.json'.format(itemtype.file_name()))
+        stats_row_1 = 'Weighted {} | LB {}'.format(m.weighted_stats, lb(m.weighted_stats))
+        stats_row_2 = '**HP** {} ({})\n**ATK** {} ({})\n**RCV** {} ({})'.format(
+            m.hp, lb(m.hp), m.atk, lb(m.atk), m.rcv, lb(m.rcv))
+    else:
+        stats_row_1 = 'Weighted {}'.format(m.weighted_stats)
+        stats_row_2 = '**HP** {}\n**ATK** {}\n**RCV** {}'.format(m.hp, m.atk, m.rcv)
+    embed.add_field(name=stats_row_1, value=stats_row_2)
+    
+    awakenings_row = ''
+    for idx, a in enumerate(m.awakenings):
+        a = a.get_name()
+        mapped_awakening = AWAKENING_NAME_MAP_RPAD.get(a, a)
+        mapped_awakening = match_emoji(emoji_list, mapped_awakening)
+        
+        if mapped_awakening is None:
+            mapped_awakening = AWAKENING_NAME_MAP.get(a, a)
+        
+        # Wrap superawakenings to the next line
+        if len(m.awakenings) - idx == m.superawakening_count:
+            awakenings_row += '\n{}'.format(mapped_awakening)
         else:
-            file_path = JSON_FILE_PATTERN.format(itemtype.file_name())
-        item_list = []
-        
-        if dataIO.is_valid_json(file_path):
-            json_data = dataIO.load_json(file_path)
-            item_list = [itemtype(item) for item in json_data['items']]
-        
-        result_map = {item.key(): item for item in item_list if not item.deleted()}
-        
-        self._all_pg_items.extend(result_map.values())
-        
-        return result_map
-    
-    def _ensure_loaded(self, item: 'PgItem'):
-        if item:
-            item.ensure_loaded(self)
-        return item
-    
-    def normalize_monster_no_na(self, monster_no_na: int):
-        if monster_no_na > 10000:
-            # Allows crows to be referenced
-            return monster_no_na - 10000
-        return self.monster_no_na_to_monster_no[monster_no_na]
-    
-    def all_monsters(self):
-        """Exported for access to the full monster list."""
-        return list(self._monster_map.values())
-    
-    def all_dungeons(self):
-        """Exported for access to the full dungeon list."""
-        return list(self._dungeon_map.values())
-    
-    def all_egg_instances(self):
-        """Exported for access to the full egg machine list."""
-        return list(self._egg_instance_map.values())
-    
-    def all_scheduled_events(self):
-        """Exported for access to event list."""
-        se = list(self._scheduled_event_map.values())
-        return se
-    
-    def rotating_skillups(self, server: str):
-        """Gets monsters used as rotating skillups for the specified server"""
-        return list(self._server_to_rotating_skillups[server])
-    
-    def getAttributeEnum(self, ta_seq: int):
-        attr = self._ensure_loaded(self._attribute_map.get(ta_seq))
-        return attr.value if attr else None
-    
-    def getAwakening(self, tma_seq: int):
-        return self._ensure_loaded(self._awakening_map.get(tma_seq))
-    
-    def getDungeon(self, dungeon_seq: int):
-        return self._ensure_loaded(self._dungeon_map.get(dungeon_seq))
-    
-    #    def getDungeonDamage(self, tds_seq: int):
-    #        return self._ensure_loaded(self._dungeon_damage_map.get(tds_seq))
-    
-    def getDungeonMonsterDrop(self, tdmd_seq: int):
-        return self._ensure_loaded(self._dungeon_monster_drop_map.get(tdmd_seq))
-    
-    def getDungeonMonster(self, tdm_seq: int):
-        return self._ensure_loaded(self._dungeon_monster_map.get(tdm_seq))
-    
-    #    def getDungeonType(self, tdt_seq: int):
-    #        return self._ensure_loaded(self._dungeon_type_map.get(tdt_seq))
-    
-    def getEvent(self, event_seq: int):
-        return self._ensure_loaded(self._event_map.get(event_seq))
-    
-    def getEvolution(self, tv_seq: int):
-        return self._ensure_loaded(self._evolution_map.get(tv_seq))
-    
-    def getEvolutionMaterial(self, tem_seq: int):
-        return self._ensure_loaded(self._evolution_material_map.get(tem_seq))
-    
-    def getMonster(self, monster_no: int):
-        return self._ensure_loaded(self._monster_map.get(monster_no))
-    
-    def getMonsterAddInfo(self, monster_no: int):
-        return self._ensure_loaded(self._monster_add_info_map.get(monster_no))
-    
-    def getMonsterInfo(self, monster_no: int):
-        return self._ensure_loaded(self._monster_info_map.get(monster_no))
-    
-    def getMonsterPrice(self, monster_no: int):
-        return self._ensure_loaded(self._monster_price_map.get(monster_no))
-    
-    def getSeries(self, tsr_seq: int):
-        return self._ensure_loaded(self._series_map.get(tsr_seq))
-    
-    def getScheduledEvent(self, schedule_seq: int):
-        return self._ensure_loaded(self._scheduled_event_map.get(schedule_seq))
-    
-    def getSkill(self, ts_seq: int):
-        return self._ensure_loaded(self._skill_map.get(ts_seq))
-    
-    def getSkillLeaderData(self, ts_seq: int):
-        skill_leader = self._skill_leader_data_map.get(ts_seq)
-        if skill_leader:
-            return self._ensure_loaded(skill_leader)
-        else:
-            return PgSkillLeaderData.empty()
-    
-    def getSkillRotation(self, tsr_seq: int):
-        return self._ensure_loaded(self._skill_rotation_map.get(tsr_seq))
-    
-    def getSkillRotationDated(self, tsrl_seq: int):
-        return self._ensure_loaded(self._skill_rotation_dated_map.get(tsrl_seq))
-    
-    #    def getSubDungeon(self, tsd_seq: int):
-    #        return self._ensure_loaded(self._sub_dungeon_map.get(tsd_seq))
-    
-    def getTypeName(self, tt_seq: int):
-        type = self._ensure_loaded(self._type_map.get(tt_seq))
-        return type.name if type else None
-    
-    def getEggInstance(self, tet_seq: int):
-        return self._ensure_loaded(self._egg_instance_map.get(tet_seq))
-    
-    def getEggMonster(self, tem_seq: int):
-        return self._ensure_loaded(self._egg_monster_map.get(tem_seq))
-    
-    def getEggName(self, tetn_seq: int):
-        return self._ensure_loaded(self._egg_name_map.get(tetn_seq))
-
-
-class PgItem(object):
-    """Base class for all items loaded from PadGuide.
-
-    You must call super().__init__() in your constructor.
-    You must override key() and load().
-    """
-    
-    def __init__(self):
-        self._loaded = False
-    
-    def key(self):
-        """Used to look up an item by id."""
-        raise NotImplementedError()
-    
-    def deleted(self):
-        """Is this item marked for deletion. Discard if true. Not all items can be deleted."""
-        return False
-    
-    def ensure_loaded(self, database: PgRawDatabase):
-        """Ensures that the dependencies have been loaded, or loads them."""
-        if not self._loaded:
-            self._loaded = True
-            self._loading_error = False
-            try:
-                self.load(database)
-            except Exception as ex:
-                self._loading_error = False
-                print('Error occurred while loading item')
-                print(type(self), 'key=', self.key())
-                traceback.print_exc()
-        
-        return self
-    
-    def load(self, database: PgRawDatabase):
-        """Override to inject dependencies."""
-        raise NotImplementedError()
-    
-    def finalize(self):
-        """Finish filling in anything that requires completion but no dependencies."""
-        pass
-
-
-class Attribute(Enum):
-    """Standard 5 PAD colors in enum form. Values correspond to PadGuide values."""
-    Fire = 1
-    Water = 2
-    Wood = 3
-    Light = 4
-    Dark = 5
-
-
-# attributeList
-# {
-#     "ORDER_IDX": "2",
-#     "TA_NAME_JP": "\u6c34",
-#     "TA_NAME_KR": "\ubb3c",
-#     "TA_NAME_US": "Water",
-#     "TA_SEQ": "2",
-#     "TSTAMP": "1372947975226"
-# },
-class PgAttribute(PgItem):
-    @staticmethod
-    def file_name():
-        return 'attributeList'
-    
-    def __init__(self, item):
-        super().__init__()
-        self.ta_seq = int(item['TA_SEQ'])  # unique id
-        self.name = item['TA_NAME_US']
-        
-        self.value = Attribute(self.ta_seq)
-    
-    def key(self):
-        return self.ta_seq
-    
-    def load(self, database: PgRawDatabase):
-        pass
-
-
-# awokenSkillList
-# {
-#     "DEL_YN": "N",
-#     "IS_SUPER": "1",
-#     "MONSTER_NO": "661",
-#     "ORDER_IDX": "1",
-#     "TMA_SEQ": "1",
-#     "TSTAMP": "1380587210665",
-#     "TS_SEQ": "2769"
-# },
-class PgAwakening(PgItem):
-    @staticmethod
-    def file_name():
-        return 'awokenSkillList'
-    
-    def __init__(self, item):
-        super().__init__()
-        self.tma_seq = int(item['TMA_SEQ'])  # unique id
-        self.ts_seq = int(item['TS_SEQ'])  # PgSkill id - awakening info
-        self.deleted_yn = item['DEL_YN']  # Either Y(discard) or N.
-        self.monster_no = int(item['MONSTER_NO'])  # PgMonster id - monster this belongs to
-        self.order = int(item['ORDER_IDX'])  # display order
-        self.is_super = item.get('IS_SUPER', '0') == '1'
-        
-        self.skill = None  # type: PgSkill  # The awakening skill
-        self.monster = None  # type: PgMonster # The monster the awakening belongs to
-    
-    def key(self):
-        return self.tma_seq
-    
-    def deleted(self):
-        return self.deleted_yn == 'Y'
-    
-    def load(self, database: PgRawDatabase):
-        self.skill = database.getSkill(self.ts_seq)
-        self.monster = database.getMonster(self.monster_no)
-        
-        self.monster.awakenings.append(self)
-        self.skill.monsters_with_awakening.append(self.monster)
-    
-    def get_name(self):
-        return self.skill.name
-
-
-# dungeonList
-# {
-#     "APP_VERSION": "",
-#     "COMMENT_JP": "",
-#     "COMMENT_KR": "",
-#     "COMMENT_US": "",
-#     "DUNGEON_SEQ": "102",
-#     "DUNGEON_TYPE": "1",
-#     "ICON_SEQ": "666",
-#     "NAME_JP": "ECO\u30b3\u30e9\u30dc",
-#     "NAME_KR": "ECO \ucf5c\ub77c\ubcf4",
-#     "NAME_US": "ECO Collab",
-#     "ORDER_IDX": "3",
-#     "SHOW_YN": "1",
-#     "TDT_SEQ": "10",
-#     "TSTAMP": "1373289123410"
-# },
-class PgDungeon(PgItem):
-    @staticmethod
-    def file_name():
-        return 'dungeonList'
-    
-    def __init__(self, item):
-        super().__init__()
-        self.dungeon_seq = int(item['DUNGEON_SEQ'])
-        self.dungeon_type = int(item['DUNGEON_TYPE'])
-        # TODO: merge these two, delete DungeonType from padevents
-        self.dungeon_type_value = DungeonType(self.dungeon_type)
-        self.name = item['NAME_US']
-        self.name_jp = item['NAME_JP']
-        # TODO: load tdt type
-        self.tdt_seq = int_or_none(item['TDT_SEQ'])
-        self.show = item['SHOW_YN'] == 1
-        self.icon = int(item['ICON_SEQ'])
-        
-        self.tdungeon_type = None
-        self.tdungeon_type_name = 'no_type'
-        
-        self.monsters = []
-        self.subdungeons = []
-    
-    def key(self):
-        return self.dungeon_seq
-    
-    def deleted(self):
-        return False
-    
-    #         return not self.show
-    
-    def load(self, database: PgRawDatabase):
-        pass
-
-
-#        if self.tdt_seq:
-#            self.tdungeon_type = database.getDungeonType(self.tdt_seq)
-#            # Somehow this can still fail
-#            if self.tdungeon_type:
-#                self.tdungeon_type_name = self.tdungeon_type.name
-
-
-class DungeonType(Enum):
-    Unknown = -1
-    Normal = 0
-    CoinDailyOther = 1
-    Technical = 2
-    Etc = 3
-
-
-# {
-#     "COIN_MAX": "2496",
-#     "COIN_MIN": "2496",
-#     "DUNGEON_SEQ": "81",
-#     "EXP_MAX": "2420",
-#     "EXP_MIN": "2420",
-#     "ORDER_IDX": "96",
-#     "STAGE": "5",
-#     "STAMINA": "15",
-#     "TSD_NAME_JP": "\u65ad\u7f6a\u306e\u7114 \u4e2d\u7d1a",
-#     "TSD_NAME_KR": "\ub2e8\uc8c4\uc758 \ubd88\uaf43 \uc911\uae09",
-#     "TSD_NAME_US": "Flame of Conviction - Int",
-#     "TSD_SEQ": "1365",
-#     "TSTAMP": "1373446281337"
-# },
-class PgSubDungeon(PgItem):
-    @staticmethod
-    def file_name():
-        return 'subDungeonList'
-    
-    def __init__(self, item):
-        super().__init__()
-        self.dungeon_seq = int(item['DUNGEON_SEQ'])
-        self.exp_max = int(item['EXP_MAX'])
-        self.exp_min = int(item['EXP_MIN'])
-        self.order = int(item['ORDER_IDX'])
-        self.stage = int(item['STAGE'])
-        self.stamina = int(item['STAMINA'])
-        self.name = item['TSD_NAME_US']
-        self.tsd_seq = int(item['TSD_SEQ'])
-        
-        self.monsters = []
-        self.floor_to_monsters = defaultdict(list)
-    
-    def key(self):
-        return self.tsd_seq
-    
-    def load(self, database: PgRawDatabase):
-        self.dungeon = database.getDungeon(self.dungeon_seq)
-        self.dungeon.subdungeons.append(self)
-
-
-# dungeonMonsterDropList.jsp
-# {
-#     "MONSTER_NO": "3427",
-#     "ORDER_IDX": "20",
-#     "STATUS": "0",
-#     "TDMD_SEQ": "967",
-#     "TDM_SEQ": "17816",
-#     "TSTAMP": "1489371218890"
-# },
-# Seems to be dedicated skillups only, like collab drops
-class PgDungeonMonsterDrop(PgItem):
-    @staticmethod
-    def file_name():
-        return 'dungeonMonsterDropList'
-    
-    def __init__(self, item):
-        super().__init__()
-        self.tdmd_seq = int(item['TDMD_SEQ'])  # unique id
-        self.monster_no = int(item['MONSTER_NO'])
-        self.status = item['STATUS']  # if 1, good, if 0, bad
-        self.tdm_seq = int(item['TDM_SEQ'])  # PgDungeonMonster id
-        
-        self.monster = None  # type: PgMonster
-        self.dungeon_monster = None  # type: PgDungeonMonster
-    
-    def key(self):
-        return self.tdmd_seq
-    
-    def deleted(self):
-        # TODO: Should we be checking status == 1?
-        return False
-    
-    def load(self, database: PgRawDatabase):
-        self.monster = database.getMonster(self.monster_no)
-        self.dungeon_monster = database.getDungeonMonster(self.tdm_seq)
-
-
-# dungeonMonsterList
-# {
-#     "AMOUNT": "1",
-#     "ATK": "9810",
-#     "COMMENT_JP": "",
-#     "COMMENT_KR": "",
-#     "COMMENT_US": "",
-#     "DEF": "340",
-#     "DROP_NO": "2789",
-#     "DUNGEON_SEQ": "150",
-#     "FLOOR": "5",
-#     "HP": "3011250",
-#     "MONSTER_NO": "2789",
-#     "ORDER_IDX": "50",
-#     "TDM_SEQ": "53122",
-#     "TSD_SEQ": "4564",
-#     "TSTAMP": "1480298353178",
-#     "TURN": "1"
-# },
-class PgDungeonMonster(PgItem):
-    @staticmethod
-    def file_name():
-        return 'dungeonMonsterList'
-    
-    def __init__(self, item):
-        super().__init__()
-        self.tdm_seq = int(item['TDM_SEQ'])  # unique id
-        self.amount = int(item['AMOUNT'])
-        self.atk = int(item['ATK'])
-        self.defence = int(item['DEF'])
-        self.drop_monster_no = int(item['DROP_NO'])  # PgMonster unique id
-        self.dungeon_seq = int(item['DUNGEON_SEQ'])  # PgDungeon uniqueId
-        self.floor = int(item['FLOOR'])
-        self.hp = int(item['HP'])
-        self.monster_no = int(item['MONSTER_NO'])  # PgMonster unique id
-        self.order = int(item['ORDER_IDX'])
-        self.tsd_seq = int(item['TSD_SEQ'])  # Sub Dungeon ID
-        self.turn = int(item['TURN'])
-        
-        self.skills = []
-    
-    def key(self):
-        return self.tdm_seq
-    
-    def load(self, database: PgRawDatabase):
-        self.monster = database.getMonster(self.monster_no)
-        
-        self.dungeon = database.getDungeon(self.dungeon_seq)
-        if self.dungeon:
-            self.dungeon.monsters.append(self)
-        
-        #         self.sub_dungeon = database.getSubDungeon(self.tsd_seq)
-        #         self.sub_dungeon.monsters.append(self)
-        #         self.sub_dungeon.floor_to_monsters[self.floor].append(self)
-        
-        self.drop_monster = database.getMonster(self.drop_monster_no)
-        if self.drop_monster and self.dungeon:
-            self.drop_monster.drop_dungeons.append(self.dungeon)
-
-
-# {
-#     "TDM_SEQ": "15044", # dungeon monster
-#     "TDS_SEQ": "8934", # damage
-#     "TSTAMP": "100",
-#     "TS_SEQ": "2190" # skill
-# },
-class PgDungeonSkill(PgItem):
-    @staticmethod
-    def file_name():
-        return 'dungeonSkillList'
-    
-    def __init__(self, item):
-        super().__init__()
-        self.tdm_seq = int(item['TDM_SEQ'])
-        self.tds_seq = int(item['TDS_SEQ'])
-        self.ts_seq = int(item['TS_SEQ'])
-    
-    def key(self):
-        return '{},{},{}'.format(self.tdm_seq, self.tds_seq, self.ts_seq)
-    
-    def load(self, database: PgRawDatabase):
-        self.dungeon_monster = database.getDungeonMonster(self.tdm_seq)
-        if self.dungeon_monster:
-            self.dungeon_monster.skills.append(self)
-        self.damage = database.getDungeonDamage(self.tds_seq)
-        self.skill = database.getSkill(self.ts_seq)
-
-
-# {
-#     "DAMAGE": "16538.0",
-#     "TDS_SEQ": "14631",
-#     "TSTAMP": "1401764306350"
-# },
-class PgDungeonDamage(PgItem):
-    @staticmethod
-    def file_name():
-        return 'dungeonSkillDamageList'
-    
-    def __init__(self, item):
-        super().__init__()
-        self.tds_seq = int(item['TDS_SEQ'])
-        self.amount = float(item['DAMAGE'])
-        
-        self.monsters = []
-        self.floor_to_monsters = defaultdict(list)
-    
-    def key(self):
-        return self.tds_seq
-    
-    def load(self, database: PgRawDatabase):
-        pass
-
-
-# {
-#     "ORDER_IDX": "120",
-#     "TDT_NAME_JP": "\u30a2\u30f3\u30b1\u30fc\u30c8",
-#     "TDT_NAME_KR": "\uc559\ucf00\uc774\ud2b8",
-#     "TDT_NAME_US": "Survey",
-#     "TDT_SEQ": "9",
-#     "TSTAMP": "1388128221704"
-# },
-class PgDungeonType(PgItem):
-    @staticmethod
-    def file_name():
-        return 'dungeonTypeList'
-    
-    def __init__(self, item):
-        super().__init__()
-        self.name = item['TDT_NAME_US']
-        self.tdt_seq = int(item['TDT_SEQ'])
-    
-    def key(self):
-        return self.tdt_seq
-    
-    def load(self, database: PgRawDatabase):
-        pass
-
-
-class EvoType(Enum):
-    """Evo types supported by PadGuide. Numbers correspond to their id values."""
-    Base = -1  # Represents monsters who didn't require evo
-    Evo = 0
-    UvoAwoken = 1
-    UuvoReincarnated = 2
-
-
-# evolutionList
-# {
-#     "APP_VERSION": "",
-#     "COMMENT_JP": "",
-#     "COMMENT_KR": "",
-#     "COMMENT_US": "",
-#     "MONSTER_NO": "1",
-#     "TO_NO": "2",
-#     "TSTAMP": "1371788673999",
-#     "TV_SEQ": "331",
-#     "TV_TYPE": "0"
-# },
-class PgEvolution(PgItem):
-    @staticmethod
-    def file_name():
-        return 'evolutionList'
-    
-    def __init__(self, item):
-        super().__init__()
-        self.tv_seq = int(item['TV_SEQ'])  # unique id
-        self.from_monster_no = int(item['MONSTER_NO'])  # PgMonster id - base monster
-        self.to_monster_no = int(item['TO_NO'])  # PgMonster id - target monster
-        self.tv_type = int(item['TV_TYPE'])
-        self.evo_type = EvoType(self.tv_type)
-    
-    def key(self):
-        return self.tv_seq
-    
-    def deleted(self):
-        # Really rare and unusual bug
-        return self.from_monster_no == 0 or self.to_monster_no == 0
-    
-    def load(self, database: PgRawDatabase):
-        self.from_monster = database.getMonster(self.from_monster_no)
-        self.to_monster = database.getMonster(self.to_monster_no)
-        
-        if self.to_monster:
-            self.to_monster.cur_evo_type = self.evo_type
-            if self.from_monster:
-                self.to_monster.evo_from = self.from_monster
-                self.from_monster.evo_to.append(self.to_monster)
-
-
-# evoMaterialList
-# {
-#     "MONSTER_NO": "153",
-#     "ORDER_IDX": "1",
-#     "TEM_SEQ": "1429",
-#     "TSTAMP": "1371788674011",
-#     "TV_SEQ": "332"
-# },
-class PgEvolutionMaterial(PgItem):
-    @staticmethod
-    def file_name():
-        return 'evoMaterialList'
-    
-    def __init__(self, item):
-        super().__init__()
-        self.tem_seq = int(item['TEM_SEQ'])  # unique id
-        self.tv_seq = int(item['TV_SEQ'])  # evo id
-        self.fodder_monster_no = int(item['MONSTER_NO'])  # material monster
-        self.order = int(item['ORDER_IDX'])  # display order
-        
-        self.evolution = None  # type: PgEvolution
-        self.fodder_monster = None  # type: PgMonster
-    
-    def key(self):
-        return self.tem_seq
-    
-    def load(self, database: PgRawDatabase):
-        self.evolution = database.getEvolution(self.tv_seq)
-        self.fodder_monster = database.getMonster(self.fodder_monster_no)
-        
-        if self.evolution is None or self.evolution.to_monster is None:
-            # Really rare and unusual bug
-            return
-        
-        target_monster = self.evolution.to_monster
-        # TODO: this is unsorted
-        target_monster.mats_for_evo.append(self.fodder_monster)
-        
-        # Prevent issues if a monster is a mat for the same monster repeatedly (gunma, stones)
-        if target_monster not in self.fodder_monster.material_of:
-            self.fodder_monster.material_of.append(target_monster)
-
-
-# monsterAddInfoList
-# {
-#     "EXTRA_VAL1": "1",
-#     "EXTRA_VAL2": "",
-#     "EXTRA_VAL3": "",
-#     "EXTRA_VAL4": "",
-#     "EXTRA_VAL5": "",
-#     "MONSTER_NO": "3329",
-#     "SUB_TYPE": "0",
-#     "TSTAMP": "1480435906788"
-# },
-class PgMonsterAddInfo(PgItem):
-    """Optional extra information for a Monster.
-
-    Data is copied into PgMonster and this is discarded."""
-    
-    @staticmethod
-    def file_name():
-        return 'monsterAddInfoList'
-    
-    def __init__(self, item):
-        super().__init__()
-        self.monster_no = int(item['MONSTER_NO'])
-        self.sub_type = int(item['SUB_TYPE'])
-        self.extra_val_1 = int_or_none(item['EXTRA_VAL1'])
-    
-    def key(self):
-        return self.monster_no
-    
-    def load(self, database: PgRawDatabase):
-        pass
-
-
-# monsterInfoList
-# {
-#     "FODDER_EXP": "675.0",
-#     "HISTORY_JP": "[2016-12-16] \u65b0\u898f\u8ffd\u52a0",
-#     "HISTORY_KR": "[2016-12-16] \uc2e0\uaddc\ucd94\uac00",
-#     "HISTORY_US": "[2016-12-16] New Added",
-#     "MONSTER_NO": "3382",
-#     "ON_KR": "1",
-#     "ON_US": "1",
-#     "PAL_EGG": "0",
-#     "RARE_EGG": "0",
-#     "SELL_PRICE": "300.0",
-#     "TSR_SEQ": "86",
-#     "TSTAMP": "1481846935838"
-# },
-class PgMonsterInfo(PgItem):
-    """Extra information for a Monster.
-
-    Data is copied into PgMonster and this is discarded."""
-    
-    @staticmethod
-    def file_name():
-        return 'monsterInfoList'
-    
-    def __init__(self, item):
-        super().__init__()
-        self.monster_no = int(item['MONSTER_NO'])
-        self.on_na = item['ON_US'] == '1'
-        self.tsr_seq = int_or_none(item['TSR_SEQ'])  # PgSeries id
-        self.in_pem = item['PAL_EGG'] == '1'
-        self.in_rem = item['RARE_EGG'] == '1'
-        self.history_us = item['HISTORY_US']
-    
-    def key(self):
-        return self.monster_no
-    
-    def load(self, database: PgRawDatabase):
-        self.series = database.getSeries(self.tsr_seq)
-
-
-# monsterList
-# {
-#     "APP_VERSION": "0.0",
-#     "ATK_MAX": "1985",
-#     "ATK_MIN": "695",
-#     "COMMENT_JP": "",
-#     "COMMENT_KR": "\uc77c\ubcf8",
-#     "COMMENT_US": "Japan",
-#     "COST": "60",
-#     "EXP": "10000000",
-#     "HP_MAX": "6258",
-#     "HP_MIN": "3528",
-#     "LEVEL": "99",
-#     "MONSTER_NO": "3646",
-#     "MONSTER_NO_JP": "3646",
-#     "MONSTER_NO_KR": "3646",
-#     "MONSTER_NO_US": "3646",
-#     "PRONUNCIATION_JP": "\u304b\u306a\u305f\u306a\u308b\u3082\u306e\u30fb\u3088\u3050\u305d\u3068\u30fc\u3059",
-#     "RARITY": "7",
-#     "RATIO_ATK": "1.5",
-#     "RATIO_HP": "1.5",
-#     "RATIO_RCV": "1.5",
-#     "RCV_MAX": "233",
-#     "RCV_MIN": "926",
-#     "REG_DATE": "2017-04-27 17:29:48.0",
-#     "TA_SEQ": "4",
-#     "TA_SEQ_SUB": "0",
-#     "TE_SEQ": "14",
-#     "TM_NAME_JP": "\u5f7c\u65b9\u306a\u308b\u3082\u306e\u30fb\u30e8\u30b0\uff1d\u30bd\u30c8\u30fc\u30b9",
-#     "TM_NAME_KR": "\u5f7c\u65b9\u306a\u308b\u3082\u306e\u30fb\u30e8\u30b0\uff1d\u30bd\u30c8\u30fc\u30b9",
-#     "TM_NAME_US": "\u5f7c\u65b9\u306a\u308b\u3082\u306e\u30fb\u30e8\u30b0\uff1d\u30bd\u30c8\u30fc\u30b9",
-#     "TSTAMP": "1494033700775",
-#     "TS_SEQ_LEADER": "12448",
-#     "TS_SEQ_SKILL": "12447",
-#     "TT_SEQ": "10",
-#     "TT_SEQ_SUB": "1"
-# }
-class PgMonster(PgItem):
-    @staticmethod
-    def file_name():
-        return 'monsterList'
-    
-    def __init__(self, item):
-        super().__init__()
-        self.monster_no = int(item['MONSTER_NO'])
-        self.monster_no_na = int(item['MONSTER_NO_US'])
-        self.monster_no_jp = int(item['MONSTER_NO_JP'])
-        self.min_hp = int(item['HP_MIN'])
-        self.min_atk = int(item['ATK_MIN'])
-        self.min_rcv = int(item['RCV_MIN'])
-        self.hp = int(item['HP_MAX'])
-        self.atk = int(item['ATK_MAX'])
-        self.rcv = int(item['RCV_MAX'])
-        self.ts_seq_active = int_or_none(item['TS_SEQ_SKILL'])
-        self.ts_seq_leader = int_or_none(item['TS_SEQ_LEADER'])
-        self.rarity = int(item['RARITY'])
-        self.cost = int(item['COST'])
-        self.exp = int(item['EXP'])
-        self.max_level = int(item['LEVEL'])
-        self.name_na = item['TM_NAME_US']
-        self.name_jp = item['TM_NAME_JP']
-        self.ta_seq_1 = int(item['TA_SEQ'])  # PgAttribute id
-        self.ta_seq_2 = int(item['TA_SEQ_SUB'])  # PgAttribute id
-        self.te_seq = int(item['TE_SEQ'])
-        self.tt_seq_1 = int(item['TT_SEQ'])  # PgType id
-        self.tt_seq_2 = int(item['TT_SEQ_SUB'])  # PgType id
-        
-        self.debug_info = ''
-        self.weighted_stats = int(self.hp / 10 + self.atk / 5 + self.rcv / 3)
-        
-        self.roma_subname = None
-        if self.name_na == self.name_jp:
-            self.roma_subname = make_roma_subname(self.name_jp)
-        else:
-            # Remove annoying stuff from NA names, like Jörmungandr
-            self.name_na = rpadutils.rmdiacritics(self.name_na)
-        
-        self.active_skill = None  # type: PgSkill
-        self.leader_skill = None  # type: PgSkill
-        
-        # ???
-        self.cur_evo_type = EvoType.Base
-        self.evo_to = []
-        self.evo_from = None
-        
-        self.mats_for_evo = []
-        self.material_of = []
-        
-        self.awakenings = []  # PgAwakening
-        self.drop_dungeons = []
-        
-        self.alt_evos = []  # PgMonster
-        
-        # List of PgSkillRotationDated
-        self.rotating_skillups = []
-        self.server_actives = {}  # str(NA, JP) -> PgSkill
-        self.future_skillup_rotation = {}
-        
-        self.is_equip = False
-        
-        # Monsters start off pointing to themselves as the base, this will
-        # change once the MonsterGroups are computed.
-        self.base_monster = self
-        
-        # Data populated via override
-        self.limitbreak_stats = 1 + float(item['LIMIT_MULT']) / 100 if item['LIMIT_MULT'] else None
-        self.superawakening_count = 0
-        
-        # Data filled in post-load
-        self.translated_jp_name = None
-    
-    def key(self):
-        return self.monster_no
-    
-    def load(self, database: PgRawDatabase):
-        self.active_skill = database.getSkill(self.ts_seq_active)
-        if self.active_skill:
-            self.active_skill.monsters_with_active.append(self)
-        
-        self.leader_skill = database.getSkill(self.ts_seq_leader)
-        self.leader_skill_data = database.getSkillLeaderData(self.ts_seq_leader)
-        if self.leader_skill:
-            self.leader_skill.monsters_with_leader.append(self)
-        
-        self.attr1 = database.getAttributeEnum(self.ta_seq_1)
-        self.attr2 = database.getAttributeEnum(self.ta_seq_2)
-        
-        self.type1 = database.getTypeName(self.tt_seq_1)
-        self.type2 = database.getTypeName(self.tt_seq_2)
-        self.type3 = None
-        
-        self.assist_setting = None
-        monster_add_info = database.getMonsterAddInfo(self.monster_no)
-        if monster_add_info:
-            self.type3 = database.getTypeName(monster_add_info.sub_type)
-            self.assist_setting = monster_add_info.extra_val_1
-        
-        monster_info = database.getMonsterInfo(self.monster_no)
-        self.on_na = monster_info.on_na
-        self.series = database.getSeries(monster_info.tsr_seq)  # PgSeries
-        self.series.monsters.append(self)
-        self.is_gfe = self.series.tsr_seq == 34  # godfest
-        self.in_pem = monster_info.in_pem
-        self.in_rem = monster_info.in_rem
-        self.pem_evo = self.in_pem
-        self.rem_evo = self.in_rem
-        self.history_us = monster_info.history_us
-        
-        monster_price = database.getMonsterPrice(self.monster_no)
-        self.sell_mp = monster_price.sell_mp if monster_price else 0
-        self.buy_mp = monster_price.buy_mp if monster_price else 0
-        self.in_mpshop = self.buy_mp > 0
-        self.mp_evo = self.in_mpshop
-    
-    def finalize(self):
-        self.farmable = len(self.drop_dungeons) > 0
-        self.farmable_evo = self.farmable
-        
-        self.awakenings.sort(key=lambda x: x.order)
-        self.superawakening_count = sum(int(a.is_super) for a in self.awakenings)
-        
-        if self.assist_setting == 1:
-            self.is_inheritable = True
-        elif self.assist_setting == 2:
-            self.is_inheritable = False
-        else:
-            has_awakenings = len(self.awakenings) > 0
-            self.is_inheritable = has_awakenings and self.rarity >= 5 and self.sell_mp >= 3000
-        
-        self.is_equip = 'Awoken Assist' in [a.get_name() for a in self.awakenings]
-        
-        self.types = [t.lower() for t in [self.type1, self.type2, self.type3] if t]
-        
-        if self.evo_from is None:
-            def link(m: PgMonster, alt_evos: list):
-                alt_evos.append(m)
-                m.alt_evos = alt_evos
-                for em in m.evo_to:
-                    link(em, alt_evos)
-            
-            link(self, [])
-        
-        self.search = MonsterSearchHelper(self)
-        
-        # Compute server skill rotations
-        for server, server_tz in {'JP': rpadutils.JP_TZ_OBJ, 'NA': rpadutils.NA_TZ_OBJ}.items():
-            server_now = datetime.now().replace(tzinfo=server_tz).date()
-            server_skillups = list(filter(lambda s: s.skill_rotation.server == server,
-                                          self.rotating_skillups))
-            future_skillup = list(filter(lambda s: server_now < s.rotation_date, server_skillups))
-            if future_skillup:
-                self.future_skillup_rotation[server] = future_skillup[0]
-            
-            past_skillups = list(filter(lambda s: server_now >= s.rotation_date, server_skillups))
-            if past_skillups:
-                active_skillup = max(past_skillups, key=lambda s: s.rotation_date)
-                self.server_actives[server] = active_skillup.skill
-                active_skillup.skill.server_skillups[server] = active_skillup.skill_rotation.monster
-
-
-class MonsterSearchHelper(object):
-    def __init__(self, m: PgMonster):
-        
-        self.name = '{} {}'.format(m.name_na, m.name_jp).lower()
-        self.leader = m.leader_skill.desc.lower() if m.leader_skill else ''
-        self.active_name = m.active_skill.name.lower() if m.active_skill else ''
-        self.active_desc = m.active_skill.desc.lower() if m.active_skill else ''
-        self.active = '{} {}'.format(self.active_name, self.active_desc)
-        self.active_min = m.active_skill.turn_min if m.active_skill else None
-        self.active_max = m.active_skill.turn_max if m.active_skill else None
-        
-        self.color = [m.attr1.name.lower()]
-        self.hascolor = [c.name.lower() for c in [m.attr1, m.attr2] if c]
-        
-        self.limitbreak_stats = m.limitbreak_stats or 1
-        
-        self.hp = m.hp * self.limitbreak_stats
-        self.atk = m.atk * self.limitbreak_stats
-        self.rcv = m.rcv * self.limitbreak_stats
-        self.weighted_stats = m.weighted_stats * self.limitbreak_stats
-        
-        self.types = m.types
-        
-        def replace_colors(text: str):
-            return text.replace('red', 'fire').replace('blue', 'water').replace('green', 'wood')
-        
-        self.leader = replace_colors(self.leader)
-        self.active = replace_colors(self.active)
-        self.active_name = replace_colors(self.active_name)
-        self.active_desc = replace_colors(self.active_desc)
-        
-        self.board_change = []
-        self.orb_convert = defaultdict(list)
-        self.row_convert = []
-        self.column_convert = []
-        
-        def color_txt_to_list(txt):
-            txt = txt.replace('and', ' ')
-            txt = txt.replace(',', ' ')
-            txt = txt.replace('orbs', ' ')
-            txt = txt.replace('orb', ' ')
-            txt = txt.replace('mortal poison', 'mortalpoison')
-            txt = txt.replace('jammers', 'jammer')
-            txt = txt.strip()
-            return txt.split()
-        
-        def strip_prev_clause(txt: str, sep: str):
-            prev_clause_start_idx = txt.find(sep)
-            if prev_clause_start_idx >= 0:
-                prev_clause_start_idx += len(sep)
-                txt = txt[prev_clause_start_idx:]
-            return txt
-        
-        def strip_next_clause(txt: str, sep: str):
-            next_clause_start_idx = txt.find(sep)
-            if next_clause_start_idx >= 0:
-                txt = txt[:next_clause_start_idx]
-            return txt
-        
-        active_desc = self.active_desc
-        active_desc = active_desc.replace(' rows ', ' row ')
-        active_desc = active_desc.replace(' columns ', ' column ')
-        active_desc = active_desc.replace(' into ', ' to ')
-        active_desc = active_desc.replace('changes orbs to', 'all orbs to')
-        
-        board_change_txt = 'all orbs to'
-        if board_change_txt in active_desc:
-            txt = strip_prev_clause(active_desc, board_change_txt)
-            txt = strip_next_clause(txt, 'orbs')
-            txt = strip_next_clause(txt, ';')
-            self.board_change = color_txt_to_list(txt)
-        
-        txt = active_desc
-        if 'row' in txt:
-            parts = re.split('\Wand\W|;\W', txt)
-            for i in range(0, len(parts)):
-                if 'row' in parts[i]:
-                    self.row_convert.append(strip_next_clause(
-                        strip_prev_clause(parts[i], 'to '), ' orbs'))
-        
-        txt = active_desc
-        if 'column' in txt:
-            parts = re.split('\Wand\W|;\W', txt)
-            for i in range(0, len(parts)):
-                if 'column' in parts[i]:
-                    self.column_convert.append(strip_next_clause(
-                        strip_prev_clause(parts[i], 'to '), ' orbs'))
-        
-        convert_done = self.board_change or self.row_convert or self.column_convert
-        
-        change_txt = 'change '
-        if not convert_done and change_txt in active_desc and 'orb' in active_desc:
-            txt = active_desc
-            parts = re.split('\Wand\W|;\W', txt)
-            for i in range(0, len(parts)):
-                parts[i] = strip_prev_clause(parts[i], change_txt) if change_txt in parts[i] else ''
-            
-            for part in parts:
-                sub_parts = part.split(' to ')
-                if len(sub_parts) > 1:
-                    source_orbs = color_txt_to_list(sub_parts[0])
-                    dest_orbs = color_txt_to_list(sub_parts[1])
-                    for so in source_orbs:
-                        for do in dest_orbs:
-                            self.orb_convert[so].append(do)
-
-
-class MonsterGroup(object):
-    """Computes shared values across a tree of monsters and injects them."""
-    
-    def __init__(self, base_monster: PgMonster):
-        self.base_monster = base_monster
-        self.members = list()
-        self._recursive_add(base_monster)
-        self._initialize_members()
-    
-    def _recursive_add(self, m: PgMonster):
-        m.base_monster = self.base_monster
-        self.members.append(m)
-        for em in m.evo_to:
-            self._recursive_add(em)
-    
-    def _initialize_members(self):
-        # Compute tree acquisition status
-        farmable_evo, pem_evo, rem_evo, mp_evo = False, False, False, False
-        for m in self.members:
-            farmable_evo = farmable_evo or m.farmable
-            pem_evo = pem_evo or m.in_pem
-            rem_evo = rem_evo or m.in_rem
-            mp_evo = mp_evo or m.in_mpshop
-        
-        # Override tree acquisition status
-        for m in self.members:
-            m.farmable_evo = farmable_evo
-            m.pem_evo = pem_evo
-            m.rem_evo = rem_evo
-            m.mp_evo = mp_evo
-
-
-# monsterPriceList
-# {
-#     "BUY_PRICE": "0",
-#     "MONSTER_NO": "3577",
-#     "SELL_PRICE": "99",
-#     "TSTAMP": "1492101772974"
-# }
-
-
-class PgMonsterPrice(PgItem):
-    @staticmethod
-    def file_name():
-        return 'monsterPriceList'
-    
-    def __init__(self, item):
-        super().__init__()
-        self.monster_no = int(item['MONSTER_NO'])
-        self.buy_mp = int(item['BUY_PRICE'])
-        self.sell_mp = int(item['SELL_PRICE'])
-    
-    def key(self):
-        return self.monster_no
-    
-    def load(self, database: PgRawDatabase):
-        pass
-
-
-# seriesList
-# {
-#     "DEL_YN": "N",
-#     "NAME_JP": "\u308a\u3093",
-#     "NAME_KR": "\uc2ac\ub77c\uc784",
-#     "NAME_US": "Slime",
-#     "SEARCH_DATA": "\u308a\u3093 Slime \uc2ac\ub77c\uc784",
-#     "TSR_SEQ": "3",
-#     "TSTAMP": "1380587210667"
-# },
-class PgSeries(PgItem):
-    @staticmethod
-    def file_name():
-        return 'seriesList'
-    
-    def __init__(self, item):
-        super().__init__()
-        self.tsr_seq = int(item['TSR_SEQ'])
-        self.name = item['NAME_US']
-        self.deleted_yn = item['DEL_YN']  # Either Y(discard) or N.
-        
-        self.monsters = []
-    
-    def key(self):
-        return self.tsr_seq
-    
-    def deleted(self):
-        return False
-        # Temporary
-    
-    #         return self.deleted_yn == 'Y'
-    
-    def load(self, database: PgRawDatabase):
-        pass
-
-
-# skillList
-# {
-#     "MAG_ATK": "0.0",
-#     "MAG_HP": "0.0",
-#     "MAG_RCV": "0.0",
-#     "ORDER_IDX": "3",
-#     "REDUCE_DMG": "0.0",
-#     "RTA_SEQ_1": "0",
-#     "RTA_SEQ_2": "0",
-#     "SEARCH_DATA": "\u6e9c\u3081\u65ac\u308a \u6e9c\u3081\u65ac\u308a \u6e9c\u3081\u65ac\u308a 2\u30bf\u30fc\u30f3\u306e\u9593\u3001\u30c1\u30fc\u30e0\u5185\u306e\u30c9\u30e9\u30b4\u30f3\u30ad\u30e9\u30fc\u306e\u899a\u9192\u6570\u306b\u5fdc\u3058\u3066\u653b\u6483\u529b\u304c\u4e0a\u6607\u3002(1\u500b\u306b\u3064\u304d50%) Increase ATK depending on number of Dragon Killer Awakening Skills on team for 2 turns (50% per each) 2\ud134\uac04 \ud300\ub0b4\uc758 \ub4dc\ub798\uace4 \ud0ac\ub7ec \uac01\uc131 \uac2f\uc218\uc5d0 \ub530\ub77c \uacf5\uaca9\ub825\uc774 \uc0c1\uc2b9 (\uac1c\ub2f9 50%)",
-#     "TA_SEQ_1": "0",
-#     "TA_SEQ_2": "0",
-#     "TSTAMP": "1493861895693",
-#     "TS_DESC_JP": "2\u30bf\u30fc\u30f3\u306e\u9593\u3001\u30c1\u30fc\u30e0\u5185\u306e\u30c9\u30e9\u30b4\u30f3\u30ad\u30e9\u30fc\u306e\u899a\u9192\u6570\u306b\u5fdc\u3058\u3066\u653b\u6483\u529b\u304c\u4e0a\u6607\u3002(1\u500b\u306b\u3064\u304d50%)",
-#     "TS_DESC_KR": "2\ud134\uac04 \ud300\ub0b4\uc758 \ub4dc\ub798\uace4 \ud0ac\ub7ec \uac01\uc131 \uac2f\uc218\uc5d0 \ub530\ub77c \uacf5\uaca9\ub825\uc774 \uc0c1\uc2b9 (\uac1c\ub2f9 50%)",
-#     "TS_DESC_US": "Increase ATK depending on number of Dragon Killer Awakening Skills on team for 2 turns (50% per each)",
-#     "TS_NAME_JP": "\u6e9c\u3081\u65ac\u308a",
-#     "TS_NAME_KR": "\u6e9c\u3081\u65ac\u308a",
-#     "TS_NAME_US": "\u6e9c\u3081\u65ac\u308a",
-#     "TS_SEQ": "12478",
-#     "TT_SEQ_1": "0",
-#     "TT_SEQ_2": "0",
-#     "TURN_MAX": "22",
-#     "TURN_MIN": "14",
-#     "T_CONDITION": "3"
-# }
-class PgSkill(PgItem):
-    @staticmethod
-    def file_name():
-        return 'skillList'
-    
-    def __init__(self, item):
-        super().__init__()
-        self.ts_seq = int(item['TS_SEQ'])
-        self.name = item['TS_NAME_US']
-        self.desc = item['TS_DESC_US']
-        self.turn_min = int(item['TURN_MIN'])
-        self.turn_max = int(item['TURN_MAX'])
-        
-        self.monsters_with_active = []  # PgMonster
-        self.monsters_with_leader = []  # PgMonster
-        self.monsters_with_awakening = []  # PgMonster
-        
-        # str (NA, JP) -> PgMonster
-        self.server_skillups = {}
-    
-    def key(self):
-        return self.ts_seq
-    
-    def load(self, database: PgRawDatabase):
-        pass
-
-
-# skillLeaderDataList
-#
-# PgSkillLeaderData
-# 4 pipe delimited fields, each field is a condition
-# Slashes separate effects for conditions
-# 1: Code 1=HP, 2=ATK, 3=RCV, 4=Reduction
-# 2: Multiplier
-# 3: Color restriction (coded)
-# 4: Type restriction (coded)
-# 5: Combo restriction
-#
-# Reincarnated Izanagi, 4x + 50% for heal cross, 2x atk 2x rcv for god/dragon/balanced
-# {
-#     "LEADER_DATA": "4/0.5///|2/4///|2/2//6,1,2/|3/2//6,1,2/",
-#     "TSTAMP": "1487553365770",
-#     "TS_SEQ": "11695"
-# },
-# Gold Saint, Shion : 4.5X atk when 3+ light combo
-# {
-#     "LEADER_DATA": "2/4.5///3",
-#     "TSTAMP": "1432940060708",
-#     "TS_SEQ": "6661"
-# },
-# Reincarnated Minerva, 3x damage, 2x damage, color resist
-# {
-#     "LEADER_DATA": "2/3/1//|2/2///|4/0.5/1,4,5//",
-#     "TSTAMP": "1475243514648",
-#     "TS_SEQ": "10835"
-# },
-class PgSkillLeaderData(PgItem):
-    @staticmethod
-    def empty():
-        return PgSkillLeaderData({
-            'TS_SEQ': '-1',
-            'LEADER_DATA': '',
-        })
-    
-    @staticmethod
-    def file_name():
-        return 'skillLeaderDataList'
-    
-    def __init__(self, item):
-        super().__init__()
-        self.ts_seq = int(item['TS_SEQ'])  # unique id
-        self.leader_data = item['LEADER_DATA']
-        
-        hp, atk, rcv, resist = (1.0,) * 4
-        for mod in self.leader_data.split('|'):
-            if not mod.strip():
-                continue
-            items = mod.split('/')
-            
-            code = items[0]
-            mult = float(items[1])
-            if code == '1':
-                hp *= mult
-            if code == '2':
-                atk *= mult
-            if code == '3':
-                rcv *= mult
-            if code == '4':
-                resist *= mult
-        
-        self.hp = hp
-        self.atk = atk
-        self.rcv = rcv
-        self.resist = resist
-    
-    def key(self):
-        return self.ts_seq
-    
-    def load(self, database: PgRawDatabase):
-        pass
-    
-    def get_data(self):
-        return self.hp, self.atk, self.rcv, self.resist
-
-
-# skillRotationList
-# {
-#     "MONSTER_NO": "915",
-#     "SERVER": "JP",
-#     "STATUS": "0",
-#     "TSR_SEQ": "2",
-#     "TSTAMP": "1481627094573"
-# }
-class PgSkillRotation(PgItem):
-    @staticmethod
-    def file_name():
-        return 'skillRotationList'
-    
-    def __init__(self, item):
-        super().__init__()
-        self.tsr_seq = int(item['TSR_SEQ'])  # unique id
-        self.monster_no = int(item['MONSTER_NO'])
-        self.server = normalizeServer(item['SERVER'])  # JP, NA, KR
-        # Status seems to be rarely '2'
-        self.status = int(item['STATUS'])
-    
-    def key(self):
-        return self.tsr_seq
-    
-    def deleted(self):
-        return self.server == 'KR' or self.status != 0  # We don't do KR
-    
-    def load(self, database: PgRawDatabase):
-        self.monster = database.getMonster(self.monster_no)
-
-
-# skillRotationListList
-# {
-#     "ROTATION_DATE": "2016-12-14",
-#     "STATUS": "0",
-#     "TSRL_SEQ": "960",
-#     "TSR_SEQ": "86",
-#     "TSTAMP": "1481627993157",
-#     "TS_SEQ": "9926"
-# }
-class PgSkillRotationDated(PgItem):
-    @staticmethod
-    def file_name():
-        return 'skillRotationListList'
-    
-    def __init__(self, item):
-        super().__init__()
-        self.tsrl_seq = int(item['TSRL_SEQ'])  # unique id
-        self.tsr_seq = int(item['TSR_SEQ'])  # PgSkillRotation id - Current skillup monster
-        self.ts_seq = int(item['TS_SEQ'])  # PGSkill id - Current skill
-        self.rotation_date_str = item['ROTATION_DATE']
-        
-        self.rotation_date = None
-        if len(self.rotation_date_str):
-            self.rotation_date = datetime.strptime(self.rotation_date_str, "%Y-%m-%d").date()
-    
-    def key(self):
-        return self.tsrl_seq
-    
-    def load(self, database: PgRawDatabase):
-        self.skill = database.getSkill(self.ts_seq)
-        self.skill_rotation = database.getSkillRotation(self.tsr_seq)
-        
-        if self.skill_rotation:
-            self.skill_rotation.monster.rotating_skillups.append(self)
-
-
-# typeList
-# {
-#     "ORDER_IDX": "2",
-#     "TSTAMP": "1375363406092",
-#     "TT_NAME_JP": "\u60aa\u9b54",
-#     "TT_NAME_KR": "\uc545\ub9c8",
-#     "TT_NAME_US": "Devil",
-#     "TT_SEQ": "10"
-# },
-class PgType(PgItem):
-    @staticmethod
-    def file_name():
-        return 'typeList'
-    
-    def __init__(self, item):
-        super().__init__()
-        self.tt_seq = int(item['TT_SEQ'])  # unique id
-        self.name = item['TT_NAME_US']
-    
-    def key(self):
-        return self.tt_seq
-    
-    def load(self, database: PgRawDatabase):
-        pass
-
-
-class PgMonsterDropInfoCombined(object):
-    def __init__(self, monster_id, dungeon_monster_drop, dungeon_monster, dungeon):
-        self.monster_id = monster_id
-        self.dungeon_monster_drop = dungeon_monster_drop
-        self.dungeon_monster = dungeon_monster
-        self.dungeon = dungeon
-
-
-# ================================================================================
-# PadRem items below
-# ================================================================================
-
-class RemType(Enum):
-    godfest = 1
-    rare = 2
-    pal = 3
-    unknown1 = 4
-
-
-class RemRowType(Enum):
-    subsection = 0
-    divider = 1
-
-
-# eggTitleList
-#       {
-#            "DEL_YN": "N",
-#            "END_DATE": "2016-10-24 07:59:00",
-#            "ORDER_IDX": "0",
-#            "SERVER": "US",
-#            "SHOW_YN": "Y",
-#            "START_DATE": "2016-10-17 08:00:00",
-#            "TEC_SEQ": "2",
-#            "TET_SEQ": "64",
-#            "TSTAMP": "1476490114488",
-#            "TYPE": "1"
-#        },
-class PgEggInstance(PgItem):
-    @staticmethod
-    def file_name():
-        return 'eggTitleList'
-    
-    def __init__(self, item):
-        super().__init__()
-        self.server = normalizeServer(item['SERVER'])
-        self.deleted_yn = item['DEL_YN']  # Y, N
-        self.show_yn = item['SHOW_YN']  # Y, N
-        self.rem_type = RemType(int(item['TEC_SEQ']))  # matches RemType
-        self.tet_seq = int(item['TET_SEQ'])  # primary key
-        self.row_type = RemRowType(int(item['TYPE']))  # 0-> row with just name, 1-> row with date
-        
-        self.order = int(item["ORDER_IDX"])
-        self.start_date_str = item['START_DATE']
-        self.end_date_str = item['END_DATE']
-        
-        self.egg_name_us = None
-        self.egg_monsters = []
-        
-        tz = pytz.UTC
-        self.start_datetime = None
-        self.end_datetime = None
-        self.open_date_str = None
-        
-        #         self.pt_date_str = None
-        if len(self.start_date_str):
-            self.start_datetime = datetime.strptime(
-                self.start_date_str, "%Y-%m-%d %H:%M:%S").replace(tzinfo=tz)
-            self.end_datetime = datetime.strptime(
-                self.end_date_str, "%Y-%m-%d %H:%M:%S").replace(tzinfo=tz)
-            
-            if self.server == 'NA':
-                pt_tz_obj = pytz.timezone('America/Los_Angeles')
-                self.open_date_str = self.start_datetime.replace(tzinfo=pt_tz_obj).strftime('%m/%d')
-            if self.server == 'JP':
-                jp_tz_obj = pytz.timezone('Asia/Tokyo')
-                self.open_date_str = self.start_datetime.replace(tzinfo=jp_tz_obj).strftime('%m/%d')
-    
-    def key(self):
-        return self.tet_seq
-    
-    def deleted(self):
-        return (self.deleted_yn == 'Y' or
-                self.show_yn == 'N' or
-                self.server == 'KR' or
-                self.rem_type in (RemType.pal, RemType.unknown1))
-    
-    def load(self, database: PgRawDatabase):
-        pass
-
-
-#         self.monster = database.getMonster(self.monster_no)
-
-
-# eggMonsterList
-#        {
-#            "DEL_YN": "Y",
-#            "MONSTER_NO": "120",
-#            "ORDER_IDX": "1",
-#            "TEM_SEQ": "1",
-#            "TET_SEQ": "1",
-#            "TSTAMP": "1405245537715"
-#        },
-class PgEggMonster(PgItem):
-    @staticmethod
-    def file_name():
-        return 'eggMonsterList'
-    
-    def __init__(self, item):
-        super().__init__()
-        self.deleted_yn = item['DEL_YN']
-        self.monster_no = int(item['MONSTER_NO'])
-        self.tem_seq = int(item['TEM_SEQ'])  # primary key
-        self.tet_seq = int(item['TET_SEQ'])  # fk to PgEggInstance
-    
-    def key(self):
-        return self.tem_seq
-    
-    def deleted(self):
-        return self.deleted_yn == 'Y' or self.monster_no == 0
-    
-    def load(self, database: PgRawDatabase):
-        self.monster = database.getMonster(self.monster_no)
-        self.egg_instance = database.getEggInstance(self.tet_seq)
-        if self.egg_instance:
-            # For KR stuff we clipped out
-            self.egg_instance.egg_monsters.append(self)
-
-
-# eggTitleNameList
-#        {
-#            "DEL_YN": "N",
-#            "LANGUAGE": "US",
-#            "NAME": "Batman Egg",
-#            "TETN_SEQ": "183",
-#            "TET_SEQ": "64",
-#            "TSTAMP": "1441589491425"
-#        },
-class PgEggName(PgItem):
-    @staticmethod
-    def file_name():
-        return 'eggTitleNameList'
-    
-    def __init__(self, item):
-        super().__init__()
-        self.name = item['NAME']
-        self.language = item['LANGUAGE']  # US, JP, KR
-        self.deleted_yn = item['DEL_YN']  # Y, N
-        self.tetn_seq = int(item['TETN_SEQ'])  # primary key
-        self.tet_seq = int(item['TET_SEQ'])  # fk to PgEggInstance
-    
-    def key(self):
-        return self.tetn_seq
-    
-    def deleted(self):
-        return self.deleted_yn == 'Y' or self.language != 'US'
-    
-    def load(self, database: PgRawDatabase):
-        self.egg_instance = database.getEggInstance(self.tet_seq)
-        if self.egg_instance:
-            # For KR stuff we clipped out
-            self.egg_instance.egg_name_us = self
-
-
-# ================================================================================
-# PadEvents items below
-# ================================================================================
-
-
-class EventType(Enum):
-    EventTypeWeek = 0
-    EventTypeSpecial = 1
-    EventTypeSpecialWeek = 2
-    EventTypeGuerrilla = 3
-    EventTypeGuerrillaNew = 4
-    EventTypeEtc = -100
-
-
-def normalizeServer(server):
-    server = server.upper()
-    return 'NA' if server == 'US' else server
-
-
-# {
-#     "CLOSE_DATE": "2017-09-01",
-#     "CLOSE_HOUR": "19",
-#     "CLOSE_MINUTE": "59",
-#     "CLOSE_WEEKDAY": "0",
-#     "DUNGEON_SEQ": "31",
-#     "EVENT_SEQ": "25",
-#     "EVENT_TYPE": "-100",
-#     "OPEN_DATE": "2017-09-01",
-#     "OPEN_HOUR": "08",
-#     "OPEN_MINUTE": "00",
-#     "OPEN_WEEKDAY": "0",
-#     "SCHEDULE_SEQ": "235217",
-#     "SERVER": "US",
-#     "SERVER_OPEN_DATE": "2017-09-01",
-#     "SERVER_OPEN_HOUR": "1",
-#     "TEAM_DATA": "0",
-#     "TSTAMP": "1504233623450",
-#     "URL": ""
-# },
-class PgScheduledEvent(PgItem):
-    @staticmethod
-    def file_name():
-        return 'scheduleList'
-    
-    def __init__(self, item):
-        super().__init__()
-        self.schedule_seq = int(item['SCHEDULE_SEQ'])
-        
-        self.open_timestamp = int(item['OPEN_TIMESTAMP'])
-        self.close_timestamp = int(item['CLOSE_TIMESTAMP'])
-        
-        self.dungeon_seq = int(item['DUNGEON_SEQ'])
-        self.event_seq = int(item['EVENT_SEQ'])
-        self.event_type = int(item['EVENT_TYPE'])
-        
-        self.server = normalizeServer(item['SERVER'])
-        
-        self.team_data = int_or_none(item['TEAM_DATA'])
-        self.url = item['URL']
-        
-        self.group = None
-        if self.team_data is not None:
-            if self.event_type == EventType.EventTypeGuerrilla.value:
-                self.group = chr(ord('a') + self.team_data).upper()
-            elif self.event_type == EventType.EventTypeSpecialWeek.value:
-                self.group = ['RED', 'BLUE', 'GREEN'][self.team_data]
-        
-        self.open_datetime = datetime.utcfromtimestamp(
-            self.open_timestamp).replace(tzinfo=pytz.UTC)
-        self.close_datetime = datetime.utcfromtimestamp(
-            self.close_timestamp).replace(tzinfo=pytz.UTC)
-    
-    def key(self):
-        return self.schedule_seq
-    
-    def deleted(self):
-        return self.server == 'KR'
-    
-    def load(self, database: PgRawDatabase):
-        self.dungeon = database.getDungeon(self.dungeon_seq)
-        self.event = database.getEvent(self.event_seq) if self.event_seq != '0' else None
-
-
-# {
-#     "EVENT_NAME_JP": "\u30b3\u30a4\u30f3 1.5\u500d!",
-#     "EVENT_NAME_KR": "\ucf54\uc778 1.5\ubc30!",
-#     "EVENT_NAME_US": "Coin x 1.5!",
-#     "EVENT_SEQ": "3",
-#     "TSTAMP": "1370174967128"
-# },
-class PgEvent(PgItem):
-    @staticmethod
-    def file_name():
-        return 'eventList'
-    
-    def __init__(self, item):
-        super().__init__()
-        self.event_seq = int(item['EVENT_SEQ'])
-        self.name = item['EVENT_NAME_US']
-    
-    def key(self):
-        return self.event_seq
-    
-    def load(self, database: PgRawDatabase):
-        pass
-
-
-def make_roma_subname(name_jp):
-    subname = name_jp.replace('＝', '')
-    adjusted_subname = ''
-    for part in subname.split('・'):
-        roma_part = romkan.to_roma(part)
-        if part != roma_part and not rpadutils.containsJp(roma_part):
-            adjusted_subname += ' ' + roma_part.strip('-')
-    return adjusted_subname.strip()
-
-
-def int_or_none(maybe_int: str):
-    return int(maybe_int) if maybe_int else None
-
-
-def float_or_none(maybe_float: str):
-    return float(maybe_float) if maybe_float else None
-
-
-def empty_index():
-    return MonsterIndex(PgRawDatabase(skip_load=True), {}, {})
-
-
-class MonsterIndex(object):
-    def __init__(self, monster_database, nickname_overrides, basename_overrides, accept_filter=None):
-        # Important not to hold onto anything except IDs here so we don't leak memory
-        monster_groups = monster_database.grouped_monsters
-        
-        self.attr_short_prefix_map = {
-            Attribute.Fire: ['r'],
-            Attribute.Water: ['b'],
-            Attribute.Wood: ['g'],
-            Attribute.Light: ['l'],
-            Attribute.Dark: ['d'],
-        }
-        self.attr_long_prefix_map = {
-            Attribute.Fire: ['red', 'fire'],
-            Attribute.Water: ['blue', 'water'],
-            Attribute.Wood: ['green', 'wood'],
-            Attribute.Light: ['light'],
-            Attribute.Dark: ['dark'],
-        }
-        
-        self.series_to_prefix_map = {
-            130: ['halloween', 'hw', 'h'],
-            136: ['xmas', 'christmas'],
-            125: ['summer', 'beach'],
-            114: ['school', 'academy', 'gakuen'],
-            139: ['new years', 'ny'],
-            149: ['wedding', 'bride'],
-            154: ['padr'],
-            175: ['valentines', 'vday'],
-        }
-        
-        monster_no_na_to_nicknames = defaultdict(set)
-        for nickname, monster_no_na in nickname_overrides.items():
-            monster_no_na_to_nicknames[monster_no_na].add(nickname)
-        
-        named_monsters = []
-        for mg in monster_groups:
-            group_basename_overrides = basename_overrides.get(mg.base_monster.monster_no_na, [])
-            named_mg = NamedMonsterGroup(mg, group_basename_overrides)
-            for monster in mg.members:
-                if accept_filter and not accept_filter(monster):
-                    continue
-                prefixes = self.compute_prefixes(monster, mg)
-                extra_nicknames = monster_no_na_to_nicknames[monster.monster_no_na]
-                named_monster = NamedMonster(monster, named_mg, prefixes, extra_nicknames)
-                named_monsters.append(named_monster)
-        
-        # Sort the NamedMonsters into the opposite order we want to accept their nicknames in
-        # This order is:
-        #  1) High priority first
-        #  2) Larger group sizes
-        #  3) Minimum ID size in the group
-        #  4) Monsters with higher ID values
-        def named_monsters_sort(nm: NamedMonster):
-            return (not nm.is_low_priority, nm.group_size, -1 *
-                    nm.base_monster_no_na, nm.monster_no_na)
-        
-        named_monsters.sort(key=named_monsters_sort)
-        
-        self.all_prefixes = set()
-        self.all_entries = {}
-        self.two_word_entries = {}
-        for nm in named_monsters:
-            self.all_prefixes.update(nm.prefixes)
-            for nickname in nm.final_nicknames:
-                self.all_entries[nickname] = nm
-            for nickname in nm.final_two_word_nicknames:
-                self.two_word_entries[nickname] = nm
-        
-        self.all_monsters = named_monsters
-        self.all_na_name_to_monsters = {m.name_na.lower(): m for m in named_monsters}
-        self.monster_no_na_to_named_monster = {m.monster_no_na: m for m in named_monsters}
-        self.monster_no_to_named_monster = {m.monster_no: m for m in named_monsters}
-        
-        for nickname, monster_no_na in nickname_overrides.items():
-            nm = self.monster_no_na_to_named_monster.get(monster_no_na)
-            if nm:
-                self.all_entries[nickname] = nm
-    
-    def init_index(self):
-        pass
-    
-    def compute_prefixes(self, m: PgMonster, mg: MonsterGroup):
-        prefixes = set()
-        
-        attr1_short_prefixes = self.attr_short_prefix_map[m.attr1]
-        attr1_long_prefixes = self.attr_long_prefix_map[m.attr1]
-        prefixes.update(attr1_short_prefixes)
-        prefixes.update(attr1_long_prefixes)
-        
-        # If no 2nd attribute, use x so we can look those monsters up easier
-        attr2_short_prefixes = self.attr_short_prefix_map.get(m.attr2, ['x'])
-        for a1 in attr1_short_prefixes:
-            for a2 in attr2_short_prefixes:
-                prefixes.add(a1 + a2)
-                prefixes.add(a1 + '/' + a2)
-        
-        # TODO: add prefixes based on type
-        
-        # Chibi monsters have the same NA name, except lowercased
-        if m.name_na != m.name_jp:
-            if m.name_na.lower() == m.name_na:
-                prefixes.add('chibi')
-        elif 'ミニ' in m.name_jp:
-            # Guarding this separately to prevent 'gemini' from triggering (e.g. 2645)
-            prefixes.add('chibi')
-        
-        lower_name = m.name_na.lower()
-        awoken = lower_name.startswith('awoken') or '覚醒' in lower_name
-        revo = lower_name.startswith('reincarnated') or '転生' in lower_name
-        mega = lower_name.startswith('mega woken') or '極醒' in lower_name
-        awoken_or_revo_or_equip_or_mega = awoken or revo or m.is_equip or mega
-        
-        # These clauses need to be separate to handle things like 'Awoken Thoth' which are
-        # actually Evos but have awoken in the name
-        if awoken:
-            prefixes.add('a')
-            prefixes.add('awoken')
-        
-        if revo:
-            prefixes.add('revo')
-            prefixes.add('reincarnated')
-        
-        if mega:
-            prefixes.add('mega')
-            prefixes.add('mega awoken')
-            prefixes.add('awoken')
-        
-        # Prefixes for evo type
-        if m.cur_evo_type == EvoType.Base:
-            prefixes.add('base')
-        elif m.cur_evo_type == EvoType.Evo:
-            prefixes.add('evo')
-        elif m.cur_evo_type == EvoType.UvoAwoken and not awoken_or_revo_or_equip_or_mega:
-            prefixes.add('uvo')
-            prefixes.add('uevo')
-        elif m.cur_evo_type == EvoType.UuvoReincarnated and not awoken_or_revo_or_equip_or_mega:
-            prefixes.add('uuvo')
-            prefixes.add('uuevo')
-        
-        # If any monster in the group is a pixel, add 'nonpixel' to all the versions
-        # without pixel in the name. Add 'pixel' as a prefix to the ones with pixel in the name.
-        def is_pixel(n):
-            n = n.name_na.lower()
-            return n.startswith('pixel') or n.startswith('ドット')
-        
-        for gm in mg.members:
-            if is_pixel(gm):
-                prefixes.update(['pixel'] if is_pixel(m) else ['np', 'nonpixel'])
-                break
-        
-        if m.is_equip:
-            prefixes.add('assist')
-            prefixes.add('equip')
-        
-        # Collab prefixes
-        prefixes.update(self.series_to_prefix_map.get(m.series.tsr_seq, []))
-        
-        return prefixes
-    
-    def find_monster(self, query):
-        query = rpadutils.rmdiacritics(query).lower().strip()
-        
-        # id search
-        if query.isdigit():
-            m = self.monster_no_na_to_named_monster.get(int(query))
-            if m is None:
-                return None, 'Looks like a monster ID but was not found', None
+            awakenings_row += ' {}'.format(mapped_awakening)
+    
+    awakenings_row = awakenings_row.strip()
+    
+    if not len(awakenings_row):
+        awakenings_row = 'No Awakenings'
+    
+    killers = compute_killers(m.type1, m.type2, m.type3)
+    killers_row = '**Available Killers:** {}'.format(' '.join(killers))
+    
+    embed.description = '{}\n{}'.format(awakenings_row, killers_row)
+    
+    if len(m.server_actives) >= 2:
+        for server, active in m.server_actives.items():
+            active_header = '({} Server) Active Skill ({} -> {})'.format(server,
+                                                                         active.turn_max, active.turn_min)
+            active_body = active.desc
+            embed.add_field(name=active_header, value=active_body, inline=False)
+    else:
+        active_header = 'Active Skill'
+        active_body = 'None/Missing'
+        if m.active_skill:
+            active_header = 'Active Skill ({} -> {})'.format(m.active_skill.turn_max,
+                                                             m.active_skill.turn_min)
+            active_body = m.active_skill.desc
+        embed.add_field(name=active_header, value=active_body, inline=False)
+    
+    ls_row = m.leader_skill.desc if m.leader_skill else 'None/Missing'
+    ls_header = 'Leader Skill'
+    if m.leader_skill_data:
+        hp, atk, rcv, resist = m.leader_skill_data.get_data()
+        multiplier_text = createMultiplierText(hp, atk, rcv, resist)
+        ls_header += " [ {} ]".format(multiplier_text)
+    embed.add_field(name=ls_header, value=ls_row, inline=False)
+    
+    return embed
+
+
+def monsterToOtherInfoEmbed(m: padguide2.PgMonster):
+    embed = monsterToBaseEmbed(m)
+    # Clear the thumbnail, takes up too much space
+    embed.set_thumbnail(url='')
+    
+    stat_cols = ['', 'Max', 'M297', 'Inh', 'I297']
+    tbl = prettytable.PrettyTable(stat_cols)
+    tbl.hrules = prettytable.NONE
+    tbl.vrules = prettytable.NONE
+    tbl.align = "r"
+    hhp = m.hp + 99 * 10
+    hatk = m.atk + 99 * 5
+    hrcv = m.rcv + 99 * 3
+    tbl.add_row(['HP', m.hp, hhp, int(m.hp * .1), int(hhp * .1)])
+    tbl.add_row(['ATK', m.atk, hatk, int(m.atk * .05), int(hatk * .05)])
+    tbl.add_row(['RCV', m.rcv, hrcv, int(m.rcv * .15), int(hrcv * .15)])
+    
+    body_text = box(tbl.get_string())
+    
+    search_text = YT_SEARCH_TEMPLATE.format(m.name_jp)
+    skyozora_text = SKYOZORA_TEMPLATE.format(m.monster_no_jp)
+    body_text += "\n**JP Name**: {} | [YouTube]({}) | [Skyozora]({})".format(
+        m.name_jp, search_text, skyozora_text)
+    
+    if m.history_us:
+        body_text += '\n**History:** {}'.format(m.history_us)
+    
+    body_text += '\n**Series:** {}'.format(m.series.name)
+    body_text += '\n**Sell MP:** {:,}'.format(m.sell_mp)
+    if m.buy_mp > 0:
+        body_text += "  **Buy MP:** {:,}".format(m.buy_mp)
+    
+    if m.exp < 1000000:
+        xp_text = '{:,}'.format(m.exp)
+    else:
+        xp_text = '{:.1f}'.format(m.exp / 1000000).rstrip('0').rstrip('.') + 'M'
+    body_text += '\n**XP to Max:** {}'.format(xp_text)
+    body_text += '  **Max Level:**: {}'.format(m.max_level)
+    body_text += '\n**Rarity:** {} **Cost:** {}'.format(m.rarity, m.cost)
+    
+    if m.translated_jp_name:
+        body_text += '\n**Google Translated:** {}'.format(m.translated_jp_name)
+    
+    embed.description = body_text
+    
+    return embed
+
+
+def monsters_to_rotation_list(monster_list, server: str, index_all: padguide2.MonsterIndex):
+    # Shorten some of the longer names
+    name_remap = {
+        'Extreme King Metal Tamadra': 'Fat Tama',
+        'Extreme King Metal Dragon': 'EKMD',
+        'Ancient Green Sacred Mask': 'Green Mask',
+        'Ancient Blue Sacred Mask': 'Blue Mask',
+    }
+    ignore_monsters = [
+        'Ancient Draggie Knight',
+    ]
+    
+    monster_list.sort(key=lambda m: m.monster_no, reverse=True)
+    next_rotation_date = None
+    for m in monster_list:
+        if server in m.future_skillup_rotation:
+            next_rotation_date = m.future_skillup_rotation[server].rotation_date_str
+            break
+    
+    cols = [server + ' Skillup', 'Current']
+    if next_rotation_date:
+        cols.append(next_rotation_date)
+    tbl = prettytable.PrettyTable(cols)
+    tbl.hrules = prettytable.HEADER
+    tbl.vrules = prettytable.NONE
+    tbl.align = "l"
+    
+    def cell_name(m: padguide2.PgMonster):
+        nm = index_all.monster_no_to_named_monster[m.monster_no]
+        name = nm.group_computed_basename.title()
+        return name_remap.get(name, name)
+    
+    for m in monster_list:
+        skill = m.server_actives[server]
+        
+        sm = skill.monsters_with_active
+        
+        # Since some newer monsters like jewel of creation are being used as
+        # skillups, exclude them from the list of skillup targets.
+        
+        def is_bad_type(m):
+            return set(['enhance', 'evolve', 'vendor']).intersection(set(m.types))
+        
+        sm = max(sm, key=lambda x: (not is_bad_type(x), x.monster_no))
+        
+        skillup_name = cell_name(m)
+        if skillup_name in ignore_monsters:
+            continue
+        row = [skillup_name, cell_name(sm)]
+        if next_rotation_date:
+            if server in m.future_skillup_rotation:
+                next_skill = m.future_skillup_rotation[server].skill
+                nm = max(next_skill.monsters_with_active, key=lambda x: x.monster_no)
+                row.append(cell_name(nm))
             else:
-                return m, None, "ID lookup"
-            # special handling for na/jp
-        
-        # TODO: need to handle na_only?
-        
-        # handle exact nickname match
-        if query in self.all_entries:
-            return self.all_entries[query], None, "Exact nickname"
-        
-        contains_jp = rpadutils.containsJp(query)
-        if len(query) < 2 and contains_jp:
-            return None, 'Japanese queries must be at least 2 characters', None
-        elif len(query) < 4 and not contains_jp:
-            return None, 'Your query must be at least 4 letters', None
-        
-        # TODO: this should be a length-limited priority queue
-        matches = set()
-        # prefix search for nicknames, space-preceeded, take max id
-        for nickname, m in self.all_entries.items():
-            if nickname.startswith(query + ' '):
-                matches.add(m)
-        if len(matches):
-            return self.pickBestMonster(matches), None, "Space nickname prefix, max of {}".format(len(matches))
-        
-        # prefix search for nicknames, take max id
-        for nickname, m in self.all_entries.items():
-            if nickname.startswith(query):
-                matches.add(m)
-        if len(matches):
-            all_names = ",".join(map(lambda x: x.name_na, matches))
-            return self.pickBestMonster(matches), None, "Nickname prefix, max of {}, matches=({})".format(len(matches),
-                                                                                                          all_names)
-        
-        # prefix search for full name, take max id
-        for nickname, m in self.all_entries.items():
-            if (m.name_na.lower().startswith(query) or m.name_jp.lower().startswith(query)):
-                matches.add(m)
-        if len(matches):
-            return self.pickBestMonster(matches), None, "Full name, max of {}".format(len(matches))
-        
-        # for nicknames with 2 names, prefix search 2nd word, take max id
-        if query in self.two_word_entries:
-            return self.two_word_entries[query], None, "Second-word nickname prefix, max of {}".format(len(matches))
-        
-        # TODO: refactor 2nd search characteristcs for 2nd word
-        
-        # full name contains on nickname, take max id
-        for nickname, m in self.all_entries.items():
-            if (query in m.name_na.lower() or query in m.name_jp.lower()):
-                matches.add(m)
-        if len(matches):
-            return self.pickBestMonster(matches), None, 'Full name match on nickname, max of {}'.format(len(matches))
-        
-        # full name contains on full monster list, take max id
-        
-        for m in self.all_monsters:
-            if (query in m.name_na.lower() or query in m.name_jp.lower()):
-                matches.add(m)
-        if len(matches):
-            return self.pickBestMonster(matches), None, 'Full name match on full list, max of {}'.format(len(matches))
-        
-        # No decent matches. Try near hits on nickname instead
-        matches = difflib.get_close_matches(query, self.all_entries.keys(), n=1, cutoff=.8)
-        if len(matches):
-            match = matches[0]
-            return self.all_entries[match], None, 'Close nickname match ({})'.format(match)
-        
-        # Still no decent matches. Try near hits on full name instead
-        matches = difflib.get_close_matches(
-            query, self.all_na_name_to_monsters.keys(), n=1, cutoff=.9)
-        if len(matches):
-            match = matches[0]
-            return self.all_na_name_to_monsters[match], None, 'Close name match ({})'.format(match)
-        
-        # couldn't find anything
-        return None, "Could not find a match for: " + query, None
+                row.append('')
+        tbl.add_row(row)
     
-    def find_monster2(self, query):
-        """Search with alternative method for resolving prefixes.
+    return tbl.get_string()
 
-        Implements the lookup for id2, where you are allowed to specify multiple prefixes for a card.
-        All prefixes are required to be exactly matched by the card.
-        Follows a similar logic to the regular id but after each check, will remove any potential match that doesn't
-        contain every single specified prefix.
-        """
-        query = rpadutils.rmdiacritics(query).lower().strip()
-        # id search
-        if query.isdigit():
-            m = self.monster_no_na_to_named_monster.get(int(query))
-            if m is None:
-                return None, 'Looks like a monster ID but was not found', None
-            else:
-                return m, None, "ID lookup"
-        
-        # handle exact nickname match
-        if query in self.all_entries:
-            return self.all_entries[query], None, "Exact nickname"
-        
-        contains_jp = rpadutils.containsJp(query)
-        if len(query) < 2 and contains_jp:
-            return None, 'Japanese queries must be at least 2 characters', None
-        elif len(query) < 4 and not contains_jp:
-            return None, 'Your query must be at least 4 letters', None
-        
-        # we want to look up only the main part of the query, and then verify that each result has the prefixes
-        # so break up the query into an array of prefixes, and a string (new_query) that will be the lookup
-        query_prefixes = []
-        parts_of_query = query.split()
-        new_query = ''
-        for i, part in enumerate(parts_of_query):
-            if part in self.all_prefixes:
-                query_prefixes.append(part)
-            else:
-                new_query = ' '.join(parts_of_query[i:])
-                break
-        
-        # if we don't actually have multiple prefixes, then default to using the regular id lookup
-        if len(query_prefixes) < 2:
-            return self.find_monster(query)
-        
-        matches = set()
-        
-        # first try to get matches from nicknames
-        for nickname, m in self.all_entries.items():
-            if new_query in nickname:
-                matches.add(m)
-        self.remove_potential_matches_without_all_prefixes(matches, query_prefixes)
-        
-        # if we don't have any candidates yet, pick a new method
-        if not len(matches):
-            # try matching on exact names next
-            for nickname, m in self.all_na_name_to_monsters.items():
-                if new_query in m.name_na.lower() or new_query in m.name_jp.lower():
-                    matches.add(m)
-            self.remove_potential_matches_without_all_prefixes(matches, query_prefixes)
-        
-        if len(matches):
-            return self.pickBestMonster(matches), None, None
-        return None, "Could not find a match for: " + query, None
+
+AWAKENING_NAME_MAP_RPAD = {
+    'Enhanced Attack': 'boost_atk',
+    'Enhanced HP': 'boost_hp',
+    'Enhanced Heal': 'boost_rcv',
     
-    # verify that potential matches do in fact have the prefixes that we want
-    def remove_potential_matches_without_all_prefixes(self, matches, query_prefixes):
-        to_remove = set()
-        for m in matches:
-            for prefix in query_prefixes:
-                if prefix not in m.prefixes:
-                    to_remove.add(m)
-                    break
-        matches.difference_update(to_remove)
+    'Enhanced Team HP': 'teamboost_hp',
+    'Enhanced Team Attack': 'teamboost_atk',
+    'Enhanced Team RCV': 'teamboost_rcv',
     
-    def pickBestMonster(self, named_monster_list):
-        return max(named_monster_list, key=lambda x: (not x.is_low_priority, x.rarity, x.monster_no_na))
-
-
-class NamedMonsterGroup(object):
-    def __init__(self, monster_group: MonsterGroup, basename_overrides: list):
-        self.is_low_priority = (
-                        self._is_low_priority_monster(monster_group.base_monster)
-                        or self._is_low_priority_group(monster_group))
-        
-        monsters = monster_group.members
-        self.group_size = len(monsters)
-        self.base_monster_no = monster_group.base_monster.monster_no
-        self.base_monster_no_na = monster_group.base_monster.monster_no_na
-        
-        self.monster_no_to_basename = {
-            m.monster_no: self._compute_monster_basename(m) for m in monsters
-        }
-        
-        self.computed_basename = self._compute_group_basename(monsters)
-        self.computed_basenames = set([self.computed_basename])
-        if '-' in self.computed_basename:
-            self.computed_basenames.add(self.computed_basename.replace('-', ' '))
-        
-        self.basenames = basename_overrides or self.computed_basenames
+    'God Killer': 'killer_god',
+    'Dragon Killer': 'killer_dragon',
+    'Devil Killer': 'killer_devil',
+    'Machine Killer': 'killer_machine',
+    'Balanced Killer': 'killer_balance',
+    'Attacker Killer': 'killer_attacker',
     
-    def _compute_monster_basename(self, m: PgMonster):
-        basename = m.name_na.lower()
-        if ',' in basename:
-            name_parts = basename.split(',')
-            if name_parts[1].strip().startswith('the '):
-                # handle names like 'xxx, the yyy' where xxx is the name
-                basename = name_parts[0]
-            else:
-                # otherwise, grab the chunk after the last comma
-                basename = name_parts[-1]
-        
-        for x in ['awoken', 'reincarnated']:
-            if basename.startswith(x):
-                basename = basename.replace(x, '')
-        
-        # Fix for DC collab garbage
-        basename = basename.replace('(comics)', '')
-        basename = basename.replace('(film)', '')
-        
-        return basename.strip()
+    'Physical Killer': 'killer_physical',
+    'Healer Killer': 'killer_healer',
+    'Evolve Material Killer': 'killer_evomat',
+    'Awaken Material Killer': 'killer_awoken',
+    'Enhance Material Killer': 'killer_enhancemat',
+    'Vendor Material Killer': 'killer_vendor',
     
-    def _compute_group_basename(self, monsters):
-        """Computes the basename for a group of monsters.
-
-        Prefer a basename with the largest count across the group. If all the
-        groups have equal size, prefer the lowest monster number basename.
-        This monster in general has better names, particularly when all the
-        names are unique, e.g. for male/female hunters."""
-        
-        def count_and_id(): return [0, 0]
-        
-        basename_to_info = defaultdict(count_and_id)
-        
-        for m in monsters:
-            basename = self.monster_no_to_basename[m.monster_no]
-            entry = basename_to_info[basename]
-            entry[0] += 1
-            entry[1] = max(entry[1], m.monster_no)
-        
-        entries = [[count_id[0], -1 * count_id[1], bn] for bn, count_id in basename_to_info.items()]
-        return max(entries)[2]
+    'Auto-Recover': 'misc_autoheal',
+    'Recover Bind': 'misc_bindclear',
+    'Enhanced Combo': 'misc_comboboost',
+    'Super Enhanced Combo': 'misc_super_comboboost',
+    'Guard Break': 'misc_guardbreak',
+    'Multi Boost': 'misc_multiboost',
+    'Additional Attack': 'misc_extraattack',
+    'Skill Boost': 'misc_sb',
+    'Extend Time': 'misc_te',
+    'Two-Pronged Attack': 'misc_tpa',
+    'Damage Void Shield Penetration': 'misc_voidshield',
+    'Awoken Assist': 'misc_assist',
     
-    def _is_low_priority_monster(self, m: PgMonster):
-        lp_types = ['evolve', 'enhance', 'protected', 'awoken', 'vendor']
-        lp_substrings = ['tamadra']
-        lp_min_rarity = 2
-        name = m.name_na.lower()
-        
-        failed_type = m.type1.lower() in lp_types
-        failed_ss = any([x in name for x in lp_substrings])
-        failed_rarity = m.rarity < lp_min_rarity
-        failed_chibi = name == m.name_na and m.name_na != m.name_jp
-        failed_equip = m.is_equip
-        return failed_type or failed_ss or failed_rarity or failed_chibi or failed_equip
+    'Enhanced Fire Orbs': 'oe_fire',
+    'Enhanced Water Orbs': 'oe_water',
+    'Enhanced Wood Orbs': 'oe_wood',
+    'Enhanced Light Orbs': 'oe_light',
+    'Enhanced Dark Orbs': 'oe_dark',
+    'Enhanced Heal Orbs': 'oe_heart',
     
-    def _is_low_priority_group(self, mg: MonsterGroup):
-        lp_grp_min_rarity = 5
-        max_rarity = max(m.rarity for m in mg.members)
-        failed_max_rarity = max_rarity < lp_grp_min_rarity
-        return failed_max_rarity
+    'Reduce Fire Damage': 'reduce_fire',
+    'Reduce Water Damage': 'reduce_water',
+    'Reduce Wood Damage': 'reduce_wood',
+    'Reduce Light Damage': 'reduce_light',
+    'Reduce Dark Damage': 'reduce_dark',
+    
+    'Resistance-Bind': 'res_bind',
+    'Resistance-Dark': 'res_blind',
+    'Resistance-Jammers': 'res_jammer',
+    'Resistance-Poison': 'res_poison',
+    'Resistance-Skill Bind': 'res_skillbind',
+    
+    'Enhanced Fire Att.': 'row_fire',
+    'Enhanced Water Att.': 'row_water',
+    'Enhanced Wood Att.': 'row_wood',
+    'Enhanced Light Att.': 'row_light',
+    'Enhanced Dark Att.': 'row_dark',
+    
+    'Skill Charge': 'misc_skillcharge',
+    'Super Additional Attack': 'misc_super_extraattack',
+    'Resistance-Bind＋': 'res_bind_super',
+    'Extend Time＋': 'misc_te_super',
+    'Resistance-Cloud': 'res_cloud',
+    'Resistance-Board Restrict': 'res_seal',
+    'Skill Boost＋': 'misc_sb_super',
+    'L-Shape Attack': 'l_attack',
+    'L-Shape Damage Reduction': 'l_shield',
+    'Enhance when HP is below 50%': 'attack_boost_low',
+    'Enhance when HP is above 80%': 'attack_boost_high',
+    'Combo Orb': 'orb_combo',
+    'Skill Voice': 'misc_voice',
+    'Dungeon Bonus': 'misc_dungeonbonus',
+}
+
+AWAKENING_NAME_MAP = {
+    'Enhanced Fire Orbs': 'R-OE',
+    'Enhanced Water Orbs': 'B-OE',
+    'Enhanced Wood Orbs': 'G-OE',
+    'Enhanced Light Orbs': 'L-OE',
+    'Enhanced Dark Orbs': 'D-OE',
+    'Enhanced Heal Orbs': 'H-OE',
+    
+    'Enhanced Fire Att.': 'R-RE',
+    'Enhanced Water Att.': 'B-RE',
+    'Enhanced Wood Att.': 'G-RE',
+    'Enhanced Light Att.': 'L-RE',
+    'Enhanced Dark Att.': 'D-RE',
+    
+    'Enhanced HP': 'HP',
+    'Enhanced Attack': 'ATK',
+    'Enhanced Heal': 'RCV',
+    
+    'Enhanced Team HP': 'TEAM-HP',
+    'Enhanced Team Attack': 'TEAM-ATK',
+    'Enhanced Team RCV': 'TEAM-RCV',
+    
+    'Auto-Recover': 'AUTO-RECOVER',
+    'Skill Boost': 'SB',
+    'Resistance-Skill Bind': 'SBR',
+    'Two-Pronged Attack': 'TPA',
+    'Multi Boost': 'MULTI-BOOST',
+    'Recover Bind': 'RCV-BIND',
+    'Extend Time': 'TE',
+    'Enhanced Combo': 'COMBO-BOOST',
+    'Guard Break': 'DEF-BREAK',
+    'Additional Attack': 'EXTRA-ATK',
+    'Damage Void Shield Penetration': 'VOID-BREAK',
+    'Awoken Assist': 'ASSIST',
+    
+    'Resistance-Bind': 'RES-BIND',
+    'Resistance-Dark': 'RES-BLIND',
+    'Resistance-Poison': 'RES-POISON',
+    'Resistance-Jammers': 'RES-JAMMER',
+    
+    'Reduce Fire Damage': 'R-RES',
+    'Reduce Water Damage': 'B-RES',
+    'Reduce Wood Damage': 'G-RES',
+    'Reduce Light Damage': 'L-RES',
+    'Reduce Dark Damage': 'D-RES',
+    
+    'Healer Killer': 'K-HEALER',
+    'Machine Killer': 'K-MACHINE',
+    'Dragon Killer': 'K-DRAGON',
+    'Attacker Killer': 'K-ATTACKER',
+    'Physical Killer': 'K-PHYSICAL',
+    'God Killer': 'K-GOD',
+    'Devil Killer': 'K-DEVIL',
+    'Balance Killer': 'K-BALANCE',
+}
 
 
-class NamedMonster(object):
-    def __init__(self, monster: PgMonster, monster_group: NamedMonsterGroup, prefixes: set, extra_nicknames: set):
-        # Must not hold onto monster or monster_group!
-        
-        # Hold on to the IDs instead
-        self.monster_no = monster.monster_no
-        self.monster_no_na = monster.monster_no_na
-        self.monster_no_jp = monster.monster_no_jp
-        
-        # ID of the root of the tree for this monster
-        self.base_monster_no = monster_group.base_monster_no
-        self.base_monster_no_na = monster_group.base_monster_no_na
-        
-        # This stuff is important for nickname generation
-        self.group_basenames = monster_group.basenames
-        self.prefixes = prefixes
-        
-        # Data used to determine how to rank the nicknames
-        self.is_low_priority = monster_group.is_low_priority or monster.is_equip
-        self.group_size = monster_group.group_size
-        self.rarity = monster.rarity
-        
-        # Used in fallback searches
-        self.name_na = monster.name_na
-        self.name_jp = monster.name_jp
-        
-        # These are just extra metadata
-        self.monster_basename = monster_group.monster_no_to_basename[self.monster_no]
-        self.group_computed_basename = monster_group.computed_basename
-        self.extra_nicknames = extra_nicknames
-        
-        # Compute any extra prefixes
-        if self.monster_basename in ('ana', 'ace'):
-            self.prefixes.add(self.monster_basename)
-        
-        # Compute extra basenames by checking for two-word basenames and using the second half
-        self.two_word_basenames = set()
-        for basename in self.group_basenames:
-            basename_words = basename.split(' ')
-            if len(basename_words) == 2:
-                self.two_word_basenames.add(basename_words[1])
-        
-        # The primary result nicknames
-        self.final_nicknames = set()
-        # Set the configured override nicknames
-        self.final_nicknames.update(self.extra_nicknames)
-        # Set the roma subname for JP monsters
-        if monster.roma_subname:
-            self.final_nicknames.add(monster.roma_subname)
-        
-        # For each basename, add nicknames
-        for basename in self.group_basenames:
-            # Add the basename directly
-            self.final_nicknames.add(basename)
-            # Add the prefix plus basename, and the prefix with a space between basename
-            for prefix in self.prefixes:
-                self.final_nicknames.add(prefix + basename)
-                self.final_nicknames.add(prefix + ' ' + basename)
-        
-        self.final_two_word_nicknames = set()
-        # Slightly different process for two-word basenames. Does this make sense? Who knows.
-        for basename in self.two_word_basenames:
-            self.final_two_word_nicknames.add(basename)
-            # Add the prefix plus basename, and the prefix with a space between basename
-            for prefix in self.prefixes:
-                self.final_two_word_nicknames.add(prefix + basename)
-                self.final_two_word_nicknames.add(prefix + ' ' + basename)
+def createMultiplierText(hp1, atk1, rcv1, resist1, hp2=None, atk2=None, rcv2=None, resist2=None):
+    hp2, atk2, rcv2, resist2 = hp2 or hp1, atk2 or atk1, rcv2 or rcv1, resist2 or resist1
+    
+    def fmtNum(val):
+        return ('{:.2f}').format(val).strip('0').rstrip('.')
+    
+    text = "{}/{}/{}".format(fmtNum(hp1 * hp2), fmtNum(atk1 * atk2), fmtNum(rcv1 * rcv2))
+    if resist1 * resist2 < 1:
+        resist1 = resist1 if resist1 < 1 else 0
+        resist2 = resist2 if resist2 < 1 else 0
+        text += ' Resist {}%'.format(fmtNum(100 * (1 - (1 - resist1) * (1 - resist2))))
+    return text
 
 
+def _map_awakenings_text(m: padguide2.PgMonster):
+    awakenings_row = ''
+    unique_awakenings = set(m.awakening_names)
+    for a in unique_awakenings:
+        count = m.awakening_names.count(a)
+        awakenings_row += ' {}x{}'.format(AWAKENING_NAME_MAP.get(a, a), count)
+    awakenings_row = awakenings_row.strip()
+    
+    if not len(awakenings_row):
+        awakenings_row = 'No Awakenings'
+    
+    return awakenings_row
+
+
+# TODO: move to padguide2
 def compute_killers(*types):
     if 'Balance' in types:
         return ['Any']

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -164,12 +164,22 @@ class PadInfo:
         await self._do_id(ctx, query)
 
     @commands.command(name="idna", pass_context=True)
-    async def _do_id_na(self, ctx, *, query: str):
+    async def _do_id_na_multiple_prefixes(self, ctx, *, query: str):
         """Monster info (limited to NA monsters ONLY)"""
         await self._do_id(ctx, query, na_only=True)
 
-    async def _do_id(self, ctx, query: str, na_only=False):
-        m, err, debug_info = self.findMonster(query, na_only=na_only)
+    @commands.command(name="id2", pass_context=True)
+    async def _do_id_all_multiple_prefixes(self, ctx, *, query: str):
+        """Monster info (main tab)"""
+        await self._do_id(ctx, query, multiple_prefixes=True)
+
+    @commands.command(name="idna2", pass_context=True)
+    async def _do_id_na(self, ctx, *, query: str):
+        """Monster info (limited to NA monsters ONLY)"""
+        await self._do_id(ctx, query, na_only=True, multiple_prefixes=True)
+    
+    async def _do_id(self, ctx, query: str, na_only=False, multiple_prefixes=False):
+        m, err, debug_info = self.findMonster(query, na_only=na_only, multiple_prefixes=multiple_prefixes)
         if m is not None:
             await self._do_idmenu(ctx, m, self.id_emoji)
         else:
@@ -410,9 +420,9 @@ class PadInfo:
         msg += 'Try one of <id>, <name>, [argbld]/[rgbld] <name>. Unexpected results? Use ^helpid for more info.'
         return box(msg)
 
-    def findMonster(self, query, na_only=False):
+    def findMonster(self, query, na_only=False, multiple_prefixes=False):
         query = rmdiacritics(query)
-        nm, err, debug_info = self._findMonster(query, na_only)
+        nm, err, debug_info = self._findMonster(query, na_only, multiple_prefixes)
 
         monster_no = nm.monster_no if nm else -1
         self.historic_lookups[query] = monster_no
@@ -422,9 +432,12 @@ class PadInfo:
 
         return m, err, debug_info
 
-    def _findMonster(self, query, na_only=False):
+    def _findMonster(self, query, na_only=False, multiple_prefixes=False):
         monster_index = self.index_na if na_only else self.index_all
-        return monster_index.find_monster(query)
+        if multiple_prefixes:
+            return monster_index.find_monster_multiple_prefixes(query)
+        else:
+            return monster_index.find_monster(query)
 
     def map_awakenings_text(self, m):
         """Exported for use in other cogs"""

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -23,7 +23,6 @@ from .utils import checks
 from .utils.chat_formatting import *
 from .utils.dataIO import dataIO
 
-
 HELP_MSG = """
 ^helpid : shows this message
 ^id <query> : look up a monster and print a link to puzzledragonx
@@ -46,7 +45,6 @@ submit an override suggestion: https://docs.google.com/forms/d/1kJH9Q0S8iqqULwrR
 
 EMBED_NOT_GENERATED = -1
 
-
 INFO_PDX_TEMPLATE = 'http://www.puzzledragonx.com/en/monster.asp?n={}'
 RPAD_PIC_TEMPLATE = 'https://f002.backblazeb2.com/file/miru-data/padimages/{}/full/{}.png'
 RPAD_PORTRAIT_TEMPLATE = 'https://f002.backblazeb2.com/file/miru-data/padimages/{}/portrait/{}.png'
@@ -58,1081 +56,1094 @@ SKYOZORA_TEMPLATE = 'http://pad.skyozora.com/pets/{}'
 
 
 def get_pdx_url(m):
-    return INFO_PDX_TEMPLATE.format(rpadutils.get_pdx_id(m))
+	return INFO_PDX_TEMPLATE.format(rpadutils.get_pdx_id(m))
 
 
 def get_portrait_url(m):
-    if int(m.monster_no) != m.monster_no_na:
-        return RPAD_PORTRAIT_TEMPLATE.format('na', m.monster_no_na)
-    else:
-        return RPAD_PORTRAIT_TEMPLATE.format('jp', m.monster_no_jp)
+	if int(m.monster_no) != m.monster_no_na:
+		return RPAD_PORTRAIT_TEMPLATE.format('na', m.monster_no_na)
+	else:
+		return RPAD_PORTRAIT_TEMPLATE.format('jp', m.monster_no_jp)
 
 
 def get_pic_url(m):
-    if int(m.monster_no) != m.monster_no_na:
-        return RPAD_PIC_TEMPLATE.format('na', m.monster_no_na)
-    else:
-        return RPAD_PIC_TEMPLATE.format('jp', m.monster_no_jp)
+	if int(m.monster_no) != m.monster_no_na:
+		return RPAD_PIC_TEMPLATE.format('na', m.monster_no_na)
+	else:
+		return RPAD_PIC_TEMPLATE.format('jp', m.monster_no_jp)
 
 
 class PadInfo:
-    def __init__(self, bot):
-        self.bot = bot
+	def __init__(self, bot):
+		self.bot = bot
+		
+		self.settings = PadInfoSettings("padinfo")
+		
+		self.index_all = padguide2.empty_index()
+		self.index_na = padguide2.empty_index()
+		
+		self.menu = Menu(bot)
+		
+		# These emojis are the keys into the idmenu submenus
+		self.id_emoji = '\N{INFORMATION SOURCE}'
+		self.evo_emoji = char_to_emoji('e')
+		self.mats_emoji = char_to_emoji('m')
+		self.ls_emoji = '\N{INFORMATION SOURCE}'
+		self.left_emoji = char_to_emoji('l')
+		self.right_emoji = char_to_emoji('r')
+		self.pantheon_emoji = '\N{CLASSICAL BUILDING}'
+		self.skillups_emoji = '\N{MEAT ON BONE}'
+		self.pic_emoji = '\N{FRAME WITH PICTURE}'
+		self.other_info_emoji = '\N{SCROLL}'
+		
+		self.historic_lookups_file_path = "data/padinfo/historic_lookups.json"
+		self.historic_lookups_file_path_id2 = "data/padinfo/historic_lookups_id2.json"
+  
+		if not dataIO.is_valid_json(self.historic_lookups_file_path):
+			print("Creating empty historic_lookups.json...")
+			dataIO.save_json(self.historic_lookups_file_path, {})
 
-        self.settings = PadInfoSettings("padinfo")
+		if not dataIO.is_valid_json(self.historic_lookups_file_path_id2):
+			print("Creating empty historic_lookups_id2.json...")
+			dataIO.save_json(self.historic_lookups_file_path_id2, {})
 
-        self.index_all = padguide2.empty_index()
-        self.index_na = padguide2.empty_index()
-
-        self.menu = Menu(bot)
-
-        # These emojis are the keys into the idmenu submenus
-        self.id_emoji = '\N{INFORMATION SOURCE}'
-        self.evo_emoji = char_to_emoji('e')
-        self.mats_emoji = char_to_emoji('m')
-        self.ls_emoji = '\N{INFORMATION SOURCE}'
-        self.left_emoji = char_to_emoji('l')
-        self.right_emoji = char_to_emoji('r')
-        self.pantheon_emoji = '\N{CLASSICAL BUILDING}'
-        self.skillups_emoji = '\N{MEAT ON BONE}'
-        self.pic_emoji = '\N{FRAME WITH PICTURE}'
-        self.other_info_emoji = '\N{SCROLL}'
-
-        self.historic_lookups_file_path = "data/padinfo/historic_lookups.json"
-        if not dataIO.is_valid_json(self.historic_lookups_file_path):
-            print("Creating empty historic_lookups.json...")
-            dataIO.save_json(self.historic_lookups_file_path, {})
-
-        self.historic_lookups = dataIO.load_json(self.historic_lookups_file_path)
-
-    def __unload(self):
-        # Manually nulling out database because the GC for cogs seems to be pretty shitty
-        self.index_all = padguide2.empty_index()
-        self.index_na = padguide2.empty_index()
-        self.historic_lookups = {}
-
-    async def reload_nicknames(self):
-        await self.bot.wait_until_ready()
-        while self == self.bot.get_cog('PadInfo'):
-            try:
-                await self.refresh_index()
-                print('Done refreshing PadInfo')
-            except Exception as ex:
-                print("reload padinfo loop caught exception " + str(ex))
-                traceback.print_exc()
-
-            await asyncio.sleep(60 * 60 * 1)
-
-    async def refresh_index(self):
-        """Refresh the monster indexes."""
-        pg_cog = self.bot.get_cog('PadGuide2')
-        await pg_cog.wait_until_ready()
-        self.index_all = pg_cog.create_index()
-        self.index_na = pg_cog.create_index(lambda m: m.on_na)
-
-    def get_monster_by_no(self, monster_no: int):
-        pg_cog = self.bot.get_cog('PadGuide2')
-        return pg_cog.get_monster_by_no(monster_no)
-
-    @commands.command(pass_context=True)
-    async def skillrotation(self, ctx, server: str='NA'):
-        """Print the current rotating skillups for a server (NA/JP)"""
-        server = normalizeServer(server)
-        if server not in ['NA', 'JP']:
-            await self.bot.say(inline('Supported servers are NA, JP'))
-            return
-
-        pg_cog = self.bot.get_cog('PadGuide2')
-        monsters = pg_cog.database.rotating_skillups(server)
-
-        for page in pagify(monsters_to_rotation_list(monsters, server, self.index_all)):
-            await self.bot.say(box(page))
-
-    @commands.command(pass_context=True)
-    async def jpname(self, ctx, *, query: str):
-        """Print the Japanese name of a monster"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self.bot.say(monsterToHeader(m))
-            await self.bot.say(box(m.name_jp))
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-
-    @commands.command(name="id", pass_context=True)
-    async def _do_id_all(self, ctx, *, query: str):
-        """Monster info (main tab)"""
-        await self._do_id(ctx, query)
-
-    @commands.command(name="idna", pass_context=True)
-    async def _do_id_na_multiple_prefixes(self, ctx, *, query: str):
-        """Monster info (limited to NA monsters ONLY)"""
-        await self._do_id(ctx, query, na_only=True)
-
-    async def _do_id(self, ctx, query: str, na_only=False):
-        m, err, debug_info = self.findMonster(query, na_only=na_only)
-        if m is not None:
-            await self._do_idmenu(ctx, m, self.id_emoji)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-    
-    @commands.command(name="id2", pass_context=True)
-    async def _do_id_all_2(self, ctx, *, query: str):
-        """Monster info (main tab)"""
-        await self._do_id2(ctx, query)
-
-    @commands.command(name="idna2", pass_context=True)
-    async def _do_id_na(self, ctx, *, query: str):
-        """Monster info (limited to NA monsters ONLY)"""
-        await self._do_id2(ctx, query, na_only=True)
-    
-    async def _do_id2(self, ctx, query: str, na_only=False):
-        m, err, debug_info = self.findMonster2(query, na_only=na_only)
-        if m is not None:
-            await self._do_idmenu(ctx, m, self.id_emoji)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-
-    @commands.command(name="evos", pass_context=True)
-    async def evos(self, ctx, *, query: str):
-        """Monster info (evolutions tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self._do_idmenu(ctx, m, self.evo_emoji)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-
-    @commands.command(name="mats", pass_context=True, aliases=['evomats', 'evomat'])
-    async def evomats(self, ctx, *, query: str):
-        """Monster info (evo materials tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self._do_idmenu(ctx, m, self.mats_emoji)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-
-    @commands.command(pass_context=True)
-    async def pantheon(self, ctx, *, query: str):
-        """Monster info (pantheon tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            menu = await self._do_idmenu(ctx, m, self.pantheon_emoji)
-            if menu == EMBED_NOT_GENERATED:
-                await self.bot.say(inline('Not a pantheon monster'))
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-
-    @commands.command(pass_context=True)
-    async def skillups(self, ctx, *, query: str):
-        """Monster info (evolutions tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            menu = await self._do_idmenu(ctx, m, self.skillups_emoji)
-            if menu == EMBED_NOT_GENERATED:
-                await self.bot.say(inline('No skillups available'))
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-
-    async def _do_idmenu(self, ctx, m, starting_menu_emoji):
-        id_embed = monsterToEmbed(m, self.get_emojis())
-        evo_embed = monsterToEvoEmbed(m)
-        mats_embed = monsterToEvoMatsEmbed(m)
-        animated = self.check_monster_animated(m.monster_no_jp)
-        pic_embed = monsterToPicEmbed(m, animated=animated)
-        other_info_embed = monsterToOtherInfoEmbed(m)
-
-        emoji_to_embed = OrderedDict()
-        emoji_to_embed[self.id_emoji] = id_embed
-        emoji_to_embed[self.evo_emoji] = evo_embed
-        emoji_to_embed[self.mats_emoji] = mats_embed
-        emoji_to_embed[self.pic_emoji] = pic_embed
-
-        pantheon_embed = monsterToPantheonEmbed(m)
-        if pantheon_embed:
-            emoji_to_embed[self.pantheon_emoji] = pantheon_embed
-
-        skillups_embed = monsterToSkillupsEmbed(m)
-        if skillups_embed:
-            emoji_to_embed[self.skillups_emoji] = skillups_embed
-
-        emoji_to_embed[self.other_info_emoji] = other_info_embed
-
-        return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed)
-
-    async def _do_evolistmenu(self, ctx, sm):
-        monsters = sm.alt_evos
-        monsters.sort(key=lambda m: m.monster_no)
-
-        emoji_to_embed = OrderedDict()
-        for idx, m in enumerate(monsters):
-            emoji = char_to_emoji(str(idx))
-            emoji_to_embed[emoji] = monsterToEmbed(m, self.get_emojis())
-            if m == sm:
-                starting_menu_emoji = emoji
-
-        return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed, timeout=60)
-
-    async def _do_menu(self, ctx, starting_menu_emoji, emoji_to_embed, timeout=30):
-        if starting_menu_emoji not in emoji_to_embed:
-            # Selected menu wasn't generated for this monster
-            return EMBED_NOT_GENERATED
-
-        remove_emoji = self.menu.emoji['no']
-        emoji_to_embed[remove_emoji] = self.menu.reaction_delete_message
-
-        try:
-            result_msg, result_embed = await self.menu.custom_menu(ctx, emoji_to_embed, starting_menu_emoji, timeout=timeout)
-            if result_msg and result_embed:
-                # Message is finished but not deleted, clear the footer
-                result_embed.set_footer(text=discord.Embed.Empty)
-                await self.bot.edit_message(result_msg, embed=result_embed)
-        except Exception as ex:
-            print('Menu failure', ex)
-
-    @commands.command(pass_context=True, aliases=['img'])
-    async def pic(self, ctx, *, query: str):
-        """Monster info (full image tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self._do_idmenu(ctx, m, self.pic_emoji)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-
-    @commands.command(pass_context=True, aliases=['stats'])
-    async def otherinfo(self, ctx, *, query: str):
-        """Monster info (misc info tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self._do_idmenu(ctx, m, self.other_info_emoji)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-
-    @commands.command(pass_context=True)
-    async def lookup(self, ctx, *, query: str):
-        """Short info results for a monster query"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            embed = monsterToHeaderEmbed(m)
-            await self.bot.say(embed=embed)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-
-    @commands.command(pass_context=True)
-    async def evolist(self, ctx, *, query):
-        """Monster info (for all monsters in the evo tree)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self._do_evolistmenu(ctx, m)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-
-    @commands.command(pass_context=True, aliases=['leaders', 'leaderskills', 'ls'])
-    async def leaderskill(self, ctx, left_query: str, right_query: str=None, *, bad=None):
-        """Display the multiplier and leaderskills for two monsters
+		self.historic_lookups = dataIO.load_json(self.historic_lookups_file_path)
+		self.historic_lookups_id2 = dataIO.load_json(self.historic_lookups_file_path_id2)
+	
+	def __unload(self):
+		# Manually nulling out database because the GC for cogs seems to be pretty shitty
+		self.index_all = padguide2.empty_index()
+		self.index_na = padguide2.empty_index()
+		self.historic_lookups = {}
+		self.historic_lookups_id2 = {}
+	
+	async def reload_nicknames(self):
+		await self.bot.wait_until_ready()
+		while self == self.bot.get_cog('PadInfo'):
+			try:
+				await self.refresh_index()
+				print('Done refreshing PadInfo')
+			except Exception as ex:
+				print("reload padinfo loop caught exception " + str(ex))
+				traceback.print_exc()
+			
+			await asyncio.sleep(60 * 60 * 1)
+	
+	async def refresh_index(self):
+		"""Refresh the monster indexes."""
+		pg_cog = self.bot.get_cog('PadGuide2')
+		await pg_cog.wait_until_ready()
+		self.index_all = pg_cog.create_index()
+		self.index_na = pg_cog.create_index(lambda m: m.on_na)
+	
+	def get_monster_by_no(self, monster_no: int):
+		pg_cog = self.bot.get_cog('PadGuide2')
+		return pg_cog.get_monster_by_no(monster_no)
+	
+	@commands.command(pass_context=True)
+	async def skillrotation(self, ctx, server: str = 'NA'):
+		"""Print the current rotating skillups for a server (NA/JP)"""
+		server = normalizeServer(server)
+		if server not in ['NA', 'JP']:
+			await self.bot.say(inline('Supported servers are NA, JP'))
+			return
+		
+		pg_cog = self.bot.get_cog('PadGuide2')
+		monsters = pg_cog.database.rotating_skillups(server)
+		
+		for page in pagify(monsters_to_rotation_list(monsters, server, self.index_all)):
+			await self.bot.say(box(page))
+	
+	@commands.command(pass_context=True)
+	async def jpname(self, ctx, *, query: str):
+		"""Print the Japanese name of a monster"""
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			await self.bot.say(monsterToHeader(m))
+			await self.bot.say(box(m.name_jp))
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(name="id", pass_context=True)
+	async def _do_id_all(self, ctx, *, query: str):
+		"""Monster info (main tab)"""
+		await self._do_id(ctx, query)
+	
+	@commands.command(name="idna", pass_context=True)
+	async def _do_id_na(self, ctx, *, query: str):
+		"""Monster info (limited to NA monsters ONLY)"""
+		await self._do_id(ctx, query, na_only=True)
+	
+	async def _do_id(self, ctx, query: str, na_only=False):
+		m, err, debug_info = self.findMonster(query, na_only=na_only)
+		if m is not None:
+			await self._do_idmenu(ctx, m, self.id_emoji)
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(name="id2", pass_context=True)
+	async def _do_id2_all(self, ctx, *, query: str):
+		"""Monster info (main tab)"""
+		await self._do_id2(ctx, query)
+	
+	@commands.command(name="id2na", pass_context=True)
+	async def _do_id2_na(self, ctx, *, query: str):
+		"""Monster info (limited to NA monsters ONLY)"""
+		await self._do_id2(ctx, query, na_only=True)
+	
+	async def _do_id2(self, ctx, query: str, na_only=False):
+		m, err, debug_info = self.findMonster2(query, na_only=na_only)
+		if m is not None:
+			await self._do_idmenu(ctx, m, self.id_emoji)
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(name="evos", pass_context=True)
+	async def evos(self, ctx, *, query: str):
+		"""Monster info (evolutions tab)"""
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			await self._do_idmenu(ctx, m, self.evo_emoji)
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(name="mats", pass_context=True, aliases=['evomats', 'evomat'])
+	async def evomats(self, ctx, *, query: str):
+		"""Monster info (evo materials tab)"""
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			await self._do_idmenu(ctx, m, self.mats_emoji)
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(pass_context=True)
+	async def pantheon(self, ctx, *, query: str):
+		"""Monster info (pantheon tab)"""
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			menu = await self._do_idmenu(ctx, m, self.pantheon_emoji)
+			if menu == EMBED_NOT_GENERATED:
+				await self.bot.say(inline('Not a pantheon monster'))
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(pass_context=True)
+	async def skillups(self, ctx, *, query: str):
+		"""Monster info (evolutions tab)"""
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			menu = await self._do_idmenu(ctx, m, self.skillups_emoji)
+			if menu == EMBED_NOT_GENERATED:
+				await self.bot.say(inline('No skillups available'))
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	async def _do_idmenu(self, ctx, m, starting_menu_emoji):
+		id_embed = monsterToEmbed(m, self.get_emojis())
+		evo_embed = monsterToEvoEmbed(m)
+		mats_embed = monsterToEvoMatsEmbed(m)
+		animated = self.check_monster_animated(m.monster_no_jp)
+		pic_embed = monsterToPicEmbed(m, animated=animated)
+		other_info_embed = monsterToOtherInfoEmbed(m)
+		
+		emoji_to_embed = OrderedDict()
+		emoji_to_embed[self.id_emoji] = id_embed
+		emoji_to_embed[self.evo_emoji] = evo_embed
+		emoji_to_embed[self.mats_emoji] = mats_embed
+		emoji_to_embed[self.pic_emoji] = pic_embed
+		
+		pantheon_embed = monsterToPantheonEmbed(m)
+		if pantheon_embed:
+			emoji_to_embed[self.pantheon_emoji] = pantheon_embed
+		
+		skillups_embed = monsterToSkillupsEmbed(m)
+		if skillups_embed:
+			emoji_to_embed[self.skillups_emoji] = skillups_embed
+		
+		emoji_to_embed[self.other_info_emoji] = other_info_embed
+		
+		return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed)
+	
+	async def _do_evolistmenu(self, ctx, sm):
+		monsters = sm.alt_evos
+		monsters.sort(key=lambda m: m.monster_no)
+		
+		emoji_to_embed = OrderedDict()
+		for idx, m in enumerate(monsters):
+			emoji = char_to_emoji(str(idx))
+			emoji_to_embed[emoji] = monsterToEmbed(m, self.get_emojis())
+			if m == sm:
+				starting_menu_emoji = emoji
+		
+		return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed, timeout=60)
+	
+	async def _do_menu(self, ctx, starting_menu_emoji, emoji_to_embed, timeout=30):
+		if starting_menu_emoji not in emoji_to_embed:
+			# Selected menu wasn't generated for this monster
+			return EMBED_NOT_GENERATED
+		
+		remove_emoji = self.menu.emoji['no']
+		emoji_to_embed[remove_emoji] = self.menu.reaction_delete_message
+		
+		try:
+			result_msg, result_embed = await self.menu.custom_menu(ctx, emoji_to_embed, starting_menu_emoji,
+																   timeout=timeout)
+			if result_msg and result_embed:
+				# Message is finished but not deleted, clear the footer
+				result_embed.set_footer(text=discord.Embed.Empty)
+				await self.bot.edit_message(result_msg, embed=result_embed)
+		except Exception as ex:
+			print('Menu failure', ex)
+	
+	@commands.command(pass_context=True, aliases=['img'])
+	async def pic(self, ctx, *, query: str):
+		"""Monster info (full image tab)"""
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			await self._do_idmenu(ctx, m, self.pic_emoji)
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(pass_context=True, aliases=['stats'])
+	async def otherinfo(self, ctx, *, query: str):
+		"""Monster info (misc info tab)"""
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			await self._do_idmenu(ctx, m, self.other_info_emoji)
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(pass_context=True)
+	async def lookup(self, ctx, *, query: str):
+		"""Short info results for a monster query"""
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			embed = monsterToHeaderEmbed(m)
+			await self.bot.say(embed=embed)
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(pass_context=True)
+	async def evolist(self, ctx, *, query):
+		"""Monster info (for all monsters in the evo tree)"""
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			await self._do_evolistmenu(ctx, m)
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.command(pass_context=True, aliases=['leaders', 'leaderskills', 'ls'])
+	async def leaderskill(self, ctx, left_query: str, right_query: str = None, *, bad=None):
+		"""Display the multiplier and leaderskills for two monsters
 
         If either your left or right query contains spaces, wrap in quotes.
         e.g.: ^leaderskill "r sonia" "b sonia"
         """
-        if bad:
-            await self.bot.say(inline('Too many inputs. Try wrapping your queries in quotes.'))
-            return
-
-        # Handle a very specific failure case, user typing something like "uuvo ragdra"
-        if ' ' not in left_query and right_query is not None and ' ' not in right_query and bad is None:
-            combined_query = left_query + ' ' + right_query
-            nm, err, debug_info = self._findMonster(combined_query)
-            if nm and left_query in nm.prefixes:
-                left_query = combined_query
-                right_query = None
-
-        left_m, left_err, _ = self.findMonster(left_query)
-        if right_query:
-            right_m, right_err, _ = self.findMonster(right_query)
-        else:
-            right_m, right_err, = left_m, left_err
-
-        err_msg = '{} query failed to match a monster: [ {} ]. If your query is multiple words, wrap it in quotes.'
-        if left_err:
-            await self.bot.say(inline(err_msg.format('Left', left_query)))
-            return
-        if right_err:
-            await self.bot.say(inline(err_msg.format('Right', right_query)))
-            return
-
-        emoji_to_embed = OrderedDict()
-        emoji_to_embed[self.ls_emoji] = monstersToLsEmbed(left_m, right_m)
-        emoji_to_embed[self.left_emoji] = monsterToEmbed(left_m, self.get_emojis())
-        emoji_to_embed[self.right_emoji] = monsterToEmbed(right_m, self.get_emojis())
-
-        await self._do_menu(ctx, self.ls_emoji, emoji_to_embed)
-
-    @commands.command(name="helpid", pass_context=True, aliases=['helppic', 'helpimg'])
-    async def _helpid(self, ctx):
-        """Whispers you info on how to craft monster queries for ^id"""
-        await self.bot.whisper(box(HELP_MSG))
-
-    @commands.command(pass_context=True)
-    async def padsay(self, ctx, server, *, query: str=None):
-        """Speak the voice line of a monster into your current chat"""
-        voice = ctx.message.author.voice
-        channel = voice.voice_channel
-        if channel is None:
-            await self.bot.say(inline('You must be in a voice channel to use this command'))
-            return
-
-        speech_cog = self.bot.get_cog('Speech')
-        if not speech_cog:
-            await self.bot.say(inline('Speech seems to be offline'))
-            return
-
-        if server.lower() not in ['na', 'jp']:
-            query = server + ' ' + (query or '')
-            server = 'na'
-        query = query.strip().lower()
-
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            base_dir = '/home/tactical0retreat/pad_data/voices/fixed'
-            voice_file = os.path.join(base_dir, server, '{}.wav'.format(m.monster_no_na))
-            header = '{} ({})'.format(monsterToHeader(m), server)
-            if not os.path.exists(voice_file):
-                await self.bot.say(inline('Could not find voice for ' + header))
-                return
-            await self.bot.say('Speaking for ' + header)
-            await speech_cog.play_path(channel, voice_file)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-
-    @commands.group(pass_context=True)
-    @checks.is_owner()
-    async def padinfo(self, ctx):
-        """PAD info management"""
-        if ctx.invoked_subcommand is None:
-            await send_cmd_help(ctx)
-
-    @padinfo.command(pass_context=True)
-    @checks.is_owner()
-    async def setemojiservers(self, ctx, *, emoji_servers=''):
-        """Set the emoji servers by ID (csv)"""
-        self.settings.emojiServers().clear()
-        if emoji_servers:
-            self.settings.setEmojiServers(emoji_servers.split(','))
-        await self.bot.say(inline('Set {} servers'.format(len(self.settings.emojiServers()))))
-
-    def get_emojis(self):
-        server_ids = self.settings.emojiServers()
-        return [e for s in self.bot.servers if s.id in server_ids for e in s.emojis]
-
-    def makeFailureMsg(self, err):
-        msg = 'Lookup failed: {}.\n'.format(err)
-        msg += 'Try one of <id>, <name>, [argbld]/[rgbld] <name>. Unexpected results? Use ^helpid for more info.'
-        return box(msg)
-
-    def findMonster(self, query, na_only=False, multiple_prefixes=False):
-        query = rmdiacritics(query)
-        nm, err, debug_info = self._findMonster(query, na_only)
-
-        monster_no = nm.monster_no if nm else -1
-        self.historic_lookups[query] = monster_no
-        dataIO.save_json(self.historic_lookups_file_path, self.historic_lookups)
-
-        m = self.get_monster_by_no(nm.monster_no) if nm else None
-
-        return m, err, debug_info
-
-    def _findMonster(self, query, na_only=False):
-        monster_index = self.index_na if na_only else self.index_all
-        return monster_index.find_monster(query)
-        
-    def findMonster2(self, query, na_only=False):
-        query = rmdiacritics(query)
-        nm, err, debug_info = self._findMonster2(query, na_only)
-
-        monster_no = nm.monster_no if nm else -1
-        self.historic_lookups[query] = monster_no
-        dataIO.save_json(self.historic_lookups_file_path, self.historic_lookups)
-
-        m = self.get_monster_by_no(nm.monster_no) if nm else None
-
-        return m, err, debug_info
-
-    def _findMonster2(self, query, na_only=False):
-        monster_index = self.index_na if na_only else self.index_all
-        return monster_index.find_monster_multiple_prefixes(query)
-
-
-    def map_awakenings_text(self, m):
-        """Exported for use in other cogs"""
-        return _map_awakenings_text(m)
-
-    @padinfo.command(pass_context=True)
-    @checks.is_owner()
-    async def setanimationdir(self, ctx, *, animation_dir=''):
-        """Set a directory containing animated images"""
-        self.settings.setAnimationDir(animation_dir)
-        await self.bot.say(inline('Done'))
-
-    def check_monster_animated(self, monster_id: int):
-        if not self.settings.animationDir():
-            return False
-
-        try:
-            animated_ids = set()
-            for f in os.listdir(self.settings.animationDir()):
-                f = f.replace('.mp4', '')
-                if f.isdigit() and int(f) == monster_id:
-                    return True
-        except:
-            pass
-
-        return False
+		if bad:
+			await self.bot.say(inline('Too many inputs. Try wrapping your queries in quotes.'))
+			return
+		
+		# Handle a very specific failure case, user typing something like "uuvo ragdra"
+		if ' ' not in left_query and right_query is not None and ' ' not in right_query and bad is None:
+			combined_query = left_query + ' ' + right_query
+			nm, err, debug_info = self._findMonster(combined_query)
+			if nm and left_query in nm.prefixes:
+				left_query = combined_query
+				right_query = None
+		
+		left_m, left_err, _ = self.findMonster(left_query)
+		if right_query:
+			right_m, right_err, _ = self.findMonster(right_query)
+		else:
+			right_m, right_err, = left_m, left_err
+		
+		err_msg = '{} query failed to match a monster: [ {} ]. If your query is multiple words, wrap it in quotes.'
+		if left_err:
+			await self.bot.say(inline(err_msg.format('Left', left_query)))
+			return
+		if right_err:
+			await self.bot.say(inline(err_msg.format('Right', right_query)))
+			return
+		
+		emoji_to_embed = OrderedDict()
+		emoji_to_embed[self.ls_emoji] = monstersToLsEmbed(left_m, right_m)
+		emoji_to_embed[self.left_emoji] = monsterToEmbed(left_m, self.get_emojis())
+		emoji_to_embed[self.right_emoji] = monsterToEmbed(right_m, self.get_emojis())
+		
+		await self._do_menu(ctx, self.ls_emoji, emoji_to_embed)
+	
+	@commands.command(name="helpid", pass_context=True, aliases=['helppic', 'helpimg'])
+	async def _helpid(self, ctx):
+		"""Whispers you info on how to craft monster queries for ^id"""
+		await self.bot.whisper(box(HELP_MSG))
+	
+	@commands.command(pass_context=True)
+	async def padsay(self, ctx, server, *, query: str = None):
+		"""Speak the voice line of a monster into your current chat"""
+		voice = ctx.message.author.voice
+		channel = voice.voice_channel
+		if channel is None:
+			await self.bot.say(inline('You must be in a voice channel to use this command'))
+			return
+		
+		speech_cog = self.bot.get_cog('Speech')
+		if not speech_cog:
+			await self.bot.say(inline('Speech seems to be offline'))
+			return
+		
+		if server.lower() not in ['na', 'jp']:
+			query = server + ' ' + (query or '')
+			server = 'na'
+		query = query.strip().lower()
+		
+		m, err, debug_info = self.findMonster(query)
+		if m is not None:
+			base_dir = '/home/tactical0retreat/pad_data/voices/fixed'
+			voice_file = os.path.join(base_dir, server, '{}.wav'.format(m.monster_no_na))
+			header = '{} ({})'.format(monsterToHeader(m), server)
+			if not os.path.exists(voice_file):
+				await self.bot.say(inline('Could not find voice for ' + header))
+				return
+			await self.bot.say('Speaking for ' + header)
+			await speech_cog.play_path(channel, voice_file)
+		else:
+			await self.bot.say(self.makeFailureMsg(err))
+	
+	@commands.group(pass_context=True)
+	@checks.is_owner()
+	async def padinfo(self, ctx):
+		"""PAD info management"""
+		if ctx.invoked_subcommand is None:
+			await send_cmd_help(ctx)
+	
+	@padinfo.command(pass_context=True)
+	@checks.is_owner()
+	async def setemojiservers(self, ctx, *, emoji_servers=''):
+		"""Set the emoji servers by ID (csv)"""
+		self.settings.emojiServers().clear()
+		if emoji_servers:
+			self.settings.setEmojiServers(emoji_servers.split(','))
+		await self.bot.say(inline('Set {} servers'.format(len(self.settings.emojiServers()))))
+	
+	def get_emojis(self):
+		server_ids = self.settings.emojiServers()
+		return [e for s in self.bot.servers if s.id in server_ids for e in s.emojis]
+	
+	def makeFailureMsg(self, err):
+		msg = 'Lookup failed: {}.\n'.format(err)
+		msg += 'Try one of <id>, <name>, [argbld]/[rgbld] <name>. Unexpected results? Use ^helpid for more info.'
+		return box(msg)
+	
+	def findMonster(self, query, na_only=False):
+		query = rmdiacritics(query)
+		nm, err, debug_info = self._findMonster(query, na_only)
+		
+		monster_no = nm.monster_no if nm else -1
+		self.historic_lookups[query] = monster_no
+		dataIO.save_json(self.historic_lookups_file_path, self.historic_lookups)
+		
+		m = self.get_monster_by_no(nm.monster_no) if nm else None
+		
+		return m, err, debug_info
+	
+	def _findMonster(self, query, na_only=False):
+		monster_index = self.index_na if na_only else self.index_all
+		return monster_index.find_monster(query)
+	
+	def findMonster2(self, query, na_only=False):
+		query = rmdiacritics(query)
+		nm, err, debug_info = self._findMonster2(query, na_only)
+		
+		monster_no = nm.monster_no if nm else -1
+		self.historic_lookups_id2[query] = monster_no
+		dataIO.save_json(self.historic_lookups_file_path_id2, self.historic_lookups_id2)
+		
+		m = self.get_monster_by_no(nm.monster_no) if nm else None
+		
+		return m, err, debug_info
+	
+	def _findMonster2(self, query, na_only=False):
+		monster_index = self.index_na if na_only else self.index_all
+		return monster_index.find_monster2(query)
+	
+	def map_awakenings_text(self, m):
+		"""Exported for use in other cogs"""
+		return _map_awakenings_text(m)
+	
+	@padinfo.command(pass_context=True)
+	@checks.is_owner()
+	async def setanimationdir(self, ctx, *, animation_dir=''):
+		"""Set a directory containing animated images"""
+		self.settings.setAnimationDir(animation_dir)
+		await self.bot.say(inline('Done'))
+	
+	def check_monster_animated(self, monster_id: int):
+		if not self.settings.animationDir():
+			return False
+		
+		try:
+			animated_ids = set()
+			for f in os.listdir(self.settings.animationDir()):
+				f = f.replace('.mp4', '')
+				if f.isdigit() and int(f) == monster_id:
+					return True
+		except:
+			pass
+		
+		return False
 
 
 def setup(bot):
-    print('padinfo bot setup')
-    n = PadInfo(bot)
-    bot.add_cog(n)
-    bot.loop.create_task(n.reload_nicknames())
-    print('done adding padinfo bot')
+	print('padinfo bot setup')
+	n = PadInfo(bot)
+	bot.add_cog(n)
+	bot.loop.create_task(n.reload_nicknames())
+	print('done adding padinfo bot')
 
 
 class PadInfoSettings(CogSettings):
-    def make_default_settings(self):
-        config = {
-            'animation_dir': '',
-        }
-        return config
-
-    def emojiServers(self):
-        key = 'emoji_servers'
-        if key not in self.bot_settings:
-            self.bot_settings[key] = []
-        return self.bot_settings[key]
-
-    def setEmojiServers(self, emoji_servers):
-        es = self.emojiServers()
-        es.clear()
-        es.extend(emoji_servers)
-        self.save_settings()
-
-    def animationDir(self):
-        return self.bot_settings['animation_dir']
-
-    def setAnimationDir(self, animation_dir):
-        self.bot_settings['animation_dir'] = animation_dir
-        self.save_settings()
+	def make_default_settings(self):
+		config = {
+			'animation_dir': '',
+		}
+		return config
+	
+	def emojiServers(self):
+		key = 'emoji_servers'
+		if key not in self.bot_settings:
+			self.bot_settings[key] = []
+		return self.bot_settings[key]
+	
+	def setEmojiServers(self, emoji_servers):
+		es = self.emojiServers()
+		es.clear()
+		es.extend(emoji_servers)
+		self.save_settings()
+	
+	def animationDir(self):
+		return self.bot_settings['animation_dir']
+	
+	def setAnimationDir(self, animation_dir):
+		self.bot_settings['animation_dir'] = animation_dir
+		self.save_settings()
 
 
 def monsterToHeader(m: padguide2.PgMonster, link=False):
-    msg = 'No. {} {}'.format(m.monster_no_na, m.name_na)
-    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
+	msg = 'No. {} {}'.format(m.monster_no_na, m.name_na)
+	return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
 
 
 def monsterToJpSuffix(m: padguide2.PgMonster):
-    suffix = ""
-    if m.roma_subname:
-        suffix += ' [{}]'.format(m.roma_subname)
-    if not m.on_na:
-        suffix += ' (JP only)'
-    return suffix
+	suffix = ""
+	if m.roma_subname:
+		suffix += ' [{}]'.format(m.roma_subname)
+	if not m.on_na:
+		suffix += ' (JP only)'
+	return suffix
 
 
 def monsterToLongHeader(m: padguide2.PgMonster, link=False):
-    msg = monsterToHeader(m) + monsterToJpSuffix(m)
-    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
+	msg = monsterToHeader(m) + monsterToJpSuffix(m)
+	return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
 
 
 def monsterToLongHeaderWithAttr(m: padguide2.PgMonster, link=False):
-    header = 'No. {} {} {}'.format(
-        m.monster_no_na,
-        "({}{})".format(attr_prefix_map[m.attr1], "/" +
-                        attr_prefix_map[m.attr2] if m.attr2 else ""),
-        m.name_na)
-    msg = header + monsterToJpSuffix(m)
-    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
+	header = 'No. {} {} {}'.format(
+		m.monster_no_na,
+		"({}{})".format(attr_prefix_map[m.attr1], "/" +
+												  attr_prefix_map[m.attr2] if m.attr2 else ""),
+		m.name_na)
+	msg = header + monsterToJpSuffix(m)
+	return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
 
 
 def monsterToEvoText(m: padguide2.PgMonster):
-    output = monsterToLongHeader(m)
-    for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
-        output += "\n\t- {}".format(monsterToLongHeader(ae))
-    return output
+	output = monsterToLongHeader(m)
+	for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
+		output += "\n\t- {}".format(monsterToLongHeader(ae))
+	return output
 
 
 def monsterToThumbnailUrl(m: padguide2.PgMonster):
-    return get_portrait_url(m)
+	return get_portrait_url(m)
 
 
 def monsterToBaseEmbed(m: padguide2.PgMonster):
-    header = monsterToLongHeader(m)
-    embed = discord.Embed()
-    embed.set_thumbnail(url=monsterToThumbnailUrl(m))
-    embed.title = header
-    embed.url = get_pdx_url(m)
-    embed.set_footer(text='Requester may click the reactions below to switch tabs')
-    return embed
+	header = monsterToLongHeader(m)
+	embed = discord.Embed()
+	embed.set_thumbnail(url=monsterToThumbnailUrl(m))
+	embed.title = header
+	embed.url = get_pdx_url(m)
+	embed.set_footer(text='Requester may click the reactions below to switch tabs')
+	return embed
 
 
 def monsterToEvoEmbed(m: padguide2.PgMonster):
-    embed = monsterToBaseEmbed(m)
-
-    if not len(m.alt_evos):
-        embed.description = 'No alternate evos'
-        return embed
-
-    field_name = '{} alternate evos'.format(len(m.alt_evos))
-    field_data = ''
-    for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
-        field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
-
-    embed.add_field(name=field_name, value=field_data)
-
-    return embed
+	embed = monsterToBaseEmbed(m)
+	
+	if not len(m.alt_evos):
+		embed.description = 'No alternate evos'
+		return embed
+	
+	field_name = '{} alternate evos'.format(len(m.alt_evos))
+	field_data = ''
+	for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
+		field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
+	
+	embed.add_field(name=field_name, value=field_data)
+	
+	return embed
 
 
 def monsterToEvoMatsEmbed(m: padguide2.PgMonster):
-    embed = monsterToBaseEmbed(m)
-
-    mats_for_evo_size = len(m.mats_for_evo)
-    material_of_size = len(m.material_of)
-
-    field_name = 'Evo materials'
-    field_data = ''
-    if mats_for_evo_size:
-        for ae in m.mats_for_evo:
-            field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
-    else:
-        field_data = 'None'
-    embed.add_field(name=field_name, value=field_data)
-
-    if not material_of_size:
-        return embed
-
-    field_name = 'Material for'
-    field_data = ''
-    if material_of_size > 5:
-        field_data = '{} monsters'.format(material_of_size)
-    else:
-        item_count = min(material_of_size, 5)
-        for ae in sorted(m.material_of, key=lambda x: x.monster_no_na, reverse=True)[:item_count]:
-            field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
-    embed.add_field(name=field_name, value=field_data)
-
-    return embed
+	embed = monsterToBaseEmbed(m)
+	
+	mats_for_evo_size = len(m.mats_for_evo)
+	material_of_size = len(m.material_of)
+	
+	field_name = 'Evo materials'
+	field_data = ''
+	if mats_for_evo_size:
+		for ae in m.mats_for_evo:
+			field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
+	else:
+		field_data = 'None'
+	embed.add_field(name=field_name, value=field_data)
+	
+	if not material_of_size:
+		return embed
+	
+	field_name = 'Material for'
+	field_data = ''
+	if material_of_size > 5:
+		field_data = '{} monsters'.format(material_of_size)
+	else:
+		item_count = min(material_of_size, 5)
+		for ae in sorted(m.material_of, key=lambda x: x.monster_no_na, reverse=True)[:item_count]:
+			field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
+	embed.add_field(name=field_name, value=field_data)
+	
+	return embed
 
 
 def monsterToPantheonEmbed(m: padguide2.PgMonster):
-    full_pantheon = m.series.monsters
-    pantheon_list = list(filter(lambda x: x.evo_from is None, full_pantheon))
-    if len(pantheon_list) == 0 or len(pantheon_list) > 6:
-        return None
-
-    embed = monsterToBaseEmbed(m)
-
-    field_name = 'Pantheon: ' + m.series.name
-    field_data = ''
-    for monster in sorted(pantheon_list, key=lambda x: x.monster_no_na):
-        field_data += '\n' + monsterToHeader(monster, link=True)
-    embed.add_field(name=field_name, value=field_data)
-
-    return embed
+	full_pantheon = m.series.monsters
+	pantheon_list = list(filter(lambda x: x.evo_from is None, full_pantheon))
+	if len(pantheon_list) == 0 or len(pantheon_list) > 6:
+		return None
+	
+	embed = monsterToBaseEmbed(m)
+	
+	field_name = 'Pantheon: ' + m.series.name
+	field_data = ''
+	for monster in sorted(pantheon_list, key=lambda x: x.monster_no_na):
+		field_data += '\n' + monsterToHeader(monster, link=True)
+	embed.add_field(name=field_name, value=field_data)
+	
+	return embed
 
 
 def monsterToSkillupsEmbed(m: padguide2.PgMonster):
-    skillups_list = m.active_skill.monsters_with_active if m.active_skill else []
-    skillups_list = list(filter(lambda m: m.sell_mp < 3000, skillups_list))
-    server_skillups = m.active_skill.server_skillups if m.active_skill else []
-
-    if len(skillups_list) + len(server_skillups) == 0:
-        return None
-
-    embed = monsterToBaseEmbed(m)
-
-    skillups_to_skip = []
-    for server, skillup in server_skillups.items():
-        skillup_header = 'Skillup in ' + server
-        skillup_body = monsterToHeader(skillup, link=True)
-        embed.add_field(name=skillup_header, value=skillup_body)
-        skillups_to_skip.append(skillup.monster_no_na)
-
-    field_name = 'Skillups'
-    field_data = ''
-
-    # Prevent huge skillup lists
-    if len(skillups_list) > 8:
-        field_data = '({} skillups omitted)'.format(len(skillups_list) - 8)
-        skillups_list = skillups_list[0:8]
-
-    for monster in sorted(skillups_list, key=lambda x: x.monster_no_na):
-        if monster.monster_no_na in skillups_to_skip:
-            continue
-        field_data += '\n' + monsterToHeader(monster, link=True)
-
-    if len(field_data.strip()):
-        embed.add_field(name=field_name, value=field_data)
-
-    return embed
+	skillups_list = m.active_skill.monsters_with_active if m.active_skill else []
+	skillups_list = list(filter(lambda m: m.sell_mp < 3000, skillups_list))
+	server_skillups = m.active_skill.server_skillups if m.active_skill else []
+	
+	if len(skillups_list) + len(server_skillups) == 0:
+		return None
+	
+	embed = monsterToBaseEmbed(m)
+	
+	skillups_to_skip = []
+	for server, skillup in server_skillups.items():
+		skillup_header = 'Skillup in ' + server
+		skillup_body = monsterToHeader(skillup, link=True)
+		embed.add_field(name=skillup_header, value=skillup_body)
+		skillups_to_skip.append(skillup.monster_no_na)
+	
+	field_name = 'Skillups'
+	field_data = ''
+	
+	# Prevent huge skillup lists
+	if len(skillups_list) > 8:
+		field_data = '({} skillups omitted)'.format(len(skillups_list) - 8)
+		skillups_list = skillups_list[0:8]
+	
+	for monster in sorted(skillups_list, key=lambda x: x.monster_no_na):
+		if monster.monster_no_na in skillups_to_skip:
+			continue
+		field_data += '\n' + monsterToHeader(monster, link=True)
+	
+	if len(field_data.strip()):
+		embed.add_field(name=field_name, value=field_data)
+	
+	return embed
 
 
 def monsterToPicUrl(m: padguide2.PgMonster):
-    return get_pic_url(m)
+	return get_pic_url(m)
 
 
 def monsterToPicEmbed(m: padguide2.PgMonster, animated=False):
-    embed = monsterToBaseEmbed(m)
-    url = monsterToPicUrl(m)
-    embed.set_image(url=url)
-    # Clear the thumbnail, don't need it on pic
-    embed.set_thumbnail(url='')
-    if animated:
-        description = '[{}]({}) –– [{}]({})'.format(
-            'HQ (MP4)', monsterToVideoUrl(m), 'LQ (GIF)', monsterToGifUrl(m))
-        embed.add_field(name='Animated links', value=description)
-
-    return embed
+	embed = monsterToBaseEmbed(m)
+	url = monsterToPicUrl(m)
+	embed.set_image(url=url)
+	# Clear the thumbnail, don't need it on pic
+	embed.set_thumbnail(url='')
+	if animated:
+		description = '[{}]({}) –– [{}]({})'.format(
+			'HQ (MP4)', monsterToVideoUrl(m), 'LQ (GIF)', monsterToGifUrl(m))
+		embed.add_field(name='Animated links', value=description)
+	
+	return embed
 
 
 def monsterToVideoUrl(m: padguide2.PgMonster):
-    return VIDEO_TEMPLATE.format(m.monster_no_jp)
+	return VIDEO_TEMPLATE.format(m.monster_no_jp)
 
 
 def monsterToGifUrl(m: padguide2.PgMonster):
-    return GIF_TEMPLATE.format(m.monster_no_jp)
+	return GIF_TEMPLATE.format(m.monster_no_jp)
 
 
 def monsterToGifEmbed(m: padguide2.PgMonster):
-    embed = monsterToBaseEmbed(m)
-    url = monsterToGifUrl(m)
-    embed.set_image(url=url)
-    # Clear the thumbnail, don't need it on pic
-    embed.set_thumbnail(url='')
-    return embed
+	embed = monsterToBaseEmbed(m)
+	url = monsterToGifUrl(m)
+	embed.set_image(url=url)
+	# Clear the thumbnail, don't need it on pic
+	embed.set_thumbnail(url='')
+	return embed
 
 
 def monstersToLsEmbed(left_m: padguide2.PgMonster, right_m: padguide2.PgMonster):
-    lhp, latk, lrcv, lresist = left_m.leader_skill_data.get_data()
-    rhp, ratk, rrcv, rresist = right_m.leader_skill_data.get_data()
-    multiplier_text = createMultiplierText(lhp, latk, lrcv, lresist, rhp, ratk, rrcv, rresist)
-
-    embed = discord.Embed()
-    embed.title = 'Multiplier [{}]\n\n'.format(multiplier_text)
-    description = ''
-    description += '\n**{}**\n{}'.format(
-        monsterToHeader(left_m, link=True),
-        left_m.leader_skill.desc if left_m.leader_skill else 'None/Missing')
-    description += '\n**{}**\n{}'.format(
-        monsterToHeader(right_m, link=True),
-        right_m.leader_skill.desc if right_m.leader_skill else 'None/Missing')
-    embed.description = description
-
-    return embed
+	lhp, latk, lrcv, lresist = left_m.leader_skill_data.get_data()
+	rhp, ratk, rrcv, rresist = right_m.leader_skill_data.get_data()
+	multiplier_text = createMultiplierText(lhp, latk, lrcv, lresist, rhp, ratk, rrcv, rresist)
+	
+	embed = discord.Embed()
+	embed.title = 'Multiplier [{}]\n\n'.format(multiplier_text)
+	description = ''
+	description += '\n**{}**\n{}'.format(
+		monsterToHeader(left_m, link=True),
+		left_m.leader_skill.desc if left_m.leader_skill else 'None/Missing')
+	description += '\n**{}**\n{}'.format(
+		monsterToHeader(right_m, link=True),
+		right_m.leader_skill.desc if right_m.leader_skill else 'None/Missing')
+	embed.description = description
+	
+	return embed
 
 
 def monsterToHeaderEmbed(m: padguide2.PgMonster):
-    header = monsterToLongHeader(m, link=True)
-    embed = discord.Embed()
-    embed.description = header
-    return embed
+	header = monsterToLongHeader(m, link=True)
+	embed = discord.Embed()
+	embed.description = header
+	return embed
 
 
 def monsterToTypeString(m: padguide2.PgMonster):
-    output = m.type1
-    if m.type2:
-        output += '/' + m.type2
-    if m.type3:
-        output += '/' + m.type3
-    return output
+	output = m.type1
+	if m.type2:
+		output += '/' + m.type2
+	if m.type3:
+		output += '/' + m.type3
+	return output
 
 
 def monsterToAcquireString(m: padguide2.PgMonster):
-    acquire_text = None
-    if m.farmable and not m.mp_evo:
-        # Some MP shop monsters 'drop' in PADR
-        acquire_text = 'Farmable'
-    elif m.farmable_evo and not m.mp_evo:
-        acquire_text = 'Farmable Evo'
-    elif m.in_pem:
-        acquire_text = 'In PEM'
-    elif m.pem_evo:
-        acquire_text = 'PEM Evo'
-    elif m.in_rem:
-        acquire_text = 'In REM'
-    elif m.rem_evo:
-        acquire_text = 'REM Evo'
-    elif m.in_mpshop:
-        acquire_text = 'MP Shop'
-    elif m.mp_evo:
-        acquire_text = 'MP Shop Evo'
-    return acquire_text
+	acquire_text = None
+	if m.farmable and not m.mp_evo:
+		# Some MP shop monsters 'drop' in PADR
+		acquire_text = 'Farmable'
+	elif m.farmable_evo and not m.mp_evo:
+		acquire_text = 'Farmable Evo'
+	elif m.in_pem:
+		acquire_text = 'In PEM'
+	elif m.pem_evo:
+		acquire_text = 'PEM Evo'
+	elif m.in_rem:
+		acquire_text = 'In REM'
+	elif m.rem_evo:
+		acquire_text = 'REM Evo'
+	elif m.in_mpshop:
+		acquire_text = 'MP Shop'
+	elif m.mp_evo:
+		acquire_text = 'MP Shop Evo'
+	return acquire_text
 
 
 def match_emoji(emoji_list, name):
-    for e in emoji_list:
-        if e.name == name:
-            return e
-    return None
+	for e in emoji_list:
+		if e.name == name:
+			return e
+	return None
 
 
 def monsterToEmbed(m: padguide2.PgMonster, emoji_list):
-    embed = monsterToBaseEmbed(m)
-
-    info_row_1 = monsterToTypeString(m)
-    acquire_text = monsterToAcquireString(m)
-
-    info_row_2 = '**Rarity** {}\n**Cost** {}'.format(m.rarity, m.cost)
-    if acquire_text:
-        info_row_2 += '\n**{}**'.format(acquire_text)
-    if m.is_inheritable:
-        info_row_2 += '\n**Inheritable**'
-    else:
-        info_row_2 += '\n**Not inheritable**'
-
-    embed.add_field(name=info_row_1, value=info_row_2)
-
-    if m.limitbreak_stats and m.limitbreak_stats > 1:
-        def lb(x): return int(round(m.limitbreak_stats * x))
-        stats_row_1 = 'Weighted {} | LB {}'.format(m.weighted_stats, lb(m.weighted_stats))
-        stats_row_2 = '**HP** {} ({})\n**ATK** {} ({})\n**RCV** {} ({})'.format(
-            m.hp, lb(m.hp), m.atk, lb(m.atk), m.rcv, lb(m.rcv))
-    else:
-        stats_row_1 = 'Weighted {}'.format(m.weighted_stats)
-        stats_row_2 = '**HP** {}\n**ATK** {}\n**RCV** {}'.format(m.hp, m.atk, m.rcv)
-    embed.add_field(name=stats_row_1, value=stats_row_2)
-
-    awakenings_row = ''
-    for idx, a in enumerate(m.awakenings):
-        a = a.get_name()
-        mapped_awakening = AWAKENING_NAME_MAP_RPAD.get(a, a)
-        mapped_awakening = match_emoji(emoji_list, mapped_awakening)
-
-        if mapped_awakening is None:
-            mapped_awakening = AWAKENING_NAME_MAP.get(a, a)
-
-        # Wrap superawakenings to the next line
-        if len(m.awakenings) - idx == m.superawakening_count:
-            awakenings_row += '\n{}'.format(mapped_awakening)
-        else:
-            awakenings_row += ' {}'.format(mapped_awakening)
-
-    awakenings_row = awakenings_row.strip()
-
-    if not len(awakenings_row):
-        awakenings_row = 'No Awakenings'
-
-    killers = compute_killers(m.type1, m.type2, m.type3)
-    killers_row = '**Available Killers:** {}'.format(' '.join(killers))
-
-    embed.description = '{}\n{}'.format(awakenings_row, killers_row)
-
-    if len(m.server_actives) >= 2:
-        for server, active in m.server_actives.items():
-            active_header = '({} Server) Active Skill ({} -> {})'.format(server,
-                                                                         active.turn_max, active.turn_min)
-            active_body = active.desc
-            embed.add_field(name=active_header, value=active_body, inline=False)
-    else:
-        active_header = 'Active Skill'
-        active_body = 'None/Missing'
-        if m.active_skill:
-            active_header = 'Active Skill ({} -> {})'.format(m.active_skill.turn_max,
-                                                             m.active_skill.turn_min)
-            active_body = m.active_skill.desc
-        embed.add_field(name=active_header, value=active_body, inline=False)
-
-    ls_row = m.leader_skill.desc if m.leader_skill else 'None/Missing'
-    ls_header = 'Leader Skill'
-    if m.leader_skill_data:
-        hp, atk, rcv, resist = m.leader_skill_data.get_data()
-        multiplier_text = createMultiplierText(hp, atk, rcv, resist)
-        ls_header += " [ {} ]".format(multiplier_text)
-    embed.add_field(name=ls_header, value=ls_row, inline=False)
-
-    return embed
+	embed = monsterToBaseEmbed(m)
+	
+	info_row_1 = monsterToTypeString(m)
+	acquire_text = monsterToAcquireString(m)
+	
+	info_row_2 = '**Rarity** {}\n**Cost** {}'.format(m.rarity, m.cost)
+	if acquire_text:
+		info_row_2 += '\n**{}**'.format(acquire_text)
+	if m.is_inheritable:
+		info_row_2 += '\n**Inheritable**'
+	else:
+		info_row_2 += '\n**Not inheritable**'
+	
+	embed.add_field(name=info_row_1, value=info_row_2)
+	
+	if m.limitbreak_stats and m.limitbreak_stats > 1:
+		def lb(x):
+			return int(round(m.limitbreak_stats * x))
+		
+		stats_row_1 = 'Weighted {} | LB {}'.format(m.weighted_stats, lb(m.weighted_stats))
+		stats_row_2 = '**HP** {} ({})\n**ATK** {} ({})\n**RCV** {} ({})'.format(
+			m.hp, lb(m.hp), m.atk, lb(m.atk), m.rcv, lb(m.rcv))
+	else:
+		stats_row_1 = 'Weighted {}'.format(m.weighted_stats)
+		stats_row_2 = '**HP** {}\n**ATK** {}\n**RCV** {}'.format(m.hp, m.atk, m.rcv)
+	embed.add_field(name=stats_row_1, value=stats_row_2)
+	
+	awakenings_row = ''
+	for idx, a in enumerate(m.awakenings):
+		a = a.get_name()
+		mapped_awakening = AWAKENING_NAME_MAP_RPAD.get(a, a)
+		mapped_awakening = match_emoji(emoji_list, mapped_awakening)
+		
+		if mapped_awakening is None:
+			mapped_awakening = AWAKENING_NAME_MAP.get(a, a)
+		
+		# Wrap superawakenings to the next line
+		if len(m.awakenings) - idx == m.superawakening_count:
+			awakenings_row += '\n{}'.format(mapped_awakening)
+		else:
+			awakenings_row += ' {}'.format(mapped_awakening)
+	
+	awakenings_row = awakenings_row.strip()
+	
+	if not len(awakenings_row):
+		awakenings_row = 'No Awakenings'
+	
+	killers = compute_killers(m.type1, m.type2, m.type3)
+	killers_row = '**Available Killers:** {}'.format(' '.join(killers))
+	
+	embed.description = '{}\n{}'.format(awakenings_row, killers_row)
+	
+	if len(m.server_actives) >= 2:
+		for server, active in m.server_actives.items():
+			active_header = '({} Server) Active Skill ({} -> {})'.format(server,
+																		 active.turn_max, active.turn_min)
+			active_body = active.desc
+			embed.add_field(name=active_header, value=active_body, inline=False)
+	else:
+		active_header = 'Active Skill'
+		active_body = 'None/Missing'
+		if m.active_skill:
+			active_header = 'Active Skill ({} -> {})'.format(m.active_skill.turn_max,
+															 m.active_skill.turn_min)
+			active_body = m.active_skill.desc
+		embed.add_field(name=active_header, value=active_body, inline=False)
+	
+	ls_row = m.leader_skill.desc if m.leader_skill else 'None/Missing'
+	ls_header = 'Leader Skill'
+	if m.leader_skill_data:
+		hp, atk, rcv, resist = m.leader_skill_data.get_data()
+		multiplier_text = createMultiplierText(hp, atk, rcv, resist)
+		ls_header += " [ {} ]".format(multiplier_text)
+	embed.add_field(name=ls_header, value=ls_row, inline=False)
+	
+	return embed
 
 
 def monsterToOtherInfoEmbed(m: padguide2.PgMonster):
-    embed = monsterToBaseEmbed(m)
-    # Clear the thumbnail, takes up too much space
-    embed.set_thumbnail(url='')
-
-    stat_cols = ['', 'Max', 'M297', 'Inh', 'I297']
-    tbl = prettytable.PrettyTable(stat_cols)
-    tbl.hrules = prettytable.NONE
-    tbl.vrules = prettytable.NONE
-    tbl.align = "r"
-    hhp = m.hp + 99 * 10
-    hatk = m.atk + 99 * 5
-    hrcv = m.rcv + 99 * 3
-    tbl.add_row(['HP', m.hp, hhp, int(m.hp * .1), int(hhp * .1)])
-    tbl.add_row(['ATK', m.atk, hatk, int(m.atk * .05), int(hatk * .05)])
-    tbl.add_row(['RCV', m.rcv, hrcv, int(m.rcv * .15), int(hrcv * .15)])
-
-    body_text = box(tbl.get_string())
-
-    search_text = YT_SEARCH_TEMPLATE.format(m.name_jp)
-    skyozora_text = SKYOZORA_TEMPLATE.format(m.monster_no_jp)
-    body_text += "\n**JP Name**: {} | [YouTube]({}) | [Skyozora]({})".format(
-        m.name_jp, search_text, skyozora_text)
-
-    if m.history_us:
-        body_text += '\n**History:** {}'.format(m.history_us)
-
-    body_text += '\n**Series:** {}'.format(m.series.name)
-    body_text += '\n**Sell MP:** {:,}'.format(m.sell_mp)
-    if m.buy_mp > 0:
-        body_text += "  **Buy MP:** {:,}".format(m.buy_mp)
-
-    if m.exp < 1000000:
-        xp_text = '{:,}'.format(m.exp)
-    else:
-        xp_text = '{:.1f}'.format(m.exp / 1000000).rstrip('0').rstrip('.') + 'M'
-    body_text += '\n**XP to Max:** {}'.format(xp_text)
-    body_text += '  **Max Level:**: {}'.format(m.max_level)
-    body_text += '\n**Rarity:** {} **Cost:** {}'.format(m.rarity, m.cost)
-
-    if m.translated_jp_name:
-        body_text += '\n**Google Translated:** {}'.format(m.translated_jp_name)
-
-    embed.description = body_text
-
-    return embed
+	embed = monsterToBaseEmbed(m)
+	# Clear the thumbnail, takes up too much space
+	embed.set_thumbnail(url='')
+	
+	stat_cols = ['', 'Max', 'M297', 'Inh', 'I297']
+	tbl = prettytable.PrettyTable(stat_cols)
+	tbl.hrules = prettytable.NONE
+	tbl.vrules = prettytable.NONE
+	tbl.align = "r"
+	hhp = m.hp + 99 * 10
+	hatk = m.atk + 99 * 5
+	hrcv = m.rcv + 99 * 3
+	tbl.add_row(['HP', m.hp, hhp, int(m.hp * .1), int(hhp * .1)])
+	tbl.add_row(['ATK', m.atk, hatk, int(m.atk * .05), int(hatk * .05)])
+	tbl.add_row(['RCV', m.rcv, hrcv, int(m.rcv * .15), int(hrcv * .15)])
+	
+	body_text = box(tbl.get_string())
+	
+	search_text = YT_SEARCH_TEMPLATE.format(m.name_jp)
+	skyozora_text = SKYOZORA_TEMPLATE.format(m.monster_no_jp)
+	body_text += "\n**JP Name**: {} | [YouTube]({}) | [Skyozora]({})".format(
+		m.name_jp, search_text, skyozora_text)
+	
+	if m.history_us:
+		body_text += '\n**History:** {}'.format(m.history_us)
+	
+	body_text += '\n**Series:** {}'.format(m.series.name)
+	body_text += '\n**Sell MP:** {:,}'.format(m.sell_mp)
+	if m.buy_mp > 0:
+		body_text += "  **Buy MP:** {:,}".format(m.buy_mp)
+	
+	if m.exp < 1000000:
+		xp_text = '{:,}'.format(m.exp)
+	else:
+		xp_text = '{:.1f}'.format(m.exp / 1000000).rstrip('0').rstrip('.') + 'M'
+	body_text += '\n**XP to Max:** {}'.format(xp_text)
+	body_text += '  **Max Level:**: {}'.format(m.max_level)
+	body_text += '\n**Rarity:** {} **Cost:** {}'.format(m.rarity, m.cost)
+	
+	if m.translated_jp_name:
+		body_text += '\n**Google Translated:** {}'.format(m.translated_jp_name)
+	
+	embed.description = body_text
+	
+	return embed
 
 
 def monsters_to_rotation_list(monster_list, server: str, index_all: padguide2.MonsterIndex):
-    # Shorten some of the longer names
-    name_remap = {
-        'Extreme King Metal Tamadra': 'Fat Tama',
-        'Extreme King Metal Dragon': 'EKMD',
-        'Ancient Green Sacred Mask': 'Green Mask',
-        'Ancient Blue Sacred Mask': 'Blue Mask',
-    }
-    ignore_monsters = [
-        'Ancient Draggie Knight',
-    ]
-
-    monster_list.sort(key=lambda m: m.monster_no, reverse=True)
-    next_rotation_date = None
-    for m in monster_list:
-        if server in m.future_skillup_rotation:
-            next_rotation_date = m.future_skillup_rotation[server].rotation_date_str
-            break
-
-    cols = [server + ' Skillup', 'Current']
-    if next_rotation_date:
-        cols.append(next_rotation_date)
-    tbl = prettytable.PrettyTable(cols)
-    tbl.hrules = prettytable.HEADER
-    tbl.vrules = prettytable.NONE
-    tbl.align = "l"
-
-    def cell_name(m: padguide2.PgMonster):
-        nm = index_all.monster_no_to_named_monster[m.monster_no]
-        name = nm.group_computed_basename.title()
-        return name_remap.get(name, name)
-
-    for m in monster_list:
-        skill = m.server_actives[server]
-
-        sm = skill.monsters_with_active
-        # Since some newer monsters like jewel of creation are being used as
-        # skillups, exclude them from the list of skillup targets.
-
-        def is_bad_type(m):
-            return set(['enhance', 'evolve', 'vendor']).intersection(set(m.types))
-        sm = max(sm, key=lambda x: (not is_bad_type(x), x.monster_no))
-
-        skillup_name = cell_name(m)
-        if skillup_name in ignore_monsters:
-            continue
-        row = [skillup_name, cell_name(sm)]
-        if next_rotation_date:
-            if server in m.future_skillup_rotation:
-                next_skill = m.future_skillup_rotation[server].skill
-                nm = max(next_skill.monsters_with_active, key=lambda x: x.monster_no)
-                row.append(cell_name(nm))
-            else:
-                row.append('')
-        tbl.add_row(row)
-
-    return tbl.get_string()
+	# Shorten some of the longer names
+	name_remap = {
+		'Extreme King Metal Tamadra': 'Fat Tama',
+		'Extreme King Metal Dragon': 'EKMD',
+		'Ancient Green Sacred Mask': 'Green Mask',
+		'Ancient Blue Sacred Mask': 'Blue Mask',
+	}
+	ignore_monsters = [
+		'Ancient Draggie Knight',
+	]
+	
+	monster_list.sort(key=lambda m: m.monster_no, reverse=True)
+	next_rotation_date = None
+	for m in monster_list:
+		if server in m.future_skillup_rotation:
+			next_rotation_date = m.future_skillup_rotation[server].rotation_date_str
+			break
+	
+	cols = [server + ' Skillup', 'Current']
+	if next_rotation_date:
+		cols.append(next_rotation_date)
+	tbl = prettytable.PrettyTable(cols)
+	tbl.hrules = prettytable.HEADER
+	tbl.vrules = prettytable.NONE
+	tbl.align = "l"
+	
+	def cell_name(m: padguide2.PgMonster):
+		nm = index_all.monster_no_to_named_monster[m.monster_no]
+		name = nm.group_computed_basename.title()
+		return name_remap.get(name, name)
+	
+	for m in monster_list:
+		skill = m.server_actives[server]
+		
+		sm = skill.monsters_with_active
+		
+		# Since some newer monsters like jewel of creation are being used as
+		# skillups, exclude them from the list of skillup targets.
+		
+		def is_bad_type(m):
+			return set(['enhance', 'evolve', 'vendor']).intersection(set(m.types))
+		
+		sm = max(sm, key=lambda x: (not is_bad_type(x), x.monster_no))
+		
+		skillup_name = cell_name(m)
+		if skillup_name in ignore_monsters:
+			continue
+		row = [skillup_name, cell_name(sm)]
+		if next_rotation_date:
+			if server in m.future_skillup_rotation:
+				next_skill = m.future_skillup_rotation[server].skill
+				nm = max(next_skill.monsters_with_active, key=lambda x: x.monster_no)
+				row.append(cell_name(nm))
+			else:
+				row.append('')
+		tbl.add_row(row)
+	
+	return tbl.get_string()
 
 
 AWAKENING_NAME_MAP_RPAD = {
-    'Enhanced Attack': 'boost_atk',
-    'Enhanced HP': 'boost_hp',
-    'Enhanced Heal': 'boost_rcv',
-
-    'Enhanced Team HP': 'teamboost_hp',
-    'Enhanced Team Attack': 'teamboost_atk',
-    'Enhanced Team RCV': 'teamboost_rcv',
-
-    'God Killer': 'killer_god',
-    'Dragon Killer': 'killer_dragon',
-    'Devil Killer': 'killer_devil',
-    'Machine Killer': 'killer_machine',
-    'Balanced Killer': 'killer_balance',
-    'Attacker Killer': 'killer_attacker',
-
-    'Physical Killer': 'killer_physical',
-    'Healer Killer': 'killer_healer',
-    'Evolve Material Killer': 'killer_evomat',
-    'Awaken Material Killer': 'killer_awoken',
-    'Enhance Material Killer': 'killer_enhancemat',
-    'Vendor Material Killer': 'killer_vendor',
-
-    'Auto-Recover': 'misc_autoheal',
-    'Recover Bind': 'misc_bindclear',
-    'Enhanced Combo': 'misc_comboboost',
-    'Super Enhanced Combo': 'misc_super_comboboost',
-    'Guard Break': 'misc_guardbreak',
-    'Multi Boost': 'misc_multiboost',
-    'Additional Attack': 'misc_extraattack',
-    'Skill Boost': 'misc_sb',
-    'Extend Time': 'misc_te',
-    'Two-Pronged Attack': 'misc_tpa',
-    'Damage Void Shield Penetration': 'misc_voidshield',
-    'Awoken Assist': 'misc_assist',
-
-    'Enhanced Fire Orbs': 'oe_fire',
-    'Enhanced Water Orbs': 'oe_water',
-    'Enhanced Wood Orbs': 'oe_wood',
-    'Enhanced Light Orbs': 'oe_light',
-    'Enhanced Dark Orbs': 'oe_dark',
-    'Enhanced Heal Orbs': 'oe_heart',
-
-    'Reduce Fire Damage': 'reduce_fire',
-    'Reduce Water Damage': 'reduce_water',
-    'Reduce Wood Damage': 'reduce_wood',
-    'Reduce Light Damage': 'reduce_light',
-    'Reduce Dark Damage': 'reduce_dark',
-
-    'Resistance-Bind': 'res_bind',
-    'Resistance-Dark': 'res_blind',
-    'Resistance-Jammers': 'res_jammer',
-    'Resistance-Poison': 'res_poison',
-    'Resistance-Skill Bind': 'res_skillbind',
-
-    'Enhanced Fire Att.': 'row_fire',
-    'Enhanced Water Att.': 'row_water',
-    'Enhanced Wood Att.': 'row_wood',
-    'Enhanced Light Att.': 'row_light',
-    'Enhanced Dark Att.': 'row_dark',
-
-    'Skill Charge': 'misc_skillcharge',
-    'Super Additional Attack': 'misc_super_extraattack',
-    'Resistance-Bind＋': 'res_bind_super',
-    'Extend Time＋': 'misc_te_super',
-    'Resistance-Cloud': 'res_cloud',
-    'Resistance-Board Restrict': 'res_seal',
-    'Skill Boost＋': 'misc_sb_super',
-    'L-Shape Attack': 'l_attack',
-    'L-Shape Damage Reduction': 'l_shield',
-    'Enhance when HP is below 50%': 'attack_boost_low',
-    'Enhance when HP is above 80%': 'attack_boost_high',
-    'Combo Orb': 'orb_combo',
-    'Skill Voice': 'misc_voice',
-    'Dungeon Bonus': 'misc_dungeonbonus',
+	'Enhanced Attack': 'boost_atk',
+	'Enhanced HP': 'boost_hp',
+	'Enhanced Heal': 'boost_rcv',
+	
+	'Enhanced Team HP': 'teamboost_hp',
+	'Enhanced Team Attack': 'teamboost_atk',
+	'Enhanced Team RCV': 'teamboost_rcv',
+	
+	'God Killer': 'killer_god',
+	'Dragon Killer': 'killer_dragon',
+	'Devil Killer': 'killer_devil',
+	'Machine Killer': 'killer_machine',
+	'Balanced Killer': 'killer_balance',
+	'Attacker Killer': 'killer_attacker',
+	
+	'Physical Killer': 'killer_physical',
+	'Healer Killer': 'killer_healer',
+	'Evolve Material Killer': 'killer_evomat',
+	'Awaken Material Killer': 'killer_awoken',
+	'Enhance Material Killer': 'killer_enhancemat',
+	'Vendor Material Killer': 'killer_vendor',
+	
+	'Auto-Recover': 'misc_autoheal',
+	'Recover Bind': 'misc_bindclear',
+	'Enhanced Combo': 'misc_comboboost',
+	'Super Enhanced Combo': 'misc_super_comboboost',
+	'Guard Break': 'misc_guardbreak',
+	'Multi Boost': 'misc_multiboost',
+	'Additional Attack': 'misc_extraattack',
+	'Skill Boost': 'misc_sb',
+	'Extend Time': 'misc_te',
+	'Two-Pronged Attack': 'misc_tpa',
+	'Damage Void Shield Penetration': 'misc_voidshield',
+	'Awoken Assist': 'misc_assist',
+	
+	'Enhanced Fire Orbs': 'oe_fire',
+	'Enhanced Water Orbs': 'oe_water',
+	'Enhanced Wood Orbs': 'oe_wood',
+	'Enhanced Light Orbs': 'oe_light',
+	'Enhanced Dark Orbs': 'oe_dark',
+	'Enhanced Heal Orbs': 'oe_heart',
+	
+	'Reduce Fire Damage': 'reduce_fire',
+	'Reduce Water Damage': 'reduce_water',
+	'Reduce Wood Damage': 'reduce_wood',
+	'Reduce Light Damage': 'reduce_light',
+	'Reduce Dark Damage': 'reduce_dark',
+	
+	'Resistance-Bind': 'res_bind',
+	'Resistance-Dark': 'res_blind',
+	'Resistance-Jammers': 'res_jammer',
+	'Resistance-Poison': 'res_poison',
+	'Resistance-Skill Bind': 'res_skillbind',
+	
+	'Enhanced Fire Att.': 'row_fire',
+	'Enhanced Water Att.': 'row_water',
+	'Enhanced Wood Att.': 'row_wood',
+	'Enhanced Light Att.': 'row_light',
+	'Enhanced Dark Att.': 'row_dark',
+	
+	'Skill Charge': 'misc_skillcharge',
+	'Super Additional Attack': 'misc_super_extraattack',
+	'Resistance-Bind＋': 'res_bind_super',
+	'Extend Time＋': 'misc_te_super',
+	'Resistance-Cloud': 'res_cloud',
+	'Resistance-Board Restrict': 'res_seal',
+	'Skill Boost＋': 'misc_sb_super',
+	'L-Shape Attack': 'l_attack',
+	'L-Shape Damage Reduction': 'l_shield',
+	'Enhance when HP is below 50%': 'attack_boost_low',
+	'Enhance when HP is above 80%': 'attack_boost_high',
+	'Combo Orb': 'orb_combo',
+	'Skill Voice': 'misc_voice',
+	'Dungeon Bonus': 'misc_dungeonbonus',
 }
 
 AWAKENING_NAME_MAP = {
-    'Enhanced Fire Orbs': 'R-OE',
-    'Enhanced Water Orbs': 'B-OE',
-    'Enhanced Wood Orbs': 'G-OE',
-    'Enhanced Light Orbs': 'L-OE',
-    'Enhanced Dark Orbs': 'D-OE',
-    'Enhanced Heal Orbs': 'H-OE',
-
-    'Enhanced Fire Att.': 'R-RE',
-    'Enhanced Water Att.': 'B-RE',
-    'Enhanced Wood Att.': 'G-RE',
-    'Enhanced Light Att.': 'L-RE',
-    'Enhanced Dark Att.': 'D-RE',
-
-    'Enhanced HP': 'HP',
-    'Enhanced Attack': 'ATK',
-    'Enhanced Heal': 'RCV',
-
-    'Enhanced Team HP': 'TEAM-HP',
-    'Enhanced Team Attack': 'TEAM-ATK',
-    'Enhanced Team RCV': 'TEAM-RCV',
-
-    'Auto-Recover': 'AUTO-RECOVER',
-    'Skill Boost': 'SB',
-    'Resistance-Skill Bind': 'SBR',
-    'Two-Pronged Attack': 'TPA',
-    'Multi Boost': 'MULTI-BOOST',
-    'Recover Bind': 'RCV-BIND',
-    'Extend Time': 'TE',
-    'Enhanced Combo': 'COMBO-BOOST',
-    'Guard Break': 'DEF-BREAK',
-    'Additional Attack': 'EXTRA-ATK',
-    'Damage Void Shield Penetration': 'VOID-BREAK',
-    'Awoken Assist': 'ASSIST',
-
-    'Resistance-Bind': 'RES-BIND',
-    'Resistance-Dark': 'RES-BLIND',
-    'Resistance-Poison': 'RES-POISON',
-    'Resistance-Jammers': 'RES-JAMMER',
-
-    'Reduce Fire Damage': 'R-RES',
-    'Reduce Water Damage': 'B-RES',
-    'Reduce Wood Damage': 'G-RES',
-    'Reduce Light Damage': 'L-RES',
-    'Reduce Dark Damage': 'D-RES',
-
-    'Healer Killer': 'K-HEALER',
-    'Machine Killer': 'K-MACHINE',
-    'Dragon Killer': 'K-DRAGON',
-    'Attacker Killer': 'K-ATTACKER',
-    'Physical Killer': 'K-PHYSICAL',
-    'God Killer': 'K-GOD',
-    'Devil Killer': 'K-DEVIL',
-    'Balance Killer': 'K-BALANCE',
+	'Enhanced Fire Orbs': 'R-OE',
+	'Enhanced Water Orbs': 'B-OE',
+	'Enhanced Wood Orbs': 'G-OE',
+	'Enhanced Light Orbs': 'L-OE',
+	'Enhanced Dark Orbs': 'D-OE',
+	'Enhanced Heal Orbs': 'H-OE',
+	
+	'Enhanced Fire Att.': 'R-RE',
+	'Enhanced Water Att.': 'B-RE',
+	'Enhanced Wood Att.': 'G-RE',
+	'Enhanced Light Att.': 'L-RE',
+	'Enhanced Dark Att.': 'D-RE',
+	
+	'Enhanced HP': 'HP',
+	'Enhanced Attack': 'ATK',
+	'Enhanced Heal': 'RCV',
+	
+	'Enhanced Team HP': 'TEAM-HP',
+	'Enhanced Team Attack': 'TEAM-ATK',
+	'Enhanced Team RCV': 'TEAM-RCV',
+	
+	'Auto-Recover': 'AUTO-RECOVER',
+	'Skill Boost': 'SB',
+	'Resistance-Skill Bind': 'SBR',
+	'Two-Pronged Attack': 'TPA',
+	'Multi Boost': 'MULTI-BOOST',
+	'Recover Bind': 'RCV-BIND',
+	'Extend Time': 'TE',
+	'Enhanced Combo': 'COMBO-BOOST',
+	'Guard Break': 'DEF-BREAK',
+	'Additional Attack': 'EXTRA-ATK',
+	'Damage Void Shield Penetration': 'VOID-BREAK',
+	'Awoken Assist': 'ASSIST',
+	
+	'Resistance-Bind': 'RES-BIND',
+	'Resistance-Dark': 'RES-BLIND',
+	'Resistance-Poison': 'RES-POISON',
+	'Resistance-Jammers': 'RES-JAMMER',
+	
+	'Reduce Fire Damage': 'R-RES',
+	'Reduce Water Damage': 'B-RES',
+	'Reduce Wood Damage': 'G-RES',
+	'Reduce Light Damage': 'L-RES',
+	'Reduce Dark Damage': 'D-RES',
+	
+	'Healer Killer': 'K-HEALER',
+	'Machine Killer': 'K-MACHINE',
+	'Dragon Killer': 'K-DRAGON',
+	'Attacker Killer': 'K-ATTACKER',
+	'Physical Killer': 'K-PHYSICAL',
+	'God Killer': 'K-GOD',
+	'Devil Killer': 'K-DEVIL',
+	'Balance Killer': 'K-BALANCE',
 }
 
 
 def createMultiplierText(hp1, atk1, rcv1, resist1, hp2=None, atk2=None, rcv2=None, resist2=None):
-    hp2, atk2, rcv2, resist2 = hp2 or hp1, atk2 or atk1, rcv2 or rcv1, resist2 or resist1
-
-    def fmtNum(val):
-        return ('{:.2f}').format(val).strip('0').rstrip('.')
-    text = "{}/{}/{}".format(fmtNum(hp1 * hp2), fmtNum(atk1 * atk2), fmtNum(rcv1 * rcv2))
-    if resist1 * resist2 < 1:
-        resist1 = resist1 if resist1 < 1 else 0
-        resist2 = resist2 if resist2 < 1 else 0
-        text += ' Resist {}%'.format(fmtNum(100 * (1 - (1 - resist1) * (1 - resist2))))
-    return text
+	hp2, atk2, rcv2, resist2 = hp2 or hp1, atk2 or atk1, rcv2 or rcv1, resist2 or resist1
+	
+	def fmtNum(val):
+		return ('{:.2f}').format(val).strip('0').rstrip('.')
+	
+	text = "{}/{}/{}".format(fmtNum(hp1 * hp2), fmtNum(atk1 * atk2), fmtNum(rcv1 * rcv2))
+	if resist1 * resist2 < 1:
+		resist1 = resist1 if resist1 < 1 else 0
+		resist2 = resist2 if resist2 < 1 else 0
+		text += ' Resist {}%'.format(fmtNum(100 * (1 - (1 - resist1) * (1 - resist2))))
+	return text
 
 
 def _map_awakenings_text(m: padguide2.PgMonster):
-    awakenings_row = ''
-    unique_awakenings = set(m.awakening_names)
-    for a in unique_awakenings:
-        count = m.awakening_names.count(a)
-        awakenings_row += ' {}x{}'.format(AWAKENING_NAME_MAP.get(a, a), count)
-    awakenings_row = awakenings_row.strip()
-
-    if not len(awakenings_row):
-        awakenings_row = 'No Awakenings'
-
-    return awakenings_row
+	awakenings_row = ''
+	unique_awakenings = set(m.awakening_names)
+	for a in unique_awakenings:
+		count = m.awakening_names.count(a)
+		awakenings_row += ' {}x{}'.format(AWAKENING_NAME_MAP.get(a, a), count)
+	awakenings_row = awakenings_row.strip()
+	
+	if not len(awakenings_row):
+		awakenings_row = 'No Awakenings'
+	
+	return awakenings_row
 
 
 # TODO: move to padguide2
 def compute_killers(*types):
-    if 'Balance' in types:
-        return ['Any']
-    killers = set()
-    for t in types:
-        killers.update(type_to_killers_map.get(t, []))
-    return sorted(killers)
+	if 'Balance' in types:
+		return ['Any']
+	killers = set()
+	for t in types:
+		killers.update(type_to_killers_map.get(t, []))
+	return sorted(killers)
 
 
 type_to_killers_map = {
-    'God': ['Devil'],
-    'Devil': ['God'],
-    'Machine': ['God', 'Balance'],
-    'Dragon': ['Machine', 'Healer'],
-    'Physical': ['Machine', 'Healer'],
-    'Attacker': ['Devil', 'Physical'],
-    'Healer': ['Dragon', 'Attacker'],
+	'God': ['Devil'],
+	'Devil': ['God'],
+	'Machine': ['God', 'Balance'],
+	'Dragon': ['Machine', 'Healer'],
+	'Physical': ['Machine', 'Healer'],
+	'Attacker': ['Devil', 'Physical'],
+	'Healer': ['Dragon', 'Attacker'],
 }

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -168,18 +168,25 @@ class PadInfo:
         """Monster info (limited to NA monsters ONLY)"""
         await self._do_id(ctx, query, na_only=True)
 
+    async def _do_id(self, ctx, query: str, na_only=False):
+        m, err, debug_info = self.findMonster(query, na_only=na_only)
+        if m is not None:
+            await self._do_idmenu(ctx, m, self.id_emoji)
+        else:
+            await self.bot.say(self.makeFailureMsg(err))
+    
     @commands.command(name="id2", pass_context=True)
-    async def _do_id_all_multiple_prefixes(self, ctx, *, query: str):
+    async def _do_id_all_2(self, ctx, *, query: str):
         """Monster info (main tab)"""
-        await self._do_id(ctx, query, multiple_prefixes=True)
+        await self._do_id2(ctx, query)
 
     @commands.command(name="idna2", pass_context=True)
     async def _do_id_na(self, ctx, *, query: str):
         """Monster info (limited to NA monsters ONLY)"""
-        await self._do_id(ctx, query, na_only=True, multiple_prefixes=True)
+        await self._do_id2(ctx, query, na_only=True)
     
-    async def _do_id(self, ctx, query: str, na_only=False, multiple_prefixes=False):
-        m, err, debug_info = self.findMonster(query, na_only=na_only, multiple_prefixes=multiple_prefixes)
+    async def _do_id2(self, ctx, query: str, na_only=False):
+        m, err, debug_info = self.findMonster(query, na_only=na_only)
         if m is not None:
             await self._do_idmenu(ctx, m, self.id_emoji)
         else:
@@ -422,7 +429,7 @@ class PadInfo:
 
     def findMonster(self, query, na_only=False, multiple_prefixes=False):
         query = rmdiacritics(query)
-        nm, err, debug_info = self._findMonster(query, na_only, multiple_prefixes)
+        nm, err, debug_info = self._findMonster(query, na_only)
 
         monster_no = nm.monster_no if nm else -1
         self.historic_lookups[query] = monster_no
@@ -432,12 +439,26 @@ class PadInfo:
 
         return m, err, debug_info
 
-    def _findMonster(self, query, na_only=False, multiple_prefixes=False):
+    def _findMonster(self, query, na_only=False):
         monster_index = self.index_na if na_only else self.index_all
-        if multiple_prefixes:
-            return monster_index.find_monster_multiple_prefixes(query)
-        else:
-            return monster_index.find_monster(query)
+        return monster_index.find_monster(query)
+        
+    def findMonster2(self, query, na_only=False):
+        query = rmdiacritics(query)
+        nm, err, debug_info = self._findMonster2(query, na_only)
+
+        monster_no = nm.monster_no if nm else -1
+        self.historic_lookups[query] = monster_no
+        dataIO.save_json(self.historic_lookups_file_path, self.historic_lookups)
+
+        m = self.get_monster_by_no(nm.monster_no) if nm else None
+
+        return m, err, debug_info
+
+    def _findMonster2(self, query, na_only=False):
+        monster_index = self.index_na if na_only else self.index_all
+        return monster_index.find_monster_multiple_prefixes(query)
+
 
     def map_awakenings_text(self, m):
         """Exported for use in other cogs"""

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -1,1116 +1,2524 @@
+"""
+Provides access to PadGuide data.
+
+Loads every PadGuide related JSON into a simple data structure, and then
+combines them into a an in-memory interconnected database.
+
+Don't hold on to any of the dastructures exported from here, or the
+entire database could be leaked when the module is reloaded.
+"""
+from _collections import defaultdict
 import asyncio
-from builtins import filter, map
-from collections import OrderedDict
-from collections import defaultdict
-import io
+import csv
+from datetime import datetime
+from datetime import timedelta
+import difflib
+from itertools import groupby
 import json
+from operator import itemgetter
+import os
 import re
+import time
 import traceback
 
-from dateutil import tz
+import aiohttp
 import discord
 from discord.ext import commands
 from enum import Enum
-import prettytable
+import pytz
+import romkan
 
-from __main__ import user_allowed, send_cmd_help
+from __main__ import send_cmd_help
 
-from . import padguide2
 from . import rpadutils
-from .rpadutils import *
 from .rpadutils import CogSettings
 from .utils import checks
-from .utils.chat_formatting import *
+from .utils.chat_formatting import box, inline
 from .utils.dataIO import dataIO
 
-HELP_MSG = """
-^helpid : shows this message
-^id <query> : look up a monster and print a link to puzzledragonx
-^pic <query> : Look up a monster and display its image inline
+DUMMY_FILE_PATTERN = 'data/padguide2/{}.dummy'
+JSON_FILE_PATTERN = 'data/padguide2/{}.json'
+CSV_FILE_PATTERN = 'data/padguide2/{}.csv'
+ATTR_EXPORT_PATH = 'data/padguide2/card_data.csv'
+NAMES_EXPORT_PATH = 'data/padguide2/computed_names.json'
+BASENAMES_EXPORT_PATH = 'data/padguide2/base_names.json'
+TRANSLATEDNAMES_EXPORT_PATH = 'data/padguide2/translated_names.json'
 
-Options for <query>
-    <id> : Find a monster by ID
-        ^id 1234 (picks sun quan)
-    <name> : Take the best guess for a monster, picks the most recent monster
-        ^id kali (picks uvo d kali)
-    <prefix> <name> : Limit by element or awoken, e.g.
-        ^id ares  (selects the most recent, awoken ares)
-        ^id aares (explicitly selects awoken ares)
-        ^id a ares (spaces work too)
-        ^id rd ares (select a specific evo for ares, the red/dark one)
-        ^id r/d ares (slashes, spaces work too)
+SHEETS_PATTERN = 'https://docs.google.com/spreadsheets/d/1EoZJ3w5xsXZ67kmarLE4vfrZSIIIAfj04HXeZVST3eY/pub?gid={}&single=true&output=csv'
+GROUP_BASENAMES_OVERRIDES_SHEET = SHEETS_PATTERN.format('2070615818')
+NICKNAME_OVERRIDES_SHEET = SHEETS_PATTERN.format('0')
 
-computed nickname list and overrides: https://docs.google.com/spreadsheets/d/1EyzMjvf8ZCQ4K-gJYnNkiZlCEsT9YYI9dUd-T5qCirc/pubhtml
-submit an override suggestion: https://docs.google.com/forms/d/1kJH9Q0S8iqqULwrRqB9dSxMOMebZj6uZjECqi4t9_z0/edit"""
+NICKNAME_FILE_PATTERN = CSV_FILE_PATTERN.format('nicknames')
+BASENAME_FILE_PATTERN = CSV_FILE_PATTERN.format('basenames')
 
-EMBED_NOT_GENERATED = -1
 
-INFO_PDX_TEMPLATE = 'http://www.puzzledragonx.com/en/monster.asp?n={}'
-RPAD_PIC_TEMPLATE = 'https://f002.backblazeb2.com/file/miru-data/padimages/{}/full/{}.png'
-RPAD_PORTRAIT_TEMPLATE = 'https://f002.backblazeb2.com/file/miru-data/padimages/{}/portrait/{}.png'
-VIDEO_TEMPLATE = 'https://f002.backblazeb2.com/file/miru-data/padimages/animated/{}.mp4'
-GIF_TEMPLATE = 'https://f002.backblazeb2.com/file/miru-data/padimages/animated/{}.gif'
-
-YT_SEARCH_TEMPLATE = 'https://www.youtube.com/results?search_query={}'
-SKYOZORA_TEMPLATE = 'http://pad.skyozora.com/pets/{}'
-
-def get_pdx_url(m):
-    return INFO_PDX_TEMPLATE.format(rpadutils.get_pdx_id(m))
-
-def get_portrait_url(m):
-    if int(m.monster_no) != m.monster_no_na:
-        return RPAD_PORTRAIT_TEMPLATE.format('na', m.monster_no_na)
-    else:
-        return RPAD_PORTRAIT_TEMPLATE.format('jp', m.monster_no_jp)
-
-def get_pic_url(m):
-    if int(m.monster_no) != m.monster_no_na:
-        return RPAD_PIC_TEMPLATE.format('na', m.monster_no_na)
-    else:
-        return RPAD_PIC_TEMPLATE.format('jp', m.monster_no_jp)
-
-class PadInfo:
+class PadGuide2(object):
     def __init__(self, bot):
         self.bot = bot
+        self._is_ready = asyncio.Event(loop=self.bot.loop)
+        
+        self.settings = PadGuide2Settings("padguide2")
+        self.reload_task = None
+        
+        self._standard_refresh = [
+            PgAttribute,
+            PgAwakening,
+            PgDungeon,
+            # PgDungeonDamage,
+            PgDungeonMonsterDrop,
+            PgDungeonMonster,
+            # PgDungeonSkill,
+            # PgDungeonType,
+            PgEggInstance,
+            PgEggMonster,
+            PgEggName,
+            PgEvent,
+            PgEvolution,
+            PgEvolutionMaterial,
+            PgMonster,
+            PgMonsterAddInfo,
+            PgMonsterInfo,
+            PgMonsterPrice,
+            PgSeries,
+            PgSkillLeaderData,
+            PgSkill,
+            PgSkillRotation,
+            PgSkillRotationDated,
+            # PgSubDungeon,
+            PgType,
+        ]
+        
+        self._quick_refresh = [
+            PgScheduledEvent,
+        ]
+        
+        # A string -> int mapping, nicknames to monster_id_na
+        self.nickname_overrides = {}
+        
+        # An int -> set(string), monster_id_na to set of basename overrides
+        self.basename_overrides = defaultdict(set)
+        
+        self.database = PgRawDatabase(skip_load=True)
+        
+        # Map of google-translated JP names to EN names
+        self.translated_names = {}
+    
+    @asyncio.coroutine
+    def wait_until_ready(self):
+        """Wait until the PadGuide2 cog is ready.
 
-        self.settings = PadInfoSettings("padinfo")
-
-        self.index_all = padguide2.empty_index()
-        self.index_na = padguide2.empty_index()
-
-        self.menu = Menu(bot)
-
-        # These emojis are the keys into the idmenu submenus
-        self.id_emoji = '\N{INFORMATION SOURCE}'
-        self.evo_emoji = char_to_emoji('e')
-        self.mats_emoji = char_to_emoji('m')
-        self.ls_emoji = '\N{INFORMATION SOURCE}'
-        self.left_emoji = char_to_emoji('l')
-        self.right_emoji = char_to_emoji('r')
-        self.pantheon_emoji = '\N{CLASSICAL BUILDING}'
-        self.skillups_emoji = '\N{MEAT ON BONE}'
-        self.pic_emoji = '\N{FRAME WITH PICTURE}'
-        self.other_info_emoji = '\N{SCROLL}'
-
-        self.historic_lookups_file_path = "data/padinfo/historic_lookups.json"
-        self.historic_lookups_file_path_id2 = "data/padinfo/historic_lookups_id2.json"
-
-        if not dataIO.is_valid_json(self.historic_lookups_file_path):
-            print("Creating empty historic_lookups.json...")
-            dataIO.save_json(self.historic_lookups_file_path, {})
-
-        if not dataIO.is_valid_json(self.historic_lookups_file_path_id2):
-            print("Creating empty historic_lookups_id2.json...")
-            dataIO.save_json(self.historic_lookups_file_path_id2, {})
-
-        self.historic_lookups = dataIO.load_json(self.historic_lookups_file_path)
-        self.historic_lookups_id2 = dataIO.load_json(self.historic_lookups_file_path_id2)
-
-
+        Call this from other cogs to wait until PadGuide2 finishes refreshing its database
+        for the first time.
+        """
+        yield from self._is_ready.wait()
+    
+    def create_index(self, accept_filter=None):
+        """Exported function that allows a client cog to create a monster index"""
+        return MonsterIndex(self.database, self.nickname_overrides, self.basename_overrides,
+                            accept_filter=accept_filter)
+    
+    def get_monster_by_no(self, monster_no: int):
+        """Exported function that allows a client cog to get a full PgMonster by monster_no"""
+        return self.database.getMonster(monster_no)
+    
+    def get_translated_jp_name(self, jp_name):
+        return self.translate_names.get(jp_name, None)
+    
+    def register_tasks(self):
+        self.reload_task = self.bot.loop.create_task(self.reload_data_task())
+    
     def __unload(self):
         # Manually nulling out database because the GC for cogs seems to be pretty shitty
-        self.index_all = padguide2.empty_index()
-        self.index_na = padguide2.empty_index()
-        self.historic_lookups = {}
-        self.historic_lookups_id2 = {}
-
-    async def reload_nicknames(self):
+        self.database = None
+        self._is_ready.clear()
+    
+    async def reload_data_task(self):
         await self.bot.wait_until_ready()
-        while self == self.bot.get_cog('PadInfo'):
-            try:
-                await self.refresh_index()
-                print('Done refreshing PadInfo')
-            except Exception as ex:
-                print("reload padinfo loop caught exception " + str(ex))
-                traceback.print_exc()
-
-            await asyncio.sleep(60 * 60 * 1)
-
-    async def refresh_index(self):
-        """Refresh the monster indexes."""
-        pg_cog = self.bot.get_cog('PadGuide2')
-        await pg_cog.wait_until_ready()
-        self.index_all = pg_cog.create_index()
-        self.index_na = pg_cog.create_index(lambda m: m.on_na)
-
-
-    def get_monster_by_no(self, monster_no: int):
-        pg_cog = self.bot.get_cog('PadGuide2')
-        return pg_cog.get_monster_by_no(monster_no)
-
-    @commands.command(pass_context=True)
-    async def skillrotation(self, ctx, server: str = 'NA'):
-        """Print the current rotating skillups for a server (NA/JP)"""
-        server = normalizeServer(server)
-        if server not in ['NA', 'JP']:
-            await self.bot.say(inline('Supported servers are NA, JP'))
-            return
-
-        pg_cog = self.bot.get_cog('PadGuide2')
-        monsters = pg_cog.database.rotating_skillups(server)
-
-        for page in pagify(monsters_to_rotation_list(monsters, server, self.index_all)):
-            await self.bot.say(box(page))
-
-    @commands.command(pass_context=True)
-    async def jpname(self, ctx, *, query: str):
-        """Print the Japanese name of a monster"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self.bot.say(monsterToHeader(m))
-            await self.bot.say(box(m.name_jp))
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-
-    @commands.command(name="id", pass_context=True)
-    async def _do_id_all(self, ctx, *, query: str):
-        """Monster info (main tab)"""
-        await self._do_id(ctx, query)
-
-    @commands.command(name="idna", pass_context=True)
-    async def _do_id_na(self, ctx, *, query: str):
-        """Monster info (limited to NA monsters ONLY)"""
-        await self._do_id(ctx, query, na_only=True)
-
-    async def _do_id(self, ctx, query: str, na_only=False):
-        m, err, debug_info = self.findMonster(query, na_only=na_only)
-        if m is not None:
-            await self._do_idmenu(ctx, m, self.id_emoji)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-
-    @commands.command(name="id2", pass_context=True)
-    async def _do_id2_all(self, ctx, *, query: str):
-        """Monster info (main tab)"""
-        await self._do_id2(ctx, query)
-
-    @commands.command(name="id2na", pass_context=True)
-    async def _do_id2_na(self, ctx, *, query: str):
-        """Monster info (limited to NA monsters ONLY)"""
-        await self._do_id2(ctx, query, na_only=True)
-
-    async def _do_id2(self, ctx, query: str, na_only=False):
-        m, err, debug_info = self.findMonster2(query, na_only=na_only)
-        if m is not None:
-            await self._do_idmenu(ctx, m, self.id_emoji)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-
-    @commands.command(name="evos", pass_context=True)
-    async def evos(self, ctx, *, query: str):
-        """Monster info (evolutions tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self._do_idmenu(ctx, m, self.evo_emoji)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-
-    @commands.command(name="mats", pass_context=True, aliases=['evomats', 'evomat'])
-    async def evomats(self, ctx, *, query: str):
-        """Monster info (evo materials tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self._do_idmenu(ctx, m, self.mats_emoji)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-
-    @commands.command(pass_context=True)
-    async def pantheon(self, ctx, *, query: str):
-        """Monster info (pantheon tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            menu = await self._do_idmenu(ctx, m, self.pantheon_emoji)
-            if menu == EMBED_NOT_GENERATED:
-                await self.bot.say(inline('Not a pantheon monster'))
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-
-    @commands.command(pass_context=True)
-    async def skillups(self, ctx, *, query: str):
-        """Monster info (evolutions tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            menu = await self._do_idmenu(ctx, m, self.skillups_emoji)
-            if menu == EMBED_NOT_GENERATED:
-                await self.bot.say(inline('No skillups available'))
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-
-    async def _do_idmenu(self, ctx, m, starting_menu_emoji):
-        id_embed = monsterToEmbed(m, self.get_emojis())
-        evo_embed = monsterToEvoEmbed(m)
-        mats_embed = monsterToEvoMatsEmbed(m)
-        animated = self.check_monster_animated(m.monster_no_jp)
-        pic_embed = monsterToPicEmbed(m, animated=animated)
-        other_info_embed = monsterToOtherInfoEmbed(m)
-
-        emoji_to_embed = OrderedDict()
-        emoji_to_embed[self.id_emoji] = id_embed
-        emoji_to_embed[self.evo_emoji] = evo_embed
-        emoji_to_embed[self.mats_emoji] = mats_embed
-        emoji_to_embed[self.pic_emoji] = pic_embed
-
-        pantheon_embed = monsterToPantheonEmbed(m)
-        if pantheon_embed:
-            emoji_to_embed[self.pantheon_emoji] = pantheon_embed
-
-        skillups_embed = monsterToSkillupsEmbed(m)
-        if skillups_embed:
-            emoji_to_embed[self.skillups_emoji] = skillups_embed
-
-        emoji_to_embed[self.other_info_emoji] = other_info_embed
-
-        return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed)
-
-    async def _do_evolistmenu(self, ctx, sm):
-        monsters = sm.alt_evos
-        monsters.sort(key=lambda m: m.monster_no)
-
-        emoji_to_embed = OrderedDict()
-        for idx, m in enumerate(monsters):
-            emoji = char_to_emoji(str(idx))
-            emoji_to_embed[emoji] = monsterToEmbed(m, self.get_emojis())
-            if m == sm:
-                starting_menu_emoji = emoji
-
-        return await self._do_menu(ctx, starting_menu_emoji, emoji_to_embed, timeout=60)
-
-    async def _do_menu(self, ctx, starting_menu_emoji, emoji_to_embed, timeout=30):
-        if starting_menu_emoji not in emoji_to_embed:
-            # Selected menu wasn't generated for this monster
-            return EMBED_NOT_GENERATED
-
-        remove_emoji = self.menu.emoji['no']
-        emoji_to_embed[remove_emoji] = self.menu.reaction_delete_message
-
+        
         try:
-            result_msg, result_embed = await self.menu.custom_menu(ctx, emoji_to_embed, starting_menu_emoji,
-                                                                   timeout=timeout)
-            if result_msg and result_embed:
-                # Message is finished but not deleted, clear the footer
-                result_embed.set_footer(text=discord.Embed.Empty)
-                await self.bot.edit_message(result_msg, embed=result_embed)
+            # Try and load the PadGuide database the first time with existing files
+            self.database = PgRawDatabase(data_dir=self.settings.dataDir())
+            self._is_ready.set()
+            print('Finished initial PadGuide2 load with existing database')
         except Exception as ex:
-            print('Menu failure', ex)
-
-    @commands.command(pass_context=True, aliases=['img'])
-    async def pic(self, ctx, *, query: str):
-        """Monster info (full image tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self._do_idmenu(ctx, m, self.pic_emoji)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-
-    @commands.command(pass_context=True, aliases=['stats'])
-    async def otherinfo(self, ctx, *, query: str):
-        """Monster info (misc info tab)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self._do_idmenu(ctx, m, self.other_info_emoji)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-
-    @commands.command(pass_context=True)
-    async def lookup(self, ctx, *, query: str):
-        """Short info results for a monster query"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            embed = monsterToHeaderEmbed(m)
-            await self.bot.say(embed=embed)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-
-    @commands.command(pass_context=True)
-    async def evolist(self, ctx, *, query):
-        """Monster info (for all monsters in the evo tree)"""
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            await self._do_evolistmenu(ctx, m)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-
-    @commands.command(pass_context=True, aliases=['leaders', 'leaderskills', 'ls'])
-    async def leaderskill(self, ctx, left_query: str, right_query: str = None, *, bad=None):
-        """Display the multiplier and leaderskills for two monsters
-
-        If either your left or right query contains spaces, wrap in quotes.
-        e.g.: ^leaderskill "r sonia" "b sonia"
-        """
-        if bad:
-            await self.bot.say(inline('Too many inputs. Try wrapping your queries in quotes.'))
-            return
-
-        # Handle a very specific failure case, user typing something like "uuvo ragdra"
-        if ' ' not in left_query and right_query is not None and ' ' not in right_query and bad is None:
-            combined_query = left_query + ' ' + right_query
-            nm, err, debug_info = self._findMonster(combined_query)
-            if nm and left_query in nm.prefixes:
-                left_query = combined_query
-                right_query = None
-
-        left_m, left_err, _ = self.findMonster(left_query)
-        if right_query:
-            right_m, right_err, _ = self.findMonster(right_query)
-        else:
-            right_m, right_err, = left_m, left_err
-
-        err_msg = '{} query failed to match a monster: [ {} ]. If your query is multiple words, wrap it in quotes.'
-        if left_err:
-            await self.bot.say(inline(err_msg.format('Left', left_query)))
-            return
-        if right_err:
-            await self.bot.say(inline(err_msg.format('Right', right_query)))
-            return
-
-        emoji_to_embed = OrderedDict()
-        emoji_to_embed[self.ls_emoji] = monstersToLsEmbed(left_m, right_m)
-        emoji_to_embed[self.left_emoji] = monsterToEmbed(left_m, self.get_emojis())
-        emoji_to_embed[self.right_emoji] = monsterToEmbed(right_m, self.get_emojis())
-
-        await self._do_menu(ctx, self.ls_emoji, emoji_to_embed)
-
-    @commands.command(name="helpid", pass_context=True, aliases=['helppic', 'helpimg'])
-    async def _helpid(self, ctx):
-        """Whispers you info on how to craft monster queries for ^id"""
-        await self.bot.whisper(box(HELP_MSG))
-
-    @commands.command(pass_context=True)
-    async def padsay(self, ctx, server, *, query: str = None):
-        """Speak the voice line of a monster into your current chat"""
-        voice = ctx.message.author.voice
-        channel = voice.voice_channel
-        if channel is None:
-            await self.bot.say(inline('You must be in a voice channel to use this command'))
-            return
-
-        speech_cog = self.bot.get_cog('Speech')
-        if not speech_cog:
-            await self.bot.say(inline('Speech seems to be offline'))
-            return
-
-        if server.lower() not in ['na', 'jp']:
-            query = server + ' ' + (query or '')
-            server = 'na'
-        query = query.strip().lower()
-
-        m, err, debug_info = self.findMonster(query)
-        if m is not None:
-            base_dir = '/home/tactical0retreat/pad_data/voices/fixed'
-            voice_file = os.path.join(base_dir, server, '{}.wav'.format(m.monster_no_na))
-            header = '{} ({})'.format(monsterToHeader(m), server)
-            if not os.path.exists(voice_file):
-                await self.bot.say(inline('Could not find voice for ' + header))
-                return
-            await self.bot.say('Speaking for ' + header)
-            await speech_cog.play_path(channel, voice_file)
-        else:
-            await self.bot.say(self.makeFailureMsg(err))
-
+            print(ex)
+            print('Initial PadGuide2 database load failed, waiting for download')
+        
+        while self == self.bot.get_cog('PadGuide2'):
+            short_wait = False
+            try:
+                await self.download_and_refresh_nicknames()
+                print('Done refreshing PadGuide2, triggering ready')
+                self._is_ready.set()
+            except Exception as ex:
+                short_wait = True
+                print("padguide2 data download/refresh failed", ex)
+                traceback.print_exc()
+            
+            try:
+                await self.translate_names()
+            except Exception as ex:
+                print("translations failed", ex)
+                traceback.print_exc()
+            
+            try:
+                wait_time = 60 if short_wait else 60 * 60 * 4
+                await asyncio.sleep(wait_time)
+            except Exception as ex:
+                print("padguide2 data wait loop failed", ex)
+                traceback.print_exc()
+                raise ex
+    
+    async def reload_config_files(self):
+        os.remove(NICKNAME_FILE_PATTERN)
+        os.remove(BASENAME_FILE_PATTERN)
+        await self.download_and_refresh_nicknames()
+    
+    async def translate_names(self):
+        if os.path.exists(TRANSLATEDNAMES_EXPORT_PATH):
+            with open(TRANSLATEDNAMES_EXPORT_PATH) as f:
+                self.translated_names = json.load(f)
+        
+        for m in self.database.all_monsters():
+            name_jp = m.name_jp
+            if rpadutils.containsJp(name_jp) and name_jp not in self.translated_names:
+                self.translated_names[name_jp] = await rpadutils.translate_jp_en(self.bot, name_jp)
+            m.translated_jp_name = self.translated_names.get(name_jp, None)
+        
+        with open(TRANSLATEDNAMES_EXPORT_PATH, 'w', encoding='utf-8') as f:
+            json.dump(self.translated_names, f, sort_keys=True, indent=4)
+    
+    async def download_and_refresh_nicknames(self):
+        if not self.settings.dataDir():
+            await self._download_files()
+        await self._download_override_files()
+        
+        nickname_overrides = self._csv_to_tuples(NICKNAME_FILE_PATTERN)
+        basename_overrides = self._csv_to_tuples(BASENAME_FILE_PATTERN)
+        
+        self.nickname_overrides = {x[0].lower(): int(x[1])
+                                   for x in nickname_overrides if x[1].isdigit()}
+        
+        self.basename_overrides = defaultdict(set)
+        for x in basename_overrides:
+            k, v = x
+            if k.isdigit():
+                self.basename_overrides[int(k)].add(v.lower())
+        
+        self.database = PgRawDatabase(data_dir=self.settings.dataDir())
+        self.index = MonsterIndex(self.database, self.nickname_overrides, self.basename_overrides)
+        
+        self.write_monster_attr_data()
+        self.write_monster_computed_names()
+    
+    def write_monster_computed_names(self):
+        results = {}
+        for name, nm in self.index.all_entries.items():
+            results[name] = int(rpadutils.get_pdx_id(nm))
+        
+        with open(NAMES_EXPORT_PATH, 'w', encoding='utf-8') as f:
+            json.dump(results, f, sort_keys=True)
+        
+        results = {}
+        for nm in self.index.all_monsters:
+            entry = {'bn': list(nm.group_basenames)}
+            if nm.extra_nicknames:
+                entry['nn'] = list(nm.extra_nicknames)
+            results[int(rpadutils.get_pdx_id(nm))] = entry
+        
+        with open(BASENAMES_EXPORT_PATH, 'w', encoding='utf-8') as f:
+            json.dump(results, f, sort_keys=True)
+    
+    def write_monster_attr_data(self):
+        """Write id,server,attr1,attr2 to be used by the portrait generation process."""
+        attr_short_prefix_map = {
+            Attribute.Fire: 'r',
+            Attribute.Water: 'b',
+            Attribute.Wood: 'g',
+            Attribute.Light: 'l',
+            Attribute.Dark: 'd',
+        }
+        
+        # Monsters who exist only in na have the same na/jp id but differing monster_no
+        na_only = [x for x in self.database._monster_map.values() if x.monster_no !=
+                   x.monster_no_na and x.monster_no_na == x.monster_no_jp]
+        
+        na_only_base_no = [x.monster_no for x in na_only]
+        na_only_server_no = [x.monster_no_na for x in na_only]
+        
+        with open(ATTR_EXPORT_PATH, 'w') as csvfile:
+            writer = csv.writer(csvfile, delimiter=',', lineterminator='\n')
+            for m in self.database._monster_map.values():
+                attr1 = attr_short_prefix_map[m.attr1]
+                attr2 = attr_short_prefix_map[m.attr2] if m.attr2 else ''
+                if m.monster_no in na_only_base_no:
+                    # Writes stuff like voltron
+                    writer.writerow([m.monster_no_na, 'na', attr1, attr2])
+                elif m.monster_no_jp in na_only_server_no:
+                    # Writes stuff like crows
+                    writer.writerow([m.monster_no_jp, 'jp', attr1, attr2])
+                else:
+                    # writes everything else
+                    writer.writerow([m.monster_no_na, 'na', attr1, attr2])
+                    writer.writerow([m.monster_no_jp, 'jp', attr1, attr2])
+    
+    def _csv_to_tuples(self, file_path: str, cols: int = 2):
+        # Loads a two-column CSV into an array of tuples.
+        results = []
+        with open(file_path, encoding='utf-8') as f:
+            file_reader = csv.reader(f, delimiter=',')
+            for row in file_reader:
+                if len(row) < 2:
+                    continue
+                
+                data = [None] * cols
+                for i in range(0, min(cols, len(row))):
+                    data[i] = row[i].strip()
+                
+                if not len(data[0]):
+                    continue
+                
+                results.append(data)
+        return results
+    
+    async def _download_files(self):
+        # twelve hours expiry
+        standard_expiry_secs = 12 * 60 * 60
+        # four hours expiry
+        quick_expiry_secs = 4 * 60 * 60
+        
+        # Use a dummy file to proxy for the entire database being out of date
+        general_dummy_file = DUMMY_FILE_PATTERN.format('general')
+        download_all = rpadutils.checkPadguideCacheFile(general_dummy_file, quick_expiry_secs)
+        
+        async with aiohttp.ClientSession() as client_session:
+            for type in self._standard_refresh:
+                endpoint = type.file_name()
+                result_file = JSON_FILE_PATTERN.format(endpoint)
+                if download_all or rpadutils.should_download(result_file, quick_expiry_secs):
+                    await rpadutils.async_cached_padguide_request(client_session, endpoint, result_file)
+                    # Sleep to avoid overwhelming with requests
+                    await asyncio.sleep(1)
+            
+            for type in self._quick_refresh:
+                cur_time = int(round(time.time() * 1000))
+                three_weeks_ago = cur_time - 3 * 7 * 24 * 60 * 60 * 1000
+                endpoint = type.file_name()
+                result_file = JSON_FILE_PATTERN.format(endpoint)
+                if download_all or rpadutils.should_download(result_file, quick_expiry_secs):
+                    await rpadutils.async_cached_padguide_request(client_session, endpoint, result_file,
+                                                                  time_ms=three_weeks_ago)
+    
+    async def _download_override_files(self):
+        overrides_expiry_secs = 1 * 60 * 60
+        await rpadutils.makeAsyncCachedPlainRequest(
+            NICKNAME_FILE_PATTERN, NICKNAME_OVERRIDES_SHEET, overrides_expiry_secs)
+        await rpadutils.makeAsyncCachedPlainRequest(
+            BASENAME_FILE_PATTERN, GROUP_BASENAMES_OVERRIDES_SHEET, overrides_expiry_secs)
+    
     @commands.group(pass_context=True)
     @checks.is_owner()
-    async def padinfo(self, ctx):
-        """PAD info management"""
+    async def padguide2(self, ctx):
+        """PAD database management"""
         if ctx.invoked_subcommand is None:
             await send_cmd_help(ctx)
-
-    @padinfo.command(pass_context=True)
+    
+    @padguide2.command(pass_context=True)
     @checks.is_owner()
-    async def setemojiservers(self, ctx, *, emoji_servers=''):
-        """Set the emoji servers by ID (csv)"""
-        self.settings.emojiServers().clear()
-        if emoji_servers:
-            self.settings.setEmojiServers(emoji_servers.split(','))
-        await self.bot.say(inline('Set {} servers'.format(len(self.settings.emojiServers()))))
-
-
-    def get_emojis(self):
-        server_ids = self.settings.emojiServers()
-        return [e for s in self.bot.servers if s.id in server_ids for e in s.emojis]
-
-
-    def makeFailureMsg(self, err):
-        msg = 'Lookup failed: {}.\n'.format(err)
-        msg += 'Try one of <id>, <name>, [argbld]/[rgbld] <name>. Unexpected results? Use ^helpid for more info.'
-        return box(msg)
-
-
-    def findMonster(self, query, na_only=False):
-        query = rmdiacritics(query)
-        nm, err, debug_info = self._findMonster(query, na_only)
-
-        monster_no = nm.monster_no if nm else -1
-        self.historic_lookups[query] = monster_no
-        dataIO.save_json(self.historic_lookups_file_path, self.historic_lookups)
-
-        m = self.get_monster_by_no(nm.monster_no) if nm else None
-
-        return m, err, debug_info
-
-
-    def _findMonster(self, query, na_only=False):
-        monster_index = self.index_na if na_only else self.index_all
-        return monster_index.find_monster(query)
-
-
-    def findMonster2(self, query, na_only=False):
-        query = rmdiacritics(query)
-        nm, err, debug_info = self._findMonster2(query, na_only)
-
-        monster_no = nm.monster_no if nm else -1
-        self.historic_lookups_id2[query] = monster_no
-        dataIO.save_json(self.historic_lookups_file_path_id2, self.historic_lookups_id2)
-
-        m = self.get_monster_by_no(nm.monster_no) if nm else None
-
-        return m, err, debug_info
-
-
-    def _findMonster2(self, query, na_only=False):
-        monster_index = self.index_na if na_only else self.index_all
-        return monster_index.find_monster2(query)
-
-
-    def map_awakenings_text(self, m):
-        """Exported for use in other cogs"""
-        return _map_awakenings_text(m)
-
-    @padinfo.command(pass_context=True)
-    @checks.is_owner()
-    async def setanimationdir(self, ctx, *, animation_dir=''):
-        """Set a directory containing animated images"""
-        self.settings.setAnimationDir(animation_dir)
+    async def setdatadir(self, ctx, *, data_dir):
+        """Set a local path to padguide data instead of downloading it."""
+        self.settings.setDataDir(data_dir)
         await self.bot.say(inline('Done'))
 
 
-    def check_monster_animated(self, monster_id: int):
-        if not self.settings.animationDir():
-            return False
-
-        try:
-            animated_ids = set()
-            for f in os.listdir(self.settings.animationDir()):
-                f = f.replace('.mp4', '')
-                if f.isdigit() and int(f) == monster_id:
-                    return True
-        except:
-            pass
-
-        return False
-
-def setup(bot):
-    print('padinfo bot setup')
-    n = PadInfo(bot)
-    bot.add_cog(n)
-    bot.loop.create_task(n.reload_nicknames())
-    print('done adding padinfo bot')
-
-class PadInfoSettings(CogSettings):
+class PadGuide2Settings(CogSettings):
     def make_default_settings(self):
         config = {
-            'animation_dir': '',
+            'data_dir': '',
         }
         return config
-
-
-    def emojiServers(self):
-        key = 'emoji_servers'
-        if key not in self.bot_settings:
-            self.bot_settings[key] = []
-        return self.bot_settings[key]
-
-
-    def setEmojiServers(self, emoji_servers):
-        es = self.emojiServers()
-        es.clear()
-        es.extend(emoji_servers)
+    
+    def dataDir(self):
+        return self.bot_settings['data_dir']
+    
+    def setDataDir(self, data_dir):
+        self.bot_settings['data_dir'] = data_dir
         self.save_settings()
 
 
-    def animationDir(self):
-        return self.bot_settings['animation_dir']
+def setup(bot):
+    n = PadGuide2(bot)
+    bot.add_cog(n)
+    n.register_tasks()
 
 
-    def setAnimationDir(self, animation_dir):
-        self.bot_settings['animation_dir'] = animation_dir
-        self.save_settings()
-
-def monsterToHeader(m: padguide2.PgMonster, link=False):
-    msg = 'No. {} {}'.format(m.monster_no_na, m.name_na)
-    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
-
-def monsterToJpSuffix(m: padguide2.PgMonster):
-    suffix = ""
-    if m.roma_subname:
-        suffix += ' [{}]'.format(m.roma_subname)
-    if not m.on_na:
-        suffix += ' (JP only)'
-    return suffix
-
-def monsterToLongHeader(m: padguide2.PgMonster, link=False):
-    msg = monsterToHeader(m) + monsterToJpSuffix(m)
-    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
-
-def monsterToLongHeaderWithAttr(m: padguide2.PgMonster, link=False):
-    header = 'No. {} {} {}'.format(
-        m.monster_no_na,
-        "({}{})".format(attr_prefix_map[m.attr1], "/" +
-                                                  attr_prefix_map[m.attr2] if m.attr2 else ""),
-        m.name_na)
-    msg = header + monsterToJpSuffix(m)
-    return '[{}]({})'.format(msg, get_pdx_url(m)) if link else msg
-
-def monsterToEvoText(m: padguide2.PgMonster):
-    output = monsterToLongHeader(m)
-    for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
-        output += "\n\t- {}".format(monsterToLongHeader(ae))
-    return output
-
-def monsterToThumbnailUrl(m: padguide2.PgMonster):
-    return get_portrait_url(m)
-
-def monsterToBaseEmbed(m: padguide2.PgMonster):
-    header = monsterToLongHeader(m)
-    embed = discord.Embed()
-    embed.set_thumbnail(url=monsterToThumbnailUrl(m))
-    embed.title = header
-    embed.url = get_pdx_url(m)
-    embed.set_footer(text='Requester may click the reactions below to switch tabs')
-    return embed
-
-def monsterToEvoEmbed(m: padguide2.PgMonster):
-    embed = monsterToBaseEmbed(m)
-
-    if not len(m.alt_evos):
-        embed.description = 'No alternate evos'
-        return embed
-
-    field_name = '{} alternate evos'.format(len(m.alt_evos))
-    field_data = ''
-    for ae in sorted(m.alt_evos, key=lambda x: int(x.monster_no)):
-        field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
-
-    embed.add_field(name=field_name, value=field_data)
-
-    return embed
-
-def monsterToEvoMatsEmbed(m: padguide2.PgMonster):
-    embed = monsterToBaseEmbed(m)
-
-    mats_for_evo_size = len(m.mats_for_evo)
-    material_of_size = len(m.material_of)
-
-    field_name = 'Evo materials'
-    field_data = ''
-    if mats_for_evo_size:
-        for ae in m.mats_for_evo:
-            field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
-    else:
-        field_data = 'None'
-    embed.add_field(name=field_name, value=field_data)
-
-    if not material_of_size:
-        return embed
-
-    field_name = 'Material for'
-    field_data = ''
-    if material_of_size > 5:
-        field_data = '{} monsters'.format(material_of_size)
-    else:
-        item_count = min(material_of_size, 5)
-        for ae in sorted(m.material_of, key=lambda x: x.monster_no_na, reverse=True)[:item_count]:
-            field_data += "{}\n".format(monsterToLongHeader(ae, link=True))
-    embed.add_field(name=field_name, value=field_data)
-
-    return embed
-
-def monsterToPantheonEmbed(m: padguide2.PgMonster):
-    full_pantheon = m.series.monsters
-    pantheon_list = list(filter(lambda x: x.evo_from is None, full_pantheon))
-    if len(pantheon_list) == 0 or len(pantheon_list) > 6:
-        return None
-
-    embed = monsterToBaseEmbed(m)
-
-    field_name = 'Pantheon: ' + m.series.name
-    field_data = ''
-    for monster in sorted(pantheon_list, key=lambda x: x.monster_no_na):
-        field_data += '\n' + monsterToHeader(monster, link=True)
-    embed.add_field(name=field_name, value=field_data)
-
-    return embed
-
-def monsterToSkillupsEmbed(m: padguide2.PgMonster):
-    skillups_list = m.active_skill.monsters_with_active if m.active_skill else []
-    skillups_list = list(filter(lambda m: m.sell_mp < 3000, skillups_list))
-    server_skillups = m.active_skill.server_skillups if m.active_skill else []
-
-    if len(skillups_list) + len(server_skillups) == 0:
-        return None
-
-    embed = monsterToBaseEmbed(m)
-
-    skillups_to_skip = []
-    for server, skillup in server_skillups.items():
-        skillup_header = 'Skillup in ' + server
-        skillup_body = monsterToHeader(skillup, link=True)
-        embed.add_field(name=skillup_header, value=skillup_body)
-        skillups_to_skip.append(skillup.monster_no_na)
-
-    field_name = 'Skillups'
-    field_data = ''
-
-    # Prevent huge skillup lists
-    if len(skillups_list) > 8:
-        field_data = '({} skillups omitted)'.format(len(skillups_list) - 8)
-        skillups_list = skillups_list[0:8]
-
-    for monster in sorted(skillups_list, key=lambda x: x.monster_no_na):
-        if monster.monster_no_na in skillups_to_skip:
-            continue
-        field_data += '\n' + monsterToHeader(monster, link=True)
-
-    if len(field_data.strip()):
-        embed.add_field(name=field_name, value=field_data)
-
-    return embed
-
-def monsterToPicUrl(m: padguide2.PgMonster):
-    return get_pic_url(m)
-
-def monsterToPicEmbed(m: padguide2.PgMonster, animated=False):
-    embed = monsterToBaseEmbed(m)
-    url = monsterToPicUrl(m)
-    embed.set_image(url=url)
-    # Clear the thumbnail, don't need it on pic
-    embed.set_thumbnail(url='')
-    if animated:
-        description = '[{}]({}) –– [{}]({})'.format(
-            'HQ (MP4)', monsterToVideoUrl(m), 'LQ (GIF)', monsterToGifUrl(m))
-        embed.add_field(name='Animated links', value=description)
-
-    return embed
-
-def monsterToVideoUrl(m: padguide2.PgMonster):
-    return VIDEO_TEMPLATE.format(m.monster_no_jp)
-
-def monsterToGifUrl(m: padguide2.PgMonster):
-    return GIF_TEMPLATE.format(m.monster_no_jp)
-
-def monsterToGifEmbed(m: padguide2.PgMonster):
-    embed = monsterToBaseEmbed(m)
-    url = monsterToGifUrl(m)
-    embed.set_image(url=url)
-    # Clear the thumbnail, don't need it on pic
-    embed.set_thumbnail(url='')
-    return embed
-
-def monstersToLsEmbed(left_m: padguide2.PgMonster, right_m: padguide2.PgMonster):
-    lhp, latk, lrcv, lresist = left_m.leader_skill_data.get_data()
-    rhp, ratk, rrcv, rresist = right_m.leader_skill_data.get_data()
-    multiplier_text = createMultiplierText(lhp, latk, lrcv, lresist, rhp, ratk, rrcv, rresist)
-
-    embed = discord.Embed()
-    embed.title = 'Multiplier [{}]\n\n'.format(multiplier_text)
-    description = ''
-    description += '\n**{}**\n{}'.format(
-        monsterToHeader(left_m, link=True),
-        left_m.leader_skill.desc if left_m.leader_skill else 'None/Missing')
-    description += '\n**{}**\n{}'.format(
-        monsterToHeader(right_m, link=True),
-        right_m.leader_skill.desc if right_m.leader_skill else 'None/Missing')
-    embed.description = description
-
-    return embed
-
-def monsterToHeaderEmbed(m: padguide2.PgMonster):
-    header = monsterToLongHeader(m, link=True)
-    embed = discord.Embed()
-    embed.description = header
-    return embed
-
-def monsterToTypeString(m: padguide2.PgMonster):
-    output = m.type1
-    if m.type2:
-        output += '/' + m.type2
-    if m.type3:
-        output += '/' + m.type3
-    return output
-
-def monsterToAcquireString(m: padguide2.PgMonster):
-    acquire_text = None
-    if m.farmable and not m.mp_evo:
-        # Some MP shop monsters 'drop' in PADR
-        acquire_text = 'Farmable'
-    elif m.farmable_evo and not m.mp_evo:
-        acquire_text = 'Farmable Evo'
-    elif m.in_pem:
-        acquire_text = 'In PEM'
-    elif m.pem_evo:
-        acquire_text = 'PEM Evo'
-    elif m.in_rem:
-        acquire_text = 'In REM'
-    elif m.rem_evo:
-        acquire_text = 'REM Evo'
-    elif m.in_mpshop:
-        acquire_text = 'MP Shop'
-    elif m.mp_evo:
-        acquire_text = 'MP Shop Evo'
-    return acquire_text
-
-def match_emoji(emoji_list, name):
-    for e in emoji_list:
-        if e.name == name:
-            return e
-    return None
-
-def monsterToEmbed(m: padguide2.PgMonster, emoji_list):
-    embed = monsterToBaseEmbed(m)
-
-    info_row_1 = monsterToTypeString(m)
-    acquire_text = monsterToAcquireString(m)
-
-    info_row_2 = '**Rarity** {}\n**Cost** {}'.format(m.rarity, m.cost)
-    if acquire_text:
-        info_row_2 += '\n**{}**'.format(acquire_text)
-    if m.is_inheritable:
-        info_row_2 += '\n**Inheritable**'
-    else:
-        info_row_2 += '\n**Not inheritable**'
-
-    embed.add_field(name=info_row_1, value=info_row_2)
-
-    if m.limitbreak_stats and m.limitbreak_stats > 1:
-        def lb(x):
-            return int(round(m.limitbreak_stats * x))
-
-        stats_row_1 = 'Weighted {} | LB {}'.format(m.weighted_stats, lb(m.weighted_stats))
-        stats_row_2 = '**HP** {} ({})\n**ATK** {} ({})\n**RCV** {} ({})'.format(
-            m.hp, lb(m.hp), m.atk, lb(m.atk), m.rcv, lb(m.rcv))
-    else:
-        stats_row_1 = 'Weighted {}'.format(m.weighted_stats)
-        stats_row_2 = '**HP** {}\n**ATK** {}\n**RCV** {}'.format(m.hp, m.atk, m.rcv)
-    embed.add_field(name=stats_row_1, value=stats_row_2)
-
-    awakenings_row = ''
-    for idx, a in enumerate(m.awakenings):
-        a = a.get_name()
-        mapped_awakening = AWAKENING_NAME_MAP_RPAD.get(a, a)
-        mapped_awakening = match_emoji(emoji_list, mapped_awakening)
-
-        if mapped_awakening is None:
-            mapped_awakening = AWAKENING_NAME_MAP.get(a, a)
-
-        # Wrap superawakenings to the next line
-        if len(m.awakenings) - idx == m.superawakening_count:
-            awakenings_row += '\n{}'.format(mapped_awakening)
+class PgRawDatabase(object):
+    def __init__(self, skip_load=False, data_dir=None):
+        self._skip_load = skip_load
+        self._data_dir = data_dir
+        self._all_pg_items = []
+        
+        # Load raw data items into id->value maps
+        self._attribute_map = self._load(PgAttribute)
+        self._awakening_map = self._load(PgAwakening)
+        self._dungeon_map = self._load(PgDungeon)
+        # self._dungeon_damage_map = self._load(PgDungeonDamage)
+        self._dungeon_monster_drop_map = self._load(PgDungeonMonsterDrop)
+        self._dungeon_monster_map = self._load(PgDungeonMonster)
+        # self._dungeon_skill_map = self._load(PgDungeonSkill)
+        # self._dungeon_type_map = self._load(PgDungeonType)
+        self._event_map = self._load(PgEvent)
+        self._evolution_map = self._load(PgEvolution)
+        self._evolution_material_map = self._load(PgEvolutionMaterial)
+        self._monster_map = self._load(PgMonster)
+        self._monster_add_info_map = self._load(PgMonsterAddInfo)
+        self._monster_info_map = self._load(PgMonsterInfo)
+        self._monster_price_map = self._load(PgMonsterPrice)
+        self._series_map = self._load(PgSeries)
+        self._scheduled_event_map = self._load(PgScheduledEvent)
+        self._skill_leader_data_map = self._load(PgSkillLeaderData)
+        self._skill_map = self._load(PgSkill)
+        self._skill_rotation_map = self._load(PgSkillRotation)
+        self._skill_rotation_dated_map = self._load(PgSkillRotationDated)
+        # self._sub_dungeon_map = self._load(PgSubDungeon)
+        self._type_map = self._load(PgType)
+        
+        self._egg_instance_map = self._load(PgEggInstance)
+        self._egg_monster_map = self._load(PgEggMonster)
+        self._egg_name_map = self._load(PgEggName)
+        
+        # Ensure that every item has loaded its dependencies
+        for i in self._all_pg_items:
+            self._ensure_loaded(i)
+        
+        # Finish loading now that all the dependencies are resolved
+        for i in self._all_pg_items:
+            i.finalize()
+        
+        # Stick the monsters into groups so that we can calculate info across
+        # the entire group
+        self.grouped_monsters = list()
+        for m in self._monster_map.values():
+            if m.cur_evo_type != EvoType.Base:
+                continue
+            self.grouped_monsters.append(MonsterGroup(m))
+        
+        # Used to normalize from monster NA values back to monster number
+        self.monster_no_na_to_monster_no = {
+            m.monster_no_na: m.monster_no for m in self._monster_map.values()}
+        
+        # Skill rotation map
+        self._server_to_rotating_skillups = {
+            'NA': [],
+            'JP': [],
+        }
+        for m in self._monster_map.values():
+            for server in m.server_actives:
+                self._server_to_rotating_skillups[server].append(m)
+    
+    def _load(self, itemtype):
+        if self._skip_load:
+            return {}
+        
+        if self._data_dir:
+            file_path = os.path.join(self._data_dir, '{}.json'.format(itemtype.file_name()))
         else:
-            awakenings_row += ' {}'.format(mapped_awakening)
+            file_path = JSON_FILE_PATTERN.format(itemtype.file_name())
+        item_list = []
+        
+        if dataIO.is_valid_json(file_path):
+            json_data = dataIO.load_json(file_path)
+            item_list = [itemtype(item) for item in json_data['items']]
+        
+        result_map = {item.key(): item for item in item_list if not item.deleted()}
+        
+        self._all_pg_items.extend(result_map.values())
+        
+        return result_map
+    
+    def _ensure_loaded(self, item: 'PgItem'):
+        if item:
+            item.ensure_loaded(self)
+        return item
+    
+    def normalize_monster_no_na(self, monster_no_na: int):
+        if monster_no_na > 10000:
+            # Allows crows to be referenced
+            return monster_no_na - 10000
+        return self.monster_no_na_to_monster_no[monster_no_na]
+    
+    def all_monsters(self):
+        """Exported for access to the full monster list."""
+        return list(self._monster_map.values())
+    
+    def all_dungeons(self):
+        """Exported for access to the full dungeon list."""
+        return list(self._dungeon_map.values())
+    
+    def all_egg_instances(self):
+        """Exported for access to the full egg machine list."""
+        return list(self._egg_instance_map.values())
+    
+    def all_scheduled_events(self):
+        """Exported for access to event list."""
+        se = list(self._scheduled_event_map.values())
+        return se
+    
+    def rotating_skillups(self, server: str):
+        """Gets monsters used as rotating skillups for the specified server"""
+        return list(self._server_to_rotating_skillups[server])
+    
+    def getAttributeEnum(self, ta_seq: int):
+        attr = self._ensure_loaded(self._attribute_map.get(ta_seq))
+        return attr.value if attr else None
+    
+    def getAwakening(self, tma_seq: int):
+        return self._ensure_loaded(self._awakening_map.get(tma_seq))
+    
+    def getDungeon(self, dungeon_seq: int):
+        return self._ensure_loaded(self._dungeon_map.get(dungeon_seq))
+    
+    #    def getDungeonDamage(self, tds_seq: int):
+    #        return self._ensure_loaded(self._dungeon_damage_map.get(tds_seq))
+    
+    def getDungeonMonsterDrop(self, tdmd_seq: int):
+        return self._ensure_loaded(self._dungeon_monster_drop_map.get(tdmd_seq))
+    
+    def getDungeonMonster(self, tdm_seq: int):
+        return self._ensure_loaded(self._dungeon_monster_map.get(tdm_seq))
+    
+    #    def getDungeonType(self, tdt_seq: int):
+    #        return self._ensure_loaded(self._dungeon_type_map.get(tdt_seq))
+    
+    def getEvent(self, event_seq: int):
+        return self._ensure_loaded(self._event_map.get(event_seq))
+    
+    def getEvolution(self, tv_seq: int):
+        return self._ensure_loaded(self._evolution_map.get(tv_seq))
+    
+    def getEvolutionMaterial(self, tem_seq: int):
+        return self._ensure_loaded(self._evolution_material_map.get(tem_seq))
+    
+    def getMonster(self, monster_no: int):
+        return self._ensure_loaded(self._monster_map.get(monster_no))
+    
+    def getMonsterAddInfo(self, monster_no: int):
+        return self._ensure_loaded(self._monster_add_info_map.get(monster_no))
+    
+    def getMonsterInfo(self, monster_no: int):
+        return self._ensure_loaded(self._monster_info_map.get(monster_no))
+    
+    def getMonsterPrice(self, monster_no: int):
+        return self._ensure_loaded(self._monster_price_map.get(monster_no))
+    
+    def getSeries(self, tsr_seq: int):
+        return self._ensure_loaded(self._series_map.get(tsr_seq))
+    
+    def getScheduledEvent(self, schedule_seq: int):
+        return self._ensure_loaded(self._scheduled_event_map.get(schedule_seq))
+    
+    def getSkill(self, ts_seq: int):
+        return self._ensure_loaded(self._skill_map.get(ts_seq))
+    
+    def getSkillLeaderData(self, ts_seq: int):
+        skill_leader = self._skill_leader_data_map.get(ts_seq)
+        if skill_leader:
+            return self._ensure_loaded(skill_leader)
+        else:
+            return PgSkillLeaderData.empty()
+    
+    def getSkillRotation(self, tsr_seq: int):
+        return self._ensure_loaded(self._skill_rotation_map.get(tsr_seq))
+    
+    def getSkillRotationDated(self, tsrl_seq: int):
+        return self._ensure_loaded(self._skill_rotation_dated_map.get(tsrl_seq))
+    
+    #    def getSubDungeon(self, tsd_seq: int):
+    #        return self._ensure_loaded(self._sub_dungeon_map.get(tsd_seq))
+    
+    def getTypeName(self, tt_seq: int):
+        type = self._ensure_loaded(self._type_map.get(tt_seq))
+        return type.name if type else None
+    
+    def getEggInstance(self, tet_seq: int):
+        return self._ensure_loaded(self._egg_instance_map.get(tet_seq))
+    
+    def getEggMonster(self, tem_seq: int):
+        return self._ensure_loaded(self._egg_monster_map.get(tem_seq))
+    
+    def getEggName(self, tetn_seq: int):
+        return self._ensure_loaded(self._egg_name_map.get(tetn_seq))
 
-    awakenings_row = awakenings_row.strip()
 
-    if not len(awakenings_row):
-        awakenings_row = 'No Awakenings'
+class PgItem(object):
+    """Base class for all items loaded from PadGuide.
 
-    killers = compute_killers(m.type1, m.type2, m.type3)
-    killers_row = '**Available Killers:** {}'.format(' '.join(killers))
-
-    embed.description = '{}\n{}'.format(awakenings_row, killers_row)
-
-    if len(m.server_actives) >= 2:
-        for server, active in m.server_actives.items():
-            active_header = '({} Server) Active Skill ({} -> {})'.format(server,
-                                                                         active.turn_max, active.turn_min)
-            active_body = active.desc
-            embed.add_field(name=active_header, value=active_body, inline=False)
-    else:
-        active_header = 'Active Skill'
-        active_body = 'None/Missing'
-        if m.active_skill:
-            active_header = 'Active Skill ({} -> {})'.format(m.active_skill.turn_max,
-                                                             m.active_skill.turn_min)
-            active_body = m.active_skill.desc
-        embed.add_field(name=active_header, value=active_body, inline=False)
-
-    ls_row = m.leader_skill.desc if m.leader_skill else 'None/Missing'
-    ls_header = 'Leader Skill'
-    if m.leader_skill_data:
-        hp, atk, rcv, resist = m.leader_skill_data.get_data()
-        multiplier_text = createMultiplierText(hp, atk, rcv, resist)
-        ls_header += " [ {} ]".format(multiplier_text)
-    embed.add_field(name=ls_header, value=ls_row, inline=False)
-
-    return embed
-
-def monsterToOtherInfoEmbed(m: padguide2.PgMonster):
-    embed = monsterToBaseEmbed(m)
-    # Clear the thumbnail, takes up too much space
-    embed.set_thumbnail(url='')
-
-    stat_cols = ['', 'Max', 'M297', 'Inh', 'I297']
-    tbl = prettytable.PrettyTable(stat_cols)
-    tbl.hrules = prettytable.NONE
-    tbl.vrules = prettytable.NONE
-    tbl.align = "r"
-    hhp = m.hp + 99 * 10
-    hatk = m.atk + 99 * 5
-    hrcv = m.rcv + 99 * 3
-    tbl.add_row(['HP', m.hp, hhp, int(m.hp * .1), int(hhp * .1)])
-    tbl.add_row(['ATK', m.atk, hatk, int(m.atk * .05), int(hatk * .05)])
-    tbl.add_row(['RCV', m.rcv, hrcv, int(m.rcv * .15), int(hrcv * .15)])
-
-    body_text = box(tbl.get_string())
-
-    search_text = YT_SEARCH_TEMPLATE.format(m.name_jp)
-    skyozora_text = SKYOZORA_TEMPLATE.format(m.monster_no_jp)
-    body_text += "\n**JP Name**: {} | [YouTube]({}) | [Skyozora]({})".format(
-        m.name_jp, search_text, skyozora_text)
-
-    if m.history_us:
-        body_text += '\n**History:** {}'.format(m.history_us)
-
-    body_text += '\n**Series:** {}'.format(m.series.name)
-    body_text += '\n**Sell MP:** {:,}'.format(m.sell_mp)
-    if m.buy_mp > 0:
-        body_text += "  **Buy MP:** {:,}".format(m.buy_mp)
-
-    if m.exp < 1000000:
-        xp_text = '{:,}'.format(m.exp)
-    else:
-        xp_text = '{:.1f}'.format(m.exp / 1000000).rstrip('0').rstrip('.') + 'M'
-    body_text += '\n**XP to Max:** {}'.format(xp_text)
-    body_text += '  **Max Level:**: {}'.format(m.max_level)
-    body_text += '\n**Rarity:** {} **Cost:** {}'.format(m.rarity, m.cost)
-
-    if m.translated_jp_name:
-        body_text += '\n**Google Translated:** {}'.format(m.translated_jp_name)
-
-    embed.description = body_text
-
-    return embed
-
-def monsters_to_rotation_list(monster_list, server: str, index_all: padguide2.MonsterIndex):
-    # Shorten some of the longer names
-    name_remap = {
-        'Extreme King Metal Tamadra': 'Fat Tama',
-        'Extreme King Metal Dragon': 'EKMD',
-        'Ancient Green Sacred Mask': 'Green Mask',
-        'Ancient Blue Sacred Mask': 'Blue Mask',
-    }
-    ignore_monsters = [
-        'Ancient Draggie Knight',
-    ]
-
-    monster_list.sort(key=lambda m: m.monster_no, reverse=True)
-    next_rotation_date = None
-    for m in monster_list:
-        if server in m.future_skillup_rotation:
-            next_rotation_date = m.future_skillup_rotation[server].rotation_date_str
-            break
-
-    cols = [server + ' Skillup', 'Current']
-    if next_rotation_date:
-        cols.append(next_rotation_date)
-    tbl = prettytable.PrettyTable(cols)
-    tbl.hrules = prettytable.HEADER
-    tbl.vrules = prettytable.NONE
-    tbl.align = "l"
+    You must call super().__init__() in your constructor.
+    You must override key() and load().
+    """
+    
+    def __init__(self):
+        self._loaded = False
+    
+    def key(self):
+        """Used to look up an item by id."""
+        raise NotImplementedError()
+    
+    def deleted(self):
+        """Is this item marked for deletion. Discard if true. Not all items can be deleted."""
+        return False
+    
+    def ensure_loaded(self, database: PgRawDatabase):
+        """Ensures that the dependencies have been loaded, or loads them."""
+        if not self._loaded:
+            self._loaded = True
+            self._loading_error = False
+            try:
+                self.load(database)
+            except Exception as ex:
+                self._loading_error = False
+                print('Error occurred while loading item')
+                print(type(self), 'key=', self.key())
+                traceback.print_exc()
+        
+        return self
+    
+    def load(self, database: PgRawDatabase):
+        """Override to inject dependencies."""
+        raise NotImplementedError()
+    
+    def finalize(self):
+        """Finish filling in anything that requires completion but no dependencies."""
+        pass
 
 
-    def cell_name(m: padguide2.PgMonster):
-        nm = index_all.monster_no_to_named_monster[m.monster_no]
-        name = nm.group_computed_basename.title()
-        return name_remap.get(name, name)
+class Attribute(Enum):
+    """Standard 5 PAD colors in enum form. Values correspond to PadGuide values."""
+    Fire = 1
+    Water = 2
+    Wood = 3
+    Light = 4
+    Dark = 5
 
-    for m in monster_list:
-        skill = m.server_actives[server]
 
-        sm = skill.monsters_with_active
+# attributeList
+# {
+#     "ORDER_IDX": "2",
+#     "TA_NAME_JP": "\u6c34",
+#     "TA_NAME_KR": "\ubb3c",
+#     "TA_NAME_US": "Water",
+#     "TA_SEQ": "2",
+#     "TSTAMP": "1372947975226"
+# },
+class PgAttribute(PgItem):
+    @staticmethod
+    def file_name():
+        return 'attributeList'
+    
+    def __init__(self, item):
+        super().__init__()
+        self.ta_seq = int(item['TA_SEQ'])  # unique id
+        self.name = item['TA_NAME_US']
+        
+        self.value = Attribute(self.ta_seq)
+    
+    def key(self):
+        return self.ta_seq
+    
+    def load(self, database: PgRawDatabase):
+        pass
 
-        # Since some newer monsters like jewel of creation are being used as
-        # skillups, exclude them from the list of skillup targets.
 
-        def is_bad_type(m):
-            return set(['enhance', 'evolve', 'vendor']).intersection(set(m.types))
+# awokenSkillList
+# {
+#     "DEL_YN": "N",
+#     "IS_SUPER": "1",
+#     "MONSTER_NO": "661",
+#     "ORDER_IDX": "1",
+#     "TMA_SEQ": "1",
+#     "TSTAMP": "1380587210665",
+#     "TS_SEQ": "2769"
+# },
+class PgAwakening(PgItem):
+    @staticmethod
+    def file_name():
+        return 'awokenSkillList'
+    
+    def __init__(self, item):
+        super().__init__()
+        self.tma_seq = int(item['TMA_SEQ'])  # unique id
+        self.ts_seq = int(item['TS_SEQ'])  # PgSkill id - awakening info
+        self.deleted_yn = item['DEL_YN']  # Either Y(discard) or N.
+        self.monster_no = int(item['MONSTER_NO'])  # PgMonster id - monster this belongs to
+        self.order = int(item['ORDER_IDX'])  # display order
+        self.is_super = item.get('IS_SUPER', '0') == '1'
+        
+        self.skill = None  # type: PgSkill  # The awakening skill
+        self.monster = None  # type: PgMonster # The monster the awakening belongs to
+    
+    def key(self):
+        return self.tma_seq
+    
+    def deleted(self):
+        return self.deleted_yn == 'Y'
+    
+    def load(self, database: PgRawDatabase):
+        self.skill = database.getSkill(self.ts_seq)
+        self.monster = database.getMonster(self.monster_no)
+        
+        self.monster.awakenings.append(self)
+        self.skill.monsters_with_awakening.append(self.monster)
+    
+    def get_name(self):
+        return self.skill.name
 
-        sm = max(sm, key=lambda x: (not is_bad_type(x), x.monster_no))
 
-        skillup_name = cell_name(m)
-        if skillup_name in ignore_monsters:
-            continue
-        row = [skillup_name, cell_name(sm)]
-        if next_rotation_date:
-            if server in m.future_skillup_rotation:
-                next_skill = m.future_skillup_rotation[server].skill
-                nm = max(next_skill.monsters_with_active, key=lambda x: x.monster_no)
-                row.append(cell_name(nm))
+# dungeonList
+# {
+#     "APP_VERSION": "",
+#     "COMMENT_JP": "",
+#     "COMMENT_KR": "",
+#     "COMMENT_US": "",
+#     "DUNGEON_SEQ": "102",
+#     "DUNGEON_TYPE": "1",
+#     "ICON_SEQ": "666",
+#     "NAME_JP": "ECO\u30b3\u30e9\u30dc",
+#     "NAME_KR": "ECO \ucf5c\ub77c\ubcf4",
+#     "NAME_US": "ECO Collab",
+#     "ORDER_IDX": "3",
+#     "SHOW_YN": "1",
+#     "TDT_SEQ": "10",
+#     "TSTAMP": "1373289123410"
+# },
+class PgDungeon(PgItem):
+    @staticmethod
+    def file_name():
+        return 'dungeonList'
+    
+    def __init__(self, item):
+        super().__init__()
+        self.dungeon_seq = int(item['DUNGEON_SEQ'])
+        self.dungeon_type = int(item['DUNGEON_TYPE'])
+        # TODO: merge these two, delete DungeonType from padevents
+        self.dungeon_type_value = DungeonType(self.dungeon_type)
+        self.name = item['NAME_US']
+        self.name_jp = item['NAME_JP']
+        # TODO: load tdt type
+        self.tdt_seq = int_or_none(item['TDT_SEQ'])
+        self.show = item['SHOW_YN'] == 1
+        self.icon = int(item['ICON_SEQ'])
+        
+        self.tdungeon_type = None
+        self.tdungeon_type_name = 'no_type'
+        
+        self.monsters = []
+        self.subdungeons = []
+    
+    def key(self):
+        return self.dungeon_seq
+    
+    def deleted(self):
+        return False
+    
+    #         return not self.show
+    
+    def load(self, database: PgRawDatabase):
+        pass
+
+
+#        if self.tdt_seq:
+#            self.tdungeon_type = database.getDungeonType(self.tdt_seq)
+#            # Somehow this can still fail
+#            if self.tdungeon_type:
+#                self.tdungeon_type_name = self.tdungeon_type.name
+
+
+class DungeonType(Enum):
+    Unknown = -1
+    Normal = 0
+    CoinDailyOther = 1
+    Technical = 2
+    Etc = 3
+
+
+# {
+#     "COIN_MAX": "2496",
+#     "COIN_MIN": "2496",
+#     "DUNGEON_SEQ": "81",
+#     "EXP_MAX": "2420",
+#     "EXP_MIN": "2420",
+#     "ORDER_IDX": "96",
+#     "STAGE": "5",
+#     "STAMINA": "15",
+#     "TSD_NAME_JP": "\u65ad\u7f6a\u306e\u7114 \u4e2d\u7d1a",
+#     "TSD_NAME_KR": "\ub2e8\uc8c4\uc758 \ubd88\uaf43 \uc911\uae09",
+#     "TSD_NAME_US": "Flame of Conviction - Int",
+#     "TSD_SEQ": "1365",
+#     "TSTAMP": "1373446281337"
+# },
+class PgSubDungeon(PgItem):
+    @staticmethod
+    def file_name():
+        return 'subDungeonList'
+    
+    def __init__(self, item):
+        super().__init__()
+        self.dungeon_seq = int(item['DUNGEON_SEQ'])
+        self.exp_max = int(item['EXP_MAX'])
+        self.exp_min = int(item['EXP_MIN'])
+        self.order = int(item['ORDER_IDX'])
+        self.stage = int(item['STAGE'])
+        self.stamina = int(item['STAMINA'])
+        self.name = item['TSD_NAME_US']
+        self.tsd_seq = int(item['TSD_SEQ'])
+        
+        self.monsters = []
+        self.floor_to_monsters = defaultdict(list)
+    
+    def key(self):
+        return self.tsd_seq
+    
+    def load(self, database: PgRawDatabase):
+        self.dungeon = database.getDungeon(self.dungeon_seq)
+        self.dungeon.subdungeons.append(self)
+
+
+# dungeonMonsterDropList.jsp
+# {
+#     "MONSTER_NO": "3427",
+#     "ORDER_IDX": "20",
+#     "STATUS": "0",
+#     "TDMD_SEQ": "967",
+#     "TDM_SEQ": "17816",
+#     "TSTAMP": "1489371218890"
+# },
+# Seems to be dedicated skillups only, like collab drops
+class PgDungeonMonsterDrop(PgItem):
+    @staticmethod
+    def file_name():
+        return 'dungeonMonsterDropList'
+    
+    def __init__(self, item):
+        super().__init__()
+        self.tdmd_seq = int(item['TDMD_SEQ'])  # unique id
+        self.monster_no = int(item['MONSTER_NO'])
+        self.status = item['STATUS']  # if 1, good, if 0, bad
+        self.tdm_seq = int(item['TDM_SEQ'])  # PgDungeonMonster id
+        
+        self.monster = None  # type: PgMonster
+        self.dungeon_monster = None  # type: PgDungeonMonster
+    
+    def key(self):
+        return self.tdmd_seq
+    
+    def deleted(self):
+        # TODO: Should we be checking status == 1?
+        return False
+    
+    def load(self, database: PgRawDatabase):
+        self.monster = database.getMonster(self.monster_no)
+        self.dungeon_monster = database.getDungeonMonster(self.tdm_seq)
+
+
+# dungeonMonsterList
+# {
+#     "AMOUNT": "1",
+#     "ATK": "9810",
+#     "COMMENT_JP": "",
+#     "COMMENT_KR": "",
+#     "COMMENT_US": "",
+#     "DEF": "340",
+#     "DROP_NO": "2789",
+#     "DUNGEON_SEQ": "150",
+#     "FLOOR": "5",
+#     "HP": "3011250",
+#     "MONSTER_NO": "2789",
+#     "ORDER_IDX": "50",
+#     "TDM_SEQ": "53122",
+#     "TSD_SEQ": "4564",
+#     "TSTAMP": "1480298353178",
+#     "TURN": "1"
+# },
+class PgDungeonMonster(PgItem):
+    @staticmethod
+    def file_name():
+        return 'dungeonMonsterList'
+    
+    def __init__(self, item):
+        super().__init__()
+        self.tdm_seq = int(item['TDM_SEQ'])  # unique id
+        self.amount = int(item['AMOUNT'])
+        self.atk = int(item['ATK'])
+        self.defence = int(item['DEF'])
+        self.drop_monster_no = int(item['DROP_NO'])  # PgMonster unique id
+        self.dungeon_seq = int(item['DUNGEON_SEQ'])  # PgDungeon uniqueId
+        self.floor = int(item['FLOOR'])
+        self.hp = int(item['HP'])
+        self.monster_no = int(item['MONSTER_NO'])  # PgMonster unique id
+        self.order = int(item['ORDER_IDX'])
+        self.tsd_seq = int(item['TSD_SEQ'])  # Sub Dungeon ID
+        self.turn = int(item['TURN'])
+        
+        self.skills = []
+    
+    def key(self):
+        return self.tdm_seq
+    
+    def load(self, database: PgRawDatabase):
+        self.monster = database.getMonster(self.monster_no)
+        
+        self.dungeon = database.getDungeon(self.dungeon_seq)
+        if self.dungeon:
+            self.dungeon.monsters.append(self)
+        
+        #         self.sub_dungeon = database.getSubDungeon(self.tsd_seq)
+        #         self.sub_dungeon.monsters.append(self)
+        #         self.sub_dungeon.floor_to_monsters[self.floor].append(self)
+        
+        self.drop_monster = database.getMonster(self.drop_monster_no)
+        if self.drop_monster and self.dungeon:
+            self.drop_monster.drop_dungeons.append(self.dungeon)
+
+
+# {
+#     "TDM_SEQ": "15044", # dungeon monster
+#     "TDS_SEQ": "8934", # damage
+#     "TSTAMP": "100",
+#     "TS_SEQ": "2190" # skill
+# },
+class PgDungeonSkill(PgItem):
+    @staticmethod
+    def file_name():
+        return 'dungeonSkillList'
+    
+    def __init__(self, item):
+        super().__init__()
+        self.tdm_seq = int(item['TDM_SEQ'])
+        self.tds_seq = int(item['TDS_SEQ'])
+        self.ts_seq = int(item['TS_SEQ'])
+    
+    def key(self):
+        return '{},{},{}'.format(self.tdm_seq, self.tds_seq, self.ts_seq)
+    
+    def load(self, database: PgRawDatabase):
+        self.dungeon_monster = database.getDungeonMonster(self.tdm_seq)
+        if self.dungeon_monster:
+            self.dungeon_monster.skills.append(self)
+        self.damage = database.getDungeonDamage(self.tds_seq)
+        self.skill = database.getSkill(self.ts_seq)
+
+
+# {
+#     "DAMAGE": "16538.0",
+#     "TDS_SEQ": "14631",
+#     "TSTAMP": "1401764306350"
+# },
+class PgDungeonDamage(PgItem):
+    @staticmethod
+    def file_name():
+        return 'dungeonSkillDamageList'
+    
+    def __init__(self, item):
+        super().__init__()
+        self.tds_seq = int(item['TDS_SEQ'])
+        self.amount = float(item['DAMAGE'])
+        
+        self.monsters = []
+        self.floor_to_monsters = defaultdict(list)
+    
+    def key(self):
+        return self.tds_seq
+    
+    def load(self, database: PgRawDatabase):
+        pass
+
+
+# {
+#     "ORDER_IDX": "120",
+#     "TDT_NAME_JP": "\u30a2\u30f3\u30b1\u30fc\u30c8",
+#     "TDT_NAME_KR": "\uc559\ucf00\uc774\ud2b8",
+#     "TDT_NAME_US": "Survey",
+#     "TDT_SEQ": "9",
+#     "TSTAMP": "1388128221704"
+# },
+class PgDungeonType(PgItem):
+    @staticmethod
+    def file_name():
+        return 'dungeonTypeList'
+    
+    def __init__(self, item):
+        super().__init__()
+        self.name = item['TDT_NAME_US']
+        self.tdt_seq = int(item['TDT_SEQ'])
+    
+    def key(self):
+        return self.tdt_seq
+    
+    def load(self, database: PgRawDatabase):
+        pass
+
+
+class EvoType(Enum):
+    """Evo types supported by PadGuide. Numbers correspond to their id values."""
+    Base = -1  # Represents monsters who didn't require evo
+    Evo = 0
+    UvoAwoken = 1
+    UuvoReincarnated = 2
+
+
+# evolutionList
+# {
+#     "APP_VERSION": "",
+#     "COMMENT_JP": "",
+#     "COMMENT_KR": "",
+#     "COMMENT_US": "",
+#     "MONSTER_NO": "1",
+#     "TO_NO": "2",
+#     "TSTAMP": "1371788673999",
+#     "TV_SEQ": "331",
+#     "TV_TYPE": "0"
+# },
+class PgEvolution(PgItem):
+    @staticmethod
+    def file_name():
+        return 'evolutionList'
+    
+    def __init__(self, item):
+        super().__init__()
+        self.tv_seq = int(item['TV_SEQ'])  # unique id
+        self.from_monster_no = int(item['MONSTER_NO'])  # PgMonster id - base monster
+        self.to_monster_no = int(item['TO_NO'])  # PgMonster id - target monster
+        self.tv_type = int(item['TV_TYPE'])
+        self.evo_type = EvoType(self.tv_type)
+    
+    def key(self):
+        return self.tv_seq
+    
+    def deleted(self):
+        # Really rare and unusual bug
+        return self.from_monster_no == 0 or self.to_monster_no == 0
+    
+    def load(self, database: PgRawDatabase):
+        self.from_monster = database.getMonster(self.from_monster_no)
+        self.to_monster = database.getMonster(self.to_monster_no)
+        
+        if self.to_monster:
+            self.to_monster.cur_evo_type = self.evo_type
+            if self.from_monster:
+                self.to_monster.evo_from = self.from_monster
+                self.from_monster.evo_to.append(self.to_monster)
+
+
+# evoMaterialList
+# {
+#     "MONSTER_NO": "153",
+#     "ORDER_IDX": "1",
+#     "TEM_SEQ": "1429",
+#     "TSTAMP": "1371788674011",
+#     "TV_SEQ": "332"
+# },
+class PgEvolutionMaterial(PgItem):
+    @staticmethod
+    def file_name():
+        return 'evoMaterialList'
+    
+    def __init__(self, item):
+        super().__init__()
+        self.tem_seq = int(item['TEM_SEQ'])  # unique id
+        self.tv_seq = int(item['TV_SEQ'])  # evo id
+        self.fodder_monster_no = int(item['MONSTER_NO'])  # material monster
+        self.order = int(item['ORDER_IDX'])  # display order
+        
+        self.evolution = None  # type: PgEvolution
+        self.fodder_monster = None  # type: PgMonster
+    
+    def key(self):
+        return self.tem_seq
+    
+    def load(self, database: PgRawDatabase):
+        self.evolution = database.getEvolution(self.tv_seq)
+        self.fodder_monster = database.getMonster(self.fodder_monster_no)
+        
+        if self.evolution is None or self.evolution.to_monster is None:
+            # Really rare and unusual bug
+            return
+        
+        target_monster = self.evolution.to_monster
+        # TODO: this is unsorted
+        target_monster.mats_for_evo.append(self.fodder_monster)
+        
+        # Prevent issues if a monster is a mat for the same monster repeatedly (gunma, stones)
+        if target_monster not in self.fodder_monster.material_of:
+            self.fodder_monster.material_of.append(target_monster)
+
+
+# monsterAddInfoList
+# {
+#     "EXTRA_VAL1": "1",
+#     "EXTRA_VAL2": "",
+#     "EXTRA_VAL3": "",
+#     "EXTRA_VAL4": "",
+#     "EXTRA_VAL5": "",
+#     "MONSTER_NO": "3329",
+#     "SUB_TYPE": "0",
+#     "TSTAMP": "1480435906788"
+# },
+class PgMonsterAddInfo(PgItem):
+    """Optional extra information for a Monster.
+
+    Data is copied into PgMonster and this is discarded."""
+    
+    @staticmethod
+    def file_name():
+        return 'monsterAddInfoList'
+    
+    def __init__(self, item):
+        super().__init__()
+        self.monster_no = int(item['MONSTER_NO'])
+        self.sub_type = int(item['SUB_TYPE'])
+        self.extra_val_1 = int_or_none(item['EXTRA_VAL1'])
+    
+    def key(self):
+        return self.monster_no
+    
+    def load(self, database: PgRawDatabase):
+        pass
+
+
+# monsterInfoList
+# {
+#     "FODDER_EXP": "675.0",
+#     "HISTORY_JP": "[2016-12-16] \u65b0\u898f\u8ffd\u52a0",
+#     "HISTORY_KR": "[2016-12-16] \uc2e0\uaddc\ucd94\uac00",
+#     "HISTORY_US": "[2016-12-16] New Added",
+#     "MONSTER_NO": "3382",
+#     "ON_KR": "1",
+#     "ON_US": "1",
+#     "PAL_EGG": "0",
+#     "RARE_EGG": "0",
+#     "SELL_PRICE": "300.0",
+#     "TSR_SEQ": "86",
+#     "TSTAMP": "1481846935838"
+# },
+class PgMonsterInfo(PgItem):
+    """Extra information for a Monster.
+
+    Data is copied into PgMonster and this is discarded."""
+    
+    @staticmethod
+    def file_name():
+        return 'monsterInfoList'
+    
+    def __init__(self, item):
+        super().__init__()
+        self.monster_no = int(item['MONSTER_NO'])
+        self.on_na = item['ON_US'] == '1'
+        self.tsr_seq = int_or_none(item['TSR_SEQ'])  # PgSeries id
+        self.in_pem = item['PAL_EGG'] == '1'
+        self.in_rem = item['RARE_EGG'] == '1'
+        self.history_us = item['HISTORY_US']
+    
+    def key(self):
+        return self.monster_no
+    
+    def load(self, database: PgRawDatabase):
+        self.series = database.getSeries(self.tsr_seq)
+
+
+# monsterList
+# {
+#     "APP_VERSION": "0.0",
+#     "ATK_MAX": "1985",
+#     "ATK_MIN": "695",
+#     "COMMENT_JP": "",
+#     "COMMENT_KR": "\uc77c\ubcf8",
+#     "COMMENT_US": "Japan",
+#     "COST": "60",
+#     "EXP": "10000000",
+#     "HP_MAX": "6258",
+#     "HP_MIN": "3528",
+#     "LEVEL": "99",
+#     "MONSTER_NO": "3646",
+#     "MONSTER_NO_JP": "3646",
+#     "MONSTER_NO_KR": "3646",
+#     "MONSTER_NO_US": "3646",
+#     "PRONUNCIATION_JP": "\u304b\u306a\u305f\u306a\u308b\u3082\u306e\u30fb\u3088\u3050\u305d\u3068\u30fc\u3059",
+#     "RARITY": "7",
+#     "RATIO_ATK": "1.5",
+#     "RATIO_HP": "1.5",
+#     "RATIO_RCV": "1.5",
+#     "RCV_MAX": "233",
+#     "RCV_MIN": "926",
+#     "REG_DATE": "2017-04-27 17:29:48.0",
+#     "TA_SEQ": "4",
+#     "TA_SEQ_SUB": "0",
+#     "TE_SEQ": "14",
+#     "TM_NAME_JP": "\u5f7c\u65b9\u306a\u308b\u3082\u306e\u30fb\u30e8\u30b0\uff1d\u30bd\u30c8\u30fc\u30b9",
+#     "TM_NAME_KR": "\u5f7c\u65b9\u306a\u308b\u3082\u306e\u30fb\u30e8\u30b0\uff1d\u30bd\u30c8\u30fc\u30b9",
+#     "TM_NAME_US": "\u5f7c\u65b9\u306a\u308b\u3082\u306e\u30fb\u30e8\u30b0\uff1d\u30bd\u30c8\u30fc\u30b9",
+#     "TSTAMP": "1494033700775",
+#     "TS_SEQ_LEADER": "12448",
+#     "TS_SEQ_SKILL": "12447",
+#     "TT_SEQ": "10",
+#     "TT_SEQ_SUB": "1"
+# }
+class PgMonster(PgItem):
+    @staticmethod
+    def file_name():
+        return 'monsterList'
+    
+    def __init__(self, item):
+        super().__init__()
+        self.monster_no = int(item['MONSTER_NO'])
+        self.monster_no_na = int(item['MONSTER_NO_US'])
+        self.monster_no_jp = int(item['MONSTER_NO_JP'])
+        self.min_hp = int(item['HP_MIN'])
+        self.min_atk = int(item['ATK_MIN'])
+        self.min_rcv = int(item['RCV_MIN'])
+        self.hp = int(item['HP_MAX'])
+        self.atk = int(item['ATK_MAX'])
+        self.rcv = int(item['RCV_MAX'])
+        self.ts_seq_active = int_or_none(item['TS_SEQ_SKILL'])
+        self.ts_seq_leader = int_or_none(item['TS_SEQ_LEADER'])
+        self.rarity = int(item['RARITY'])
+        self.cost = int(item['COST'])
+        self.exp = int(item['EXP'])
+        self.max_level = int(item['LEVEL'])
+        self.name_na = item['TM_NAME_US']
+        self.name_jp = item['TM_NAME_JP']
+        self.ta_seq_1 = int(item['TA_SEQ'])  # PgAttribute id
+        self.ta_seq_2 = int(item['TA_SEQ_SUB'])  # PgAttribute id
+        self.te_seq = int(item['TE_SEQ'])
+        self.tt_seq_1 = int(item['TT_SEQ'])  # PgType id
+        self.tt_seq_2 = int(item['TT_SEQ_SUB'])  # PgType id
+        
+        self.debug_info = ''
+        self.weighted_stats = int(self.hp / 10 + self.atk / 5 + self.rcv / 3)
+        
+        self.roma_subname = None
+        if self.name_na == self.name_jp:
+            self.roma_subname = make_roma_subname(self.name_jp)
+        else:
+            # Remove annoying stuff from NA names, like Jörmungandr
+            self.name_na = rpadutils.rmdiacritics(self.name_na)
+        
+        self.active_skill = None  # type: PgSkill
+        self.leader_skill = None  # type: PgSkill
+        
+        # ???
+        self.cur_evo_type = EvoType.Base
+        self.evo_to = []
+        self.evo_from = None
+        
+        self.mats_for_evo = []
+        self.material_of = []
+        
+        self.awakenings = []  # PgAwakening
+        self.drop_dungeons = []
+        
+        self.alt_evos = []  # PgMonster
+        
+        # List of PgSkillRotationDated
+        self.rotating_skillups = []
+        self.server_actives = {}  # str(NA, JP) -> PgSkill
+        self.future_skillup_rotation = {}
+        
+        self.is_equip = False
+        
+        # Monsters start off pointing to themselves as the base, this will
+        # change once the MonsterGroups are computed.
+        self.base_monster = self
+        
+        # Data populated via override
+        self.limitbreak_stats = 1 + float(item['LIMIT_MULT']) / 100 if item['LIMIT_MULT'] else None
+        self.superawakening_count = 0
+        
+        # Data filled in post-load
+        self.translated_jp_name = None
+    
+    def key(self):
+        return self.monster_no
+    
+    def load(self, database: PgRawDatabase):
+        self.active_skill = database.getSkill(self.ts_seq_active)
+        if self.active_skill:
+            self.active_skill.monsters_with_active.append(self)
+        
+        self.leader_skill = database.getSkill(self.ts_seq_leader)
+        self.leader_skill_data = database.getSkillLeaderData(self.ts_seq_leader)
+        if self.leader_skill:
+            self.leader_skill.monsters_with_leader.append(self)
+        
+        self.attr1 = database.getAttributeEnum(self.ta_seq_1)
+        self.attr2 = database.getAttributeEnum(self.ta_seq_2)
+        
+        self.type1 = database.getTypeName(self.tt_seq_1)
+        self.type2 = database.getTypeName(self.tt_seq_2)
+        self.type3 = None
+        
+        self.assist_setting = None
+        monster_add_info = database.getMonsterAddInfo(self.monster_no)
+        if monster_add_info:
+            self.type3 = database.getTypeName(monster_add_info.sub_type)
+            self.assist_setting = monster_add_info.extra_val_1
+        
+        monster_info = database.getMonsterInfo(self.monster_no)
+        self.on_na = monster_info.on_na
+        self.series = database.getSeries(monster_info.tsr_seq)  # PgSeries
+        self.series.monsters.append(self)
+        self.is_gfe = self.series.tsr_seq == 34  # godfest
+        self.in_pem = monster_info.in_pem
+        self.in_rem = monster_info.in_rem
+        self.pem_evo = self.in_pem
+        self.rem_evo = self.in_rem
+        self.history_us = monster_info.history_us
+        
+        monster_price = database.getMonsterPrice(self.monster_no)
+        self.sell_mp = monster_price.sell_mp if monster_price else 0
+        self.buy_mp = monster_price.buy_mp if monster_price else 0
+        self.in_mpshop = self.buy_mp > 0
+        self.mp_evo = self.in_mpshop
+    
+    def finalize(self):
+        self.farmable = len(self.drop_dungeons) > 0
+        self.farmable_evo = self.farmable
+        
+        self.awakenings.sort(key=lambda x: x.order)
+        self.superawakening_count = sum(int(a.is_super) for a in self.awakenings)
+        
+        if self.assist_setting == 1:
+            self.is_inheritable = True
+        elif self.assist_setting == 2:
+            self.is_inheritable = False
+        else:
+            has_awakenings = len(self.awakenings) > 0
+            self.is_inheritable = has_awakenings and self.rarity >= 5 and self.sell_mp >= 3000
+        
+        self.is_equip = 'Awoken Assist' in [a.get_name() for a in self.awakenings]
+        
+        self.types = [t.lower() for t in [self.type1, self.type2, self.type3] if t]
+        
+        if self.evo_from is None:
+            def link(m: PgMonster, alt_evos: list):
+                alt_evos.append(m)
+                m.alt_evos = alt_evos
+                for em in m.evo_to:
+                    link(em, alt_evos)
+            
+            link(self, [])
+        
+        self.search = MonsterSearchHelper(self)
+        
+        # Compute server skill rotations
+        for server, server_tz in {'JP': rpadutils.JP_TZ_OBJ, 'NA': rpadutils.NA_TZ_OBJ}.items():
+            server_now = datetime.now().replace(tzinfo=server_tz).date()
+            server_skillups = list(filter(lambda s: s.skill_rotation.server == server,
+                                          self.rotating_skillups))
+            future_skillup = list(filter(lambda s: server_now < s.rotation_date, server_skillups))
+            if future_skillup:
+                self.future_skillup_rotation[server] = future_skillup[0]
+            
+            past_skillups = list(filter(lambda s: server_now >= s.rotation_date, server_skillups))
+            if past_skillups:
+                active_skillup = max(past_skillups, key=lambda s: s.rotation_date)
+                self.server_actives[server] = active_skillup.skill
+                active_skillup.skill.server_skillups[server] = active_skillup.skill_rotation.monster
+
+
+class MonsterSearchHelper(object):
+    def __init__(self, m: PgMonster):
+        
+        self.name = '{} {}'.format(m.name_na, m.name_jp).lower()
+        self.leader = m.leader_skill.desc.lower() if m.leader_skill else ''
+        self.active_name = m.active_skill.name.lower() if m.active_skill else ''
+        self.active_desc = m.active_skill.desc.lower() if m.active_skill else ''
+        self.active = '{} {}'.format(self.active_name, self.active_desc)
+        self.active_min = m.active_skill.turn_min if m.active_skill else None
+        self.active_max = m.active_skill.turn_max if m.active_skill else None
+        
+        self.color = [m.attr1.name.lower()]
+        self.hascolor = [c.name.lower() for c in [m.attr1, m.attr2] if c]
+        
+        self.limitbreak_stats = m.limitbreak_stats or 1
+        
+        self.hp = m.hp * self.limitbreak_stats
+        self.atk = m.atk * self.limitbreak_stats
+        self.rcv = m.rcv * self.limitbreak_stats
+        self.weighted_stats = m.weighted_stats * self.limitbreak_stats
+        
+        self.types = m.types
+        
+        def replace_colors(text: str):
+            return text.replace('red', 'fire').replace('blue', 'water').replace('green', 'wood')
+        
+        self.leader = replace_colors(self.leader)
+        self.active = replace_colors(self.active)
+        self.active_name = replace_colors(self.active_name)
+        self.active_desc = replace_colors(self.active_desc)
+        
+        self.board_change = []
+        self.orb_convert = defaultdict(list)
+        self.row_convert = []
+        self.column_convert = []
+        
+        def color_txt_to_list(txt):
+            txt = txt.replace('and', ' ')
+            txt = txt.replace(',', ' ')
+            txt = txt.replace('orbs', ' ')
+            txt = txt.replace('orb', ' ')
+            txt = txt.replace('mortal poison', 'mortalpoison')
+            txt = txt.replace('jammers', 'jammer')
+            txt = txt.strip()
+            return txt.split()
+        
+        def strip_prev_clause(txt: str, sep: str):
+            prev_clause_start_idx = txt.find(sep)
+            if prev_clause_start_idx >= 0:
+                prev_clause_start_idx += len(sep)
+                txt = txt[prev_clause_start_idx:]
+            return txt
+        
+        def strip_next_clause(txt: str, sep: str):
+            next_clause_start_idx = txt.find(sep)
+            if next_clause_start_idx >= 0:
+                txt = txt[:next_clause_start_idx]
+            return txt
+        
+        active_desc = self.active_desc
+        active_desc = active_desc.replace(' rows ', ' row ')
+        active_desc = active_desc.replace(' columns ', ' column ')
+        active_desc = active_desc.replace(' into ', ' to ')
+        active_desc = active_desc.replace('changes orbs to', 'all orbs to')
+        
+        board_change_txt = 'all orbs to'
+        if board_change_txt in active_desc:
+            txt = strip_prev_clause(active_desc, board_change_txt)
+            txt = strip_next_clause(txt, 'orbs')
+            txt = strip_next_clause(txt, ';')
+            self.board_change = color_txt_to_list(txt)
+        
+        txt = active_desc
+        if 'row' in txt:
+            parts = re.split('\Wand\W|;\W', txt)
+            for i in range(0, len(parts)):
+                if 'row' in parts[i]:
+                    self.row_convert.append(strip_next_clause(
+                        strip_prev_clause(parts[i], 'to '), ' orbs'))
+        
+        txt = active_desc
+        if 'column' in txt:
+            parts = re.split('\Wand\W|;\W', txt)
+            for i in range(0, len(parts)):
+                if 'column' in parts[i]:
+                    self.column_convert.append(strip_next_clause(
+                        strip_prev_clause(parts[i], 'to '), ' orbs'))
+        
+        convert_done = self.board_change or self.row_convert or self.column_convert
+        
+        change_txt = 'change '
+        if not convert_done and change_txt in active_desc and 'orb' in active_desc:
+            txt = active_desc
+            parts = re.split('\Wand\W|;\W', txt)
+            for i in range(0, len(parts)):
+                parts[i] = strip_prev_clause(parts[i], change_txt) if change_txt in parts[i] else ''
+            
+            for part in parts:
+                sub_parts = part.split(' to ')
+                if len(sub_parts) > 1:
+                    source_orbs = color_txt_to_list(sub_parts[0])
+                    dest_orbs = color_txt_to_list(sub_parts[1])
+                    for so in source_orbs:
+                        for do in dest_orbs:
+                            self.orb_convert[so].append(do)
+
+
+class MonsterGroup(object):
+    """Computes shared values across a tree of monsters and injects them."""
+    
+    def __init__(self, base_monster: PgMonster):
+        self.base_monster = base_monster
+        self.members = list()
+        self._recursive_add(base_monster)
+        self._initialize_members()
+    
+    def _recursive_add(self, m: PgMonster):
+        m.base_monster = self.base_monster
+        self.members.append(m)
+        for em in m.evo_to:
+            self._recursive_add(em)
+    
+    def _initialize_members(self):
+        # Compute tree acquisition status
+        farmable_evo, pem_evo, rem_evo, mp_evo = False, False, False, False
+        for m in self.members:
+            farmable_evo = farmable_evo or m.farmable
+            pem_evo = pem_evo or m.in_pem
+            rem_evo = rem_evo or m.in_rem
+            mp_evo = mp_evo or m.in_mpshop
+        
+        # Override tree acquisition status
+        for m in self.members:
+            m.farmable_evo = farmable_evo
+            m.pem_evo = pem_evo
+            m.rem_evo = rem_evo
+            m.mp_evo = mp_evo
+
+
+# monsterPriceList
+# {
+#     "BUY_PRICE": "0",
+#     "MONSTER_NO": "3577",
+#     "SELL_PRICE": "99",
+#     "TSTAMP": "1492101772974"
+# }
+
+
+class PgMonsterPrice(PgItem):
+    @staticmethod
+    def file_name():
+        return 'monsterPriceList'
+    
+    def __init__(self, item):
+        super().__init__()
+        self.monster_no = int(item['MONSTER_NO'])
+        self.buy_mp = int(item['BUY_PRICE'])
+        self.sell_mp = int(item['SELL_PRICE'])
+    
+    def key(self):
+        return self.monster_no
+    
+    def load(self, database: PgRawDatabase):
+        pass
+
+
+# seriesList
+# {
+#     "DEL_YN": "N",
+#     "NAME_JP": "\u308a\u3093",
+#     "NAME_KR": "\uc2ac\ub77c\uc784",
+#     "NAME_US": "Slime",
+#     "SEARCH_DATA": "\u308a\u3093 Slime \uc2ac\ub77c\uc784",
+#     "TSR_SEQ": "3",
+#     "TSTAMP": "1380587210667"
+# },
+class PgSeries(PgItem):
+    @staticmethod
+    def file_name():
+        return 'seriesList'
+    
+    def __init__(self, item):
+        super().__init__()
+        self.tsr_seq = int(item['TSR_SEQ'])
+        self.name = item['NAME_US']
+        self.deleted_yn = item['DEL_YN']  # Either Y(discard) or N.
+        
+        self.monsters = []
+    
+    def key(self):
+        return self.tsr_seq
+    
+    def deleted(self):
+        return False
+        # Temporary
+    
+    #         return self.deleted_yn == 'Y'
+    
+    def load(self, database: PgRawDatabase):
+        pass
+
+
+# skillList
+# {
+#     "MAG_ATK": "0.0",
+#     "MAG_HP": "0.0",
+#     "MAG_RCV": "0.0",
+#     "ORDER_IDX": "3",
+#     "REDUCE_DMG": "0.0",
+#     "RTA_SEQ_1": "0",
+#     "RTA_SEQ_2": "0",
+#     "SEARCH_DATA": "\u6e9c\u3081\u65ac\u308a \u6e9c\u3081\u65ac\u308a \u6e9c\u3081\u65ac\u308a 2\u30bf\u30fc\u30f3\u306e\u9593\u3001\u30c1\u30fc\u30e0\u5185\u306e\u30c9\u30e9\u30b4\u30f3\u30ad\u30e9\u30fc\u306e\u899a\u9192\u6570\u306b\u5fdc\u3058\u3066\u653b\u6483\u529b\u304c\u4e0a\u6607\u3002(1\u500b\u306b\u3064\u304d50%) Increase ATK depending on number of Dragon Killer Awakening Skills on team for 2 turns (50% per each) 2\ud134\uac04 \ud300\ub0b4\uc758 \ub4dc\ub798\uace4 \ud0ac\ub7ec \uac01\uc131 \uac2f\uc218\uc5d0 \ub530\ub77c \uacf5\uaca9\ub825\uc774 \uc0c1\uc2b9 (\uac1c\ub2f9 50%)",
+#     "TA_SEQ_1": "0",
+#     "TA_SEQ_2": "0",
+#     "TSTAMP": "1493861895693",
+#     "TS_DESC_JP": "2\u30bf\u30fc\u30f3\u306e\u9593\u3001\u30c1\u30fc\u30e0\u5185\u306e\u30c9\u30e9\u30b4\u30f3\u30ad\u30e9\u30fc\u306e\u899a\u9192\u6570\u306b\u5fdc\u3058\u3066\u653b\u6483\u529b\u304c\u4e0a\u6607\u3002(1\u500b\u306b\u3064\u304d50%)",
+#     "TS_DESC_KR": "2\ud134\uac04 \ud300\ub0b4\uc758 \ub4dc\ub798\uace4 \ud0ac\ub7ec \uac01\uc131 \uac2f\uc218\uc5d0 \ub530\ub77c \uacf5\uaca9\ub825\uc774 \uc0c1\uc2b9 (\uac1c\ub2f9 50%)",
+#     "TS_DESC_US": "Increase ATK depending on number of Dragon Killer Awakening Skills on team for 2 turns (50% per each)",
+#     "TS_NAME_JP": "\u6e9c\u3081\u65ac\u308a",
+#     "TS_NAME_KR": "\u6e9c\u3081\u65ac\u308a",
+#     "TS_NAME_US": "\u6e9c\u3081\u65ac\u308a",
+#     "TS_SEQ": "12478",
+#     "TT_SEQ_1": "0",
+#     "TT_SEQ_2": "0",
+#     "TURN_MAX": "22",
+#     "TURN_MIN": "14",
+#     "T_CONDITION": "3"
+# }
+class PgSkill(PgItem):
+    @staticmethod
+    def file_name():
+        return 'skillList'
+    
+    def __init__(self, item):
+        super().__init__()
+        self.ts_seq = int(item['TS_SEQ'])
+        self.name = item['TS_NAME_US']
+        self.desc = item['TS_DESC_US']
+        self.turn_min = int(item['TURN_MIN'])
+        self.turn_max = int(item['TURN_MAX'])
+        
+        self.monsters_with_active = []  # PgMonster
+        self.monsters_with_leader = []  # PgMonster
+        self.monsters_with_awakening = []  # PgMonster
+        
+        # str (NA, JP) -> PgMonster
+        self.server_skillups = {}
+    
+    def key(self):
+        return self.ts_seq
+    
+    def load(self, database: PgRawDatabase):
+        pass
+
+
+# skillLeaderDataList
+#
+# PgSkillLeaderData
+# 4 pipe delimited fields, each field is a condition
+# Slashes separate effects for conditions
+# 1: Code 1=HP, 2=ATK, 3=RCV, 4=Reduction
+# 2: Multiplier
+# 3: Color restriction (coded)
+# 4: Type restriction (coded)
+# 5: Combo restriction
+#
+# Reincarnated Izanagi, 4x + 50% for heal cross, 2x atk 2x rcv for god/dragon/balanced
+# {
+#     "LEADER_DATA": "4/0.5///|2/4///|2/2//6,1,2/|3/2//6,1,2/",
+#     "TSTAMP": "1487553365770",
+#     "TS_SEQ": "11695"
+# },
+# Gold Saint, Shion : 4.5X atk when 3+ light combo
+# {
+#     "LEADER_DATA": "2/4.5///3",
+#     "TSTAMP": "1432940060708",
+#     "TS_SEQ": "6661"
+# },
+# Reincarnated Minerva, 3x damage, 2x damage, color resist
+# {
+#     "LEADER_DATA": "2/3/1//|2/2///|4/0.5/1,4,5//",
+#     "TSTAMP": "1475243514648",
+#     "TS_SEQ": "10835"
+# },
+class PgSkillLeaderData(PgItem):
+    @staticmethod
+    def empty():
+        return PgSkillLeaderData({
+            'TS_SEQ': '-1',
+            'LEADER_DATA': '',
+        })
+    
+    @staticmethod
+    def file_name():
+        return 'skillLeaderDataList'
+    
+    def __init__(self, item):
+        super().__init__()
+        self.ts_seq = int(item['TS_SEQ'])  # unique id
+        self.leader_data = item['LEADER_DATA']
+        
+        hp, atk, rcv, resist = (1.0,) * 4
+        for mod in self.leader_data.split('|'):
+            if not mod.strip():
+                continue
+            items = mod.split('/')
+            
+            code = items[0]
+            mult = float(items[1])
+            if code == '1':
+                hp *= mult
+            if code == '2':
+                atk *= mult
+            if code == '3':
+                rcv *= mult
+            if code == '4':
+                resist *= mult
+        
+        self.hp = hp
+        self.atk = atk
+        self.rcv = rcv
+        self.resist = resist
+    
+    def key(self):
+        return self.ts_seq
+    
+    def load(self, database: PgRawDatabase):
+        pass
+    
+    def get_data(self):
+        return self.hp, self.atk, self.rcv, self.resist
+
+
+# skillRotationList
+# {
+#     "MONSTER_NO": "915",
+#     "SERVER": "JP",
+#     "STATUS": "0",
+#     "TSR_SEQ": "2",
+#     "TSTAMP": "1481627094573"
+# }
+class PgSkillRotation(PgItem):
+    @staticmethod
+    def file_name():
+        return 'skillRotationList'
+    
+    def __init__(self, item):
+        super().__init__()
+        self.tsr_seq = int(item['TSR_SEQ'])  # unique id
+        self.monster_no = int(item['MONSTER_NO'])
+        self.server = normalizeServer(item['SERVER'])  # JP, NA, KR
+        # Status seems to be rarely '2'
+        self.status = int(item['STATUS'])
+    
+    def key(self):
+        return self.tsr_seq
+    
+    def deleted(self):
+        return self.server == 'KR' or self.status != 0  # We don't do KR
+    
+    def load(self, database: PgRawDatabase):
+        self.monster = database.getMonster(self.monster_no)
+
+
+# skillRotationListList
+# {
+#     "ROTATION_DATE": "2016-12-14",
+#     "STATUS": "0",
+#     "TSRL_SEQ": "960",
+#     "TSR_SEQ": "86",
+#     "TSTAMP": "1481627993157",
+#     "TS_SEQ": "9926"
+# }
+class PgSkillRotationDated(PgItem):
+    @staticmethod
+    def file_name():
+        return 'skillRotationListList'
+    
+    def __init__(self, item):
+        super().__init__()
+        self.tsrl_seq = int(item['TSRL_SEQ'])  # unique id
+        self.tsr_seq = int(item['TSR_SEQ'])  # PgSkillRotation id - Current skillup monster
+        self.ts_seq = int(item['TS_SEQ'])  # PGSkill id - Current skill
+        self.rotation_date_str = item['ROTATION_DATE']
+        
+        self.rotation_date = None
+        if len(self.rotation_date_str):
+            self.rotation_date = datetime.strptime(self.rotation_date_str, "%Y-%m-%d").date()
+    
+    def key(self):
+        return self.tsrl_seq
+    
+    def load(self, database: PgRawDatabase):
+        self.skill = database.getSkill(self.ts_seq)
+        self.skill_rotation = database.getSkillRotation(self.tsr_seq)
+        
+        if self.skill_rotation:
+            self.skill_rotation.monster.rotating_skillups.append(self)
+
+
+# typeList
+# {
+#     "ORDER_IDX": "2",
+#     "TSTAMP": "1375363406092",
+#     "TT_NAME_JP": "\u60aa\u9b54",
+#     "TT_NAME_KR": "\uc545\ub9c8",
+#     "TT_NAME_US": "Devil",
+#     "TT_SEQ": "10"
+# },
+class PgType(PgItem):
+    @staticmethod
+    def file_name():
+        return 'typeList'
+    
+    def __init__(self, item):
+        super().__init__()
+        self.tt_seq = int(item['TT_SEQ'])  # unique id
+        self.name = item['TT_NAME_US']
+    
+    def key(self):
+        return self.tt_seq
+    
+    def load(self, database: PgRawDatabase):
+        pass
+
+
+class PgMonsterDropInfoCombined(object):
+    def __init__(self, monster_id, dungeon_monster_drop, dungeon_monster, dungeon):
+        self.monster_id = monster_id
+        self.dungeon_monster_drop = dungeon_monster_drop
+        self.dungeon_monster = dungeon_monster
+        self.dungeon = dungeon
+
+
+# ================================================================================
+# PadRem items below
+# ================================================================================
+
+class RemType(Enum):
+    godfest = 1
+    rare = 2
+    pal = 3
+    unknown1 = 4
+
+
+class RemRowType(Enum):
+    subsection = 0
+    divider = 1
+
+
+# eggTitleList
+#       {
+#            "DEL_YN": "N",
+#            "END_DATE": "2016-10-24 07:59:00",
+#            "ORDER_IDX": "0",
+#            "SERVER": "US",
+#            "SHOW_YN": "Y",
+#            "START_DATE": "2016-10-17 08:00:00",
+#            "TEC_SEQ": "2",
+#            "TET_SEQ": "64",
+#            "TSTAMP": "1476490114488",
+#            "TYPE": "1"
+#        },
+class PgEggInstance(PgItem):
+    @staticmethod
+    def file_name():
+        return 'eggTitleList'
+    
+    def __init__(self, item):
+        super().__init__()
+        self.server = normalizeServer(item['SERVER'])
+        self.deleted_yn = item['DEL_YN']  # Y, N
+        self.show_yn = item['SHOW_YN']  # Y, N
+        self.rem_type = RemType(int(item['TEC_SEQ']))  # matches RemType
+        self.tet_seq = int(item['TET_SEQ'])  # primary key
+        self.row_type = RemRowType(int(item['TYPE']))  # 0-> row with just name, 1-> row with date
+        
+        self.order = int(item["ORDER_IDX"])
+        self.start_date_str = item['START_DATE']
+        self.end_date_str = item['END_DATE']
+        
+        self.egg_name_us = None
+        self.egg_monsters = []
+        
+        tz = pytz.UTC
+        self.start_datetime = None
+        self.end_datetime = None
+        self.open_date_str = None
+        
+        #         self.pt_date_str = None
+        if len(self.start_date_str):
+            self.start_datetime = datetime.strptime(
+                self.start_date_str, "%Y-%m-%d %H:%M:%S").replace(tzinfo=tz)
+            self.end_datetime = datetime.strptime(
+                self.end_date_str, "%Y-%m-%d %H:%M:%S").replace(tzinfo=tz)
+            
+            if self.server == 'NA':
+                pt_tz_obj = pytz.timezone('America/Los_Angeles')
+                self.open_date_str = self.start_datetime.replace(tzinfo=pt_tz_obj).strftime('%m/%d')
+            if self.server == 'JP':
+                jp_tz_obj = pytz.timezone('Asia/Tokyo')
+                self.open_date_str = self.start_datetime.replace(tzinfo=jp_tz_obj).strftime('%m/%d')
+    
+    def key(self):
+        return self.tet_seq
+    
+    def deleted(self):
+        return (self.deleted_yn == 'Y' or
+                self.show_yn == 'N' or
+                self.server == 'KR' or
+                self.rem_type in (RemType.pal, RemType.unknown1))
+    
+    def load(self, database: PgRawDatabase):
+        pass
+
+
+#         self.monster = database.getMonster(self.monster_no)
+
+
+# eggMonsterList
+#        {
+#            "DEL_YN": "Y",
+#            "MONSTER_NO": "120",
+#            "ORDER_IDX": "1",
+#            "TEM_SEQ": "1",
+#            "TET_SEQ": "1",
+#            "TSTAMP": "1405245537715"
+#        },
+class PgEggMonster(PgItem):
+    @staticmethod
+    def file_name():
+        return 'eggMonsterList'
+    
+    def __init__(self, item):
+        super().__init__()
+        self.deleted_yn = item['DEL_YN']
+        self.monster_no = int(item['MONSTER_NO'])
+        self.tem_seq = int(item['TEM_SEQ'])  # primary key
+        self.tet_seq = int(item['TET_SEQ'])  # fk to PgEggInstance
+    
+    def key(self):
+        return self.tem_seq
+    
+    def deleted(self):
+        return self.deleted_yn == 'Y' or self.monster_no == 0
+    
+    def load(self, database: PgRawDatabase):
+        self.monster = database.getMonster(self.monster_no)
+        self.egg_instance = database.getEggInstance(self.tet_seq)
+        if self.egg_instance:
+            # For KR stuff we clipped out
+            self.egg_instance.egg_monsters.append(self)
+
+
+# eggTitleNameList
+#        {
+#            "DEL_YN": "N",
+#            "LANGUAGE": "US",
+#            "NAME": "Batman Egg",
+#            "TETN_SEQ": "183",
+#            "TET_SEQ": "64",
+#            "TSTAMP": "1441589491425"
+#        },
+class PgEggName(PgItem):
+    @staticmethod
+    def file_name():
+        return 'eggTitleNameList'
+    
+    def __init__(self, item):
+        super().__init__()
+        self.name = item['NAME']
+        self.language = item['LANGUAGE']  # US, JP, KR
+        self.deleted_yn = item['DEL_YN']  # Y, N
+        self.tetn_seq = int(item['TETN_SEQ'])  # primary key
+        self.tet_seq = int(item['TET_SEQ'])  # fk to PgEggInstance
+    
+    def key(self):
+        return self.tetn_seq
+    
+    def deleted(self):
+        return self.deleted_yn == 'Y' or self.language != 'US'
+    
+    def load(self, database: PgRawDatabase):
+        self.egg_instance = database.getEggInstance(self.tet_seq)
+        if self.egg_instance:
+            # For KR stuff we clipped out
+            self.egg_instance.egg_name_us = self
+
+
+# ================================================================================
+# PadEvents items below
+# ================================================================================
+
+
+class EventType(Enum):
+    EventTypeWeek = 0
+    EventTypeSpecial = 1
+    EventTypeSpecialWeek = 2
+    EventTypeGuerrilla = 3
+    EventTypeGuerrillaNew = 4
+    EventTypeEtc = -100
+
+
+def normalizeServer(server):
+    server = server.upper()
+    return 'NA' if server == 'US' else server
+
+
+# {
+#     "CLOSE_DATE": "2017-09-01",
+#     "CLOSE_HOUR": "19",
+#     "CLOSE_MINUTE": "59",
+#     "CLOSE_WEEKDAY": "0",
+#     "DUNGEON_SEQ": "31",
+#     "EVENT_SEQ": "25",
+#     "EVENT_TYPE": "-100",
+#     "OPEN_DATE": "2017-09-01",
+#     "OPEN_HOUR": "08",
+#     "OPEN_MINUTE": "00",
+#     "OPEN_WEEKDAY": "0",
+#     "SCHEDULE_SEQ": "235217",
+#     "SERVER": "US",
+#     "SERVER_OPEN_DATE": "2017-09-01",
+#     "SERVER_OPEN_HOUR": "1",
+#     "TEAM_DATA": "0",
+#     "TSTAMP": "1504233623450",
+#     "URL": ""
+# },
+class PgScheduledEvent(PgItem):
+    @staticmethod
+    def file_name():
+        return 'scheduleList'
+    
+    def __init__(self, item):
+        super().__init__()
+        self.schedule_seq = int(item['SCHEDULE_SEQ'])
+        
+        self.open_timestamp = int(item['OPEN_TIMESTAMP'])
+        self.close_timestamp = int(item['CLOSE_TIMESTAMP'])
+        
+        self.dungeon_seq = int(item['DUNGEON_SEQ'])
+        self.event_seq = int(item['EVENT_SEQ'])
+        self.event_type = int(item['EVENT_TYPE'])
+        
+        self.server = normalizeServer(item['SERVER'])
+        
+        self.team_data = int_or_none(item['TEAM_DATA'])
+        self.url = item['URL']
+        
+        self.group = None
+        if self.team_data is not None:
+            if self.event_type == EventType.EventTypeGuerrilla.value:
+                self.group = chr(ord('a') + self.team_data).upper()
+            elif self.event_type == EventType.EventTypeSpecialWeek.value:
+                self.group = ['RED', 'BLUE', 'GREEN'][self.team_data]
+        
+        self.open_datetime = datetime.utcfromtimestamp(
+            self.open_timestamp).replace(tzinfo=pytz.UTC)
+        self.close_datetime = datetime.utcfromtimestamp(
+            self.close_timestamp).replace(tzinfo=pytz.UTC)
+    
+    def key(self):
+        return self.schedule_seq
+    
+    def deleted(self):
+        return self.server == 'KR'
+    
+    def load(self, database: PgRawDatabase):
+        self.dungeon = database.getDungeon(self.dungeon_seq)
+        self.event = database.getEvent(self.event_seq) if self.event_seq != '0' else None
+
+
+# {
+#     "EVENT_NAME_JP": "\u30b3\u30a4\u30f3 1.5\u500d!",
+#     "EVENT_NAME_KR": "\ucf54\uc778 1.5\ubc30!",
+#     "EVENT_NAME_US": "Coin x 1.5!",
+#     "EVENT_SEQ": "3",
+#     "TSTAMP": "1370174967128"
+# },
+class PgEvent(PgItem):
+    @staticmethod
+    def file_name():
+        return 'eventList'
+    
+    def __init__(self, item):
+        super().__init__()
+        self.event_seq = int(item['EVENT_SEQ'])
+        self.name = item['EVENT_NAME_US']
+    
+    def key(self):
+        return self.event_seq
+    
+    def load(self, database: PgRawDatabase):
+        pass
+
+
+def make_roma_subname(name_jp):
+    subname = name_jp.replace('＝', '')
+    adjusted_subname = ''
+    for part in subname.split('・'):
+        roma_part = romkan.to_roma(part)
+        if part != roma_part and not rpadutils.containsJp(roma_part):
+            adjusted_subname += ' ' + roma_part.strip('-')
+    return adjusted_subname.strip()
+
+
+def int_or_none(maybe_int: str):
+    return int(maybe_int) if maybe_int else None
+
+
+def float_or_none(maybe_float: str):
+    return float(maybe_float) if maybe_float else None
+
+
+def empty_index():
+    return MonsterIndex(PgRawDatabase(skip_load=True), {}, {})
+
+
+class MonsterIndex(object):
+    def __init__(self, monster_database, nickname_overrides, basename_overrides, accept_filter=None):
+        # Important not to hold onto anything except IDs here so we don't leak memory
+        monster_groups = monster_database.grouped_monsters
+        
+        self.attr_short_prefix_map = {
+            Attribute.Fire: ['r'],
+            Attribute.Water: ['b'],
+            Attribute.Wood: ['g'],
+            Attribute.Light: ['l'],
+            Attribute.Dark: ['d'],
+        }
+        self.attr_long_prefix_map = {
+            Attribute.Fire: ['red', 'fire'],
+            Attribute.Water: ['blue', 'water'],
+            Attribute.Wood: ['green', 'wood'],
+            Attribute.Light: ['light'],
+            Attribute.Dark: ['dark'],
+        }
+        
+        self.series_to_prefix_map = {
+            130: ['halloween', 'hw', 'h'],
+            136: ['xmas', 'christmas'],
+            125: ['summer', 'beach'],
+            114: ['school', 'academy', 'gakuen'],
+            139: ['new years', 'ny'],
+            149: ['wedding', 'bride'],
+            154: ['padr'],
+            175: ['valentines', 'vday'],
+        }
+        
+        monster_no_na_to_nicknames = defaultdict(set)
+        for nickname, monster_no_na in nickname_overrides.items():
+            monster_no_na_to_nicknames[monster_no_na].add(nickname)
+        
+        named_monsters = []
+        for mg in monster_groups:
+            group_basename_overrides = basename_overrides.get(mg.base_monster.monster_no_na, [])
+            named_mg = NamedMonsterGroup(mg, group_basename_overrides)
+            for monster in mg.members:
+                if accept_filter and not accept_filter(monster):
+                    continue
+                prefixes = self.compute_prefixes(monster, mg)
+                extra_nicknames = monster_no_na_to_nicknames[monster.monster_no_na]
+                named_monster = NamedMonster(monster, named_mg, prefixes, extra_nicknames)
+                named_monsters.append(named_monster)
+        
+        # Sort the NamedMonsters into the opposite order we want to accept their nicknames in
+        # This order is:
+        #  1) High priority first
+        #  2) Larger group sizes
+        #  3) Minimum ID size in the group
+        #  4) Monsters with higher ID values
+        def named_monsters_sort(nm: NamedMonster):
+            return (not nm.is_low_priority, nm.group_size, -1 *
+                    nm.base_monster_no_na, nm.monster_no_na)
+        
+        named_monsters.sort(key=named_monsters_sort)
+        
+        self.all_prefixes = set()
+        self.all_entries = {}
+        self.two_word_entries = {}
+        for nm in named_monsters:
+            self.all_prefixes.update(nm.prefixes)
+            for nickname in nm.final_nicknames:
+                self.all_entries[nickname] = nm
+            for nickname in nm.final_two_word_nicknames:
+                self.two_word_entries[nickname] = nm
+        
+        self.all_monsters = named_monsters
+        self.all_na_name_to_monsters = {m.name_na.lower(): m for m in named_monsters}
+        self.monster_no_na_to_named_monster = {m.monster_no_na: m for m in named_monsters}
+        self.monster_no_to_named_monster = {m.monster_no: m for m in named_monsters}
+        
+        for nickname, monster_no_na in nickname_overrides.items():
+            nm = self.monster_no_na_to_named_monster.get(monster_no_na)
+            if nm:
+                self.all_entries[nickname] = nm
+    
+    def init_index(self):
+        pass
+    
+    def compute_prefixes(self, m: PgMonster, mg: MonsterGroup):
+        prefixes = set()
+        
+        attr1_short_prefixes = self.attr_short_prefix_map[m.attr1]
+        attr1_long_prefixes = self.attr_long_prefix_map[m.attr1]
+        prefixes.update(attr1_short_prefixes)
+        prefixes.update(attr1_long_prefixes)
+        
+        # If no 2nd attribute, use x so we can look those monsters up easier
+        attr2_short_prefixes = self.attr_short_prefix_map.get(m.attr2, ['x'])
+        for a1 in attr1_short_prefixes:
+            for a2 in attr2_short_prefixes:
+                prefixes.add(a1 + a2)
+                prefixes.add(a1 + '/' + a2)
+        
+        # TODO: add prefixes based on type
+        
+        # Chibi monsters have the same NA name, except lowercased
+        if m.name_na != m.name_jp:
+            if m.name_na.lower() == m.name_na:
+                prefixes.add('chibi')
+        elif 'ミニ' in m.name_jp:
+            # Guarding this separately to prevent 'gemini' from triggering (e.g. 2645)
+            prefixes.add('chibi')
+        
+        lower_name = m.name_na.lower()
+        awoken = lower_name.startswith('awoken') or '覚醒' in lower_name
+        revo = lower_name.startswith('reincarnated') or '転生' in lower_name
+        mega = lower_name.startswith('mega woken') or '極醒' in lower_name
+        awoken_or_revo_or_equip_or_mega = awoken or revo or m.is_equip or mega
+        
+        # These clauses need to be separate to handle things like 'Awoken Thoth' which are
+        # actually Evos but have awoken in the name
+        if awoken:
+            prefixes.add('a')
+            prefixes.add('awoken')
+        
+        if revo:
+            prefixes.add('revo')
+            prefixes.add('reincarnated')
+        
+        if mega:
+            prefixes.add('mega')
+            prefixes.add('mega awoken')
+            prefixes.add('awoken')
+        
+        # Prefixes for evo type
+        if m.cur_evo_type == EvoType.Base:
+            prefixes.add('base')
+        elif m.cur_evo_type == EvoType.Evo:
+            prefixes.add('evo')
+        elif m.cur_evo_type == EvoType.UvoAwoken and not awoken_or_revo_or_equip_or_mega:
+            prefixes.add('uvo')
+            prefixes.add('uevo')
+        elif m.cur_evo_type == EvoType.UuvoReincarnated and not awoken_or_revo_or_equip_or_mega:
+            prefixes.add('uuvo')
+            prefixes.add('uuevo')
+        
+        # If any monster in the group is a pixel, add 'nonpixel' to all the versions
+        # without pixel in the name. Add 'pixel' as a prefix to the ones with pixel in the name.
+        def is_pixel(n):
+            n = n.name_na.lower()
+            return n.startswith('pixel') or n.startswith('ドット')
+        
+        for gm in mg.members:
+            if is_pixel(gm):
+                prefixes.update(['pixel'] if is_pixel(m) else ['np', 'nonpixel'])
+                break
+        
+        if m.is_equip:
+            prefixes.add('assist')
+            prefixes.add('equip')
+        
+        # Collab prefixes
+        prefixes.update(self.series_to_prefix_map.get(m.series.tsr_seq, []))
+        
+        return prefixes
+    
+    def find_monster(self, query):
+        query = rpadutils.rmdiacritics(query).lower().strip()
+        
+        # id search
+        if query.isdigit():
+            m = self.monster_no_na_to_named_monster.get(int(query))
+            if m is None:
+                return None, 'Looks like a monster ID but was not found', None
             else:
-                row.append('')
-        tbl.add_row(row)
+                return m, None, "ID lookup"
+            # special handling for na/jp
+        
+        # TODO: need to handle na_only?
+        
+        # handle exact nickname match
+        if query in self.all_entries:
+            return self.all_entries[query], None, "Exact nickname"
+        
+        contains_jp = rpadutils.containsJp(query)
+        if len(query) < 2 and contains_jp:
+            return None, 'Japanese queries must be at least 2 characters', None
+        elif len(query) < 4 and not contains_jp:
+            return None, 'Your query must be at least 4 letters', None
+        
+        # TODO: this should be a length-limited priority queue
+        matches = set()
+        # prefix search for nicknames, space-preceeded, take max id
+        for nickname, m in self.all_entries.items():
+            if nickname.startswith(query + ' '):
+                matches.add(m)
+        if len(matches):
+            return self.pickBestMonster(matches), None, "Space nickname prefix, max of {}".format(len(matches))
+        
+        # prefix search for nicknames, take max id
+        for nickname, m in self.all_entries.items():
+            if nickname.startswith(query):
+                matches.add(m)
+        if len(matches):
+            all_names = ",".join(map(lambda x: x.name_na, matches))
+            return self.pickBestMonster(matches), None, "Nickname prefix, max of {}, matches=({})".format(len(matches),
+                                                                                                          all_names)
+        
+        # prefix search for full name, take max id
+        for nickname, m in self.all_entries.items():
+            if (m.name_na.lower().startswith(query) or m.name_jp.lower().startswith(query)):
+                matches.add(m)
+        if len(matches):
+            return self.pickBestMonster(matches), None, "Full name, max of {}".format(len(matches))
+        
+        # for nicknames with 2 names, prefix search 2nd word, take max id
+        if query in self.two_word_entries:
+            return self.two_word_entries[query], None, "Second-word nickname prefix, max of {}".format(len(matches))
+        
+        # TODO: refactor 2nd search characteristcs for 2nd word
+        
+        # full name contains on nickname, take max id
+        for nickname, m in self.all_entries.items():
+            if (query in m.name_na.lower() or query in m.name_jp.lower()):
+                matches.add(m)
+        if len(matches):
+            return self.pickBestMonster(matches), None, 'Full name match on nickname, max of {}'.format(len(matches))
+        
+        # full name contains on full monster list, take max id
+        
+        for m in self.all_monsters:
+            if (query in m.name_na.lower() or query in m.name_jp.lower()):
+                matches.add(m)
+        if len(matches):
+            return self.pickBestMonster(matches), None, 'Full name match on full list, max of {}'.format(len(matches))
+        
+        # No decent matches. Try near hits on nickname instead
+        matches = difflib.get_close_matches(query, self.all_entries.keys(), n=1, cutoff=.8)
+        if len(matches):
+            match = matches[0]
+            return self.all_entries[match], None, 'Close nickname match ({})'.format(match)
+        
+        # Still no decent matches. Try near hits on full name instead
+        matches = difflib.get_close_matches(
+            query, self.all_na_name_to_monsters.keys(), n=1, cutoff=.9)
+        if len(matches):
+            match = matches[0]
+            return self.all_na_name_to_monsters[match], None, 'Close name match ({})'.format(match)
+        
+        # couldn't find anything
+        return None, "Could not find a match for: " + query, None
+    
+    def find_monster2(self, query):
+        """Search with alternative method for resolving prefixes.
 
-    return tbl.get_string()
-
-AWAKENING_NAME_MAP_RPAD = {
-    'Enhanced Attack': 'boost_atk',
-    'Enhanced HP': 'boost_hp',
-    'Enhanced Heal': 'boost_rcv',
-
-    'Enhanced Team HP': 'teamboost_hp',
-    'Enhanced Team Attack': 'teamboost_atk',
-    'Enhanced Team RCV': 'teamboost_rcv',
-
-    'God Killer': 'killer_god',
-    'Dragon Killer': 'killer_dragon',
-    'Devil Killer': 'killer_devil',
-    'Machine Killer': 'killer_machine',
-    'Balanced Killer': 'killer_balance',
-    'Attacker Killer': 'killer_attacker',
-
-    'Physical Killer': 'killer_physical',
-    'Healer Killer': 'killer_healer',
-    'Evolve Material Killer': 'killer_evomat',
-    'Awaken Material Killer': 'killer_awoken',
-    'Enhance Material Killer': 'killer_enhancemat',
-    'Vendor Material Killer': 'killer_vendor',
-
-    'Auto-Recover': 'misc_autoheal',
-    'Recover Bind': 'misc_bindclear',
-    'Enhanced Combo': 'misc_comboboost',
-    'Super Enhanced Combo': 'misc_super_comboboost',
-    'Guard Break': 'misc_guardbreak',
-    'Multi Boost': 'misc_multiboost',
-    'Additional Attack': 'misc_extraattack',
-    'Skill Boost': 'misc_sb',
-    'Extend Time': 'misc_te',
-    'Two-Pronged Attack': 'misc_tpa',
-    'Damage Void Shield Penetration': 'misc_voidshield',
-    'Awoken Assist': 'misc_assist',
-
-    'Enhanced Fire Orbs': 'oe_fire',
-    'Enhanced Water Orbs': 'oe_water',
-    'Enhanced Wood Orbs': 'oe_wood',
-    'Enhanced Light Orbs': 'oe_light',
-    'Enhanced Dark Orbs': 'oe_dark',
-    'Enhanced Heal Orbs': 'oe_heart',
-
-    'Reduce Fire Damage': 'reduce_fire',
-    'Reduce Water Damage': 'reduce_water',
-    'Reduce Wood Damage': 'reduce_wood',
-    'Reduce Light Damage': 'reduce_light',
-    'Reduce Dark Damage': 'reduce_dark',
-
-    'Resistance-Bind': 'res_bind',
-    'Resistance-Dark': 'res_blind',
-    'Resistance-Jammers': 'res_jammer',
-    'Resistance-Poison': 'res_poison',
-    'Resistance-Skill Bind': 'res_skillbind',
-
-    'Enhanced Fire Att.': 'row_fire',
-    'Enhanced Water Att.': 'row_water',
-    'Enhanced Wood Att.': 'row_wood',
-    'Enhanced Light Att.': 'row_light',
-    'Enhanced Dark Att.': 'row_dark',
-
-    'Skill Charge': 'misc_skillcharge',
-    'Super Additional Attack': 'misc_super_extraattack',
-    'Resistance-Bind＋': 'res_bind_super',
-    'Extend Time＋': 'misc_te_super',
-    'Resistance-Cloud': 'res_cloud',
-    'Resistance-Board Restrict': 'res_seal',
-    'Skill Boost＋': 'misc_sb_super',
-    'L-Shape Attack': 'l_attack',
-    'L-Shape Damage Reduction': 'l_shield',
-    'Enhance when HP is below 50%': 'attack_boost_low',
-    'Enhance when HP is above 80%': 'attack_boost_high',
-    'Combo Orb': 'orb_combo',
-    'Skill Voice': 'misc_voice',
-    'Dungeon Bonus': 'misc_dungeonbonus',
-}
-
-AWAKENING_NAME_MAP = {
-    'Enhanced Fire Orbs': 'R-OE',
-    'Enhanced Water Orbs': 'B-OE',
-    'Enhanced Wood Orbs': 'G-OE',
-    'Enhanced Light Orbs': 'L-OE',
-    'Enhanced Dark Orbs': 'D-OE',
-    'Enhanced Heal Orbs': 'H-OE',
-
-    'Enhanced Fire Att.': 'R-RE',
-    'Enhanced Water Att.': 'B-RE',
-    'Enhanced Wood Att.': 'G-RE',
-    'Enhanced Light Att.': 'L-RE',
-    'Enhanced Dark Att.': 'D-RE',
-
-    'Enhanced HP': 'HP',
-    'Enhanced Attack': 'ATK',
-    'Enhanced Heal': 'RCV',
-
-    'Enhanced Team HP': 'TEAM-HP',
-    'Enhanced Team Attack': 'TEAM-ATK',
-    'Enhanced Team RCV': 'TEAM-RCV',
-
-    'Auto-Recover': 'AUTO-RECOVER',
-    'Skill Boost': 'SB',
-    'Resistance-Skill Bind': 'SBR',
-    'Two-Pronged Attack': 'TPA',
-    'Multi Boost': 'MULTI-BOOST',
-    'Recover Bind': 'RCV-BIND',
-    'Extend Time': 'TE',
-    'Enhanced Combo': 'COMBO-BOOST',
-    'Guard Break': 'DEF-BREAK',
-    'Additional Attack': 'EXTRA-ATK',
-    'Damage Void Shield Penetration': 'VOID-BREAK',
-    'Awoken Assist': 'ASSIST',
-
-    'Resistance-Bind': 'RES-BIND',
-    'Resistance-Dark': 'RES-BLIND',
-    'Resistance-Poison': 'RES-POISON',
-    'Resistance-Jammers': 'RES-JAMMER',
-
-    'Reduce Fire Damage': 'R-RES',
-    'Reduce Water Damage': 'B-RES',
-    'Reduce Wood Damage': 'G-RES',
-    'Reduce Light Damage': 'L-RES',
-    'Reduce Dark Damage': 'D-RES',
-
-    'Healer Killer': 'K-HEALER',
-    'Machine Killer': 'K-MACHINE',
-    'Dragon Killer': 'K-DRAGON',
-    'Attacker Killer': 'K-ATTACKER',
-    'Physical Killer': 'K-PHYSICAL',
-    'God Killer': 'K-GOD',
-    'Devil Killer': 'K-DEVIL',
-    'Balance Killer': 'K-BALANCE',
-}
-
-def createMultiplierText(hp1, atk1, rcv1, resist1, hp2=None, atk2=None, rcv2=None, resist2=None):
-    hp2, atk2, rcv2, resist2 = hp2 or hp1, atk2 or atk1, rcv2 or rcv1, resist2 or resist1
+        Implements the lookup for id2, where you are allowed to specify multiple prefixes for a card.
+        All prefixes are required to be exactly matched by the card.
+        Follows a similar logic to the regular id but after each check, will remove any potential match that doesn't
+        contain every single specified prefix.
+        """
+        query = rpadutils.rmdiacritics(query).lower().strip()
+        # id search
+        if query.isdigit():
+            m = self.monster_no_na_to_named_monster.get(int(query))
+            if m is None:
+                return None, 'Looks like a monster ID but was not found', None
+            else:
+                return m, None, "ID lookup"
+        
+        # handle exact nickname match
+        if query in self.all_entries:
+            return self.all_entries[query], None, "Exact nickname"
+        
+        contains_jp = rpadutils.containsJp(query)
+        if len(query) < 2 and contains_jp:
+            return None, 'Japanese queries must be at least 2 characters', None
+        elif len(query) < 4 and not contains_jp:
+            return None, 'Your query must be at least 4 letters', None
+        
+        # we want to look up only the main part of the query, and then verify that each result has the prefixes
+        # so break up the query into an array of prefixes, and a string (new_query) that will be the lookup
+        query_prefixes = []
+        parts_of_query = query.split()
+        new_query = ''
+        for i, part in enumerate(parts_of_query):
+            if part in self.all_prefixes:
+                query_prefixes.append(part)
+            else:
+                new_query = ' '.join(parts_of_query[i:])
+                break
+        
+        # if we don't actually have multiple prefixes, then default to using the regular id lookup
+        if len(query_prefixes) < 2:
+            return self.find_monster(query)
+        
+        matches = set()
+        
+        # first try to get matches from nicknames
+        for nickname, m in self.all_entries.items():
+            if new_query in nickname:
+                matches.add(m)
+        self.remove_potential_matches_without_all_prefixes(matches, query_prefixes)
+        
+        # if we don't have any candidates yet, pick a new method
+        if not len(matches):
+            # try matching on exact names next
+            for nickname, m in self.all_na_name_to_monsters.items():
+                if new_query in m.name_na.lower() or new_query in m.name_jp.lower():
+                    matches.add(m)
+            self.remove_potential_matches_without_all_prefixes(matches, query_prefixes)
+        
+        if len(matches):
+            return self.pickBestMonster(matches), None, None
+        return None, "Could not find a match for: " + query, None
+    
+    # verify that potential matches do in fact have the prefixes that we want
+    def remove_potential_matches_without_all_prefixes(self, matches, query_prefixes):
+        to_remove = set()
+        for m in matches:
+            for prefix in query_prefixes:
+                if prefix not in m.prefixes:
+                    to_remove.add(m)
+                    break
+        matches.difference_update(to_remove)
+    
+    def pickBestMonster(self, named_monster_list):
+        return max(named_monster_list, key=lambda x: (not x.is_low_priority, x.rarity, x.monster_no_na))
 
 
-    def fmtNum(val):
-        return ('{:.2f}').format(val).strip('0').rstrip('.')
+class NamedMonsterGroup(object):
+    def __init__(self, monster_group: MonsterGroup, basename_overrides: list):
+        self.is_low_priority = (
+                        self._is_low_priority_monster(monster_group.base_monster)
+                        or self._is_low_priority_group(monster_group))
+        
+        monsters = monster_group.members
+        self.group_size = len(monsters)
+        self.base_monster_no = monster_group.base_monster.monster_no
+        self.base_monster_no_na = monster_group.base_monster.monster_no_na
+        
+        self.monster_no_to_basename = {
+            m.monster_no: self._compute_monster_basename(m) for m in monsters
+        }
+        
+        self.computed_basename = self._compute_group_basename(monsters)
+        self.computed_basenames = set([self.computed_basename])
+        if '-' in self.computed_basename:
+            self.computed_basenames.add(self.computed_basename.replace('-', ' '))
+        
+        self.basenames = basename_overrides or self.computed_basenames
+    
+    def _compute_monster_basename(self, m: PgMonster):
+        basename = m.name_na.lower()
+        if ',' in basename:
+            name_parts = basename.split(',')
+            if name_parts[1].strip().startswith('the '):
+                # handle names like 'xxx, the yyy' where xxx is the name
+                basename = name_parts[0]
+            else:
+                # otherwise, grab the chunk after the last comma
+                basename = name_parts[-1]
+        
+        for x in ['awoken', 'reincarnated']:
+            if basename.startswith(x):
+                basename = basename.replace(x, '')
+        
+        # Fix for DC collab garbage
+        basename = basename.replace('(comics)', '')
+        basename = basename.replace('(film)', '')
+        
+        return basename.strip()
+    
+    def _compute_group_basename(self, monsters):
+        """Computes the basename for a group of monsters.
 
-    text = "{}/{}/{}".format(fmtNum(hp1 * hp2), fmtNum(atk1 * atk2), fmtNum(rcv1 * rcv2))
-    if resist1 * resist2 < 1:
-        resist1 = resist1 if resist1 < 1 else 0
-        resist2 = resist2 if resist2 < 1 else 0
-        text += ' Resist {}%'.format(fmtNum(100 * (1 - (1 - resist1) * (1 - resist2))))
-    return text
+        Prefer a basename with the largest count across the group. If all the
+        groups have equal size, prefer the lowest monster number basename.
+        This monster in general has better names, particularly when all the
+        names are unique, e.g. for male/female hunters."""
+        
+        def count_and_id(): return [0, 0]
+        
+        basename_to_info = defaultdict(count_and_id)
+        
+        for m in monsters:
+            basename = self.monster_no_to_basename[m.monster_no]
+            entry = basename_to_info[basename]
+            entry[0] += 1
+            entry[1] = max(entry[1], m.monster_no)
+        
+        entries = [[count_id[0], -1 * count_id[1], bn] for bn, count_id in basename_to_info.items()]
+        return max(entries)[2]
+    
+    def _is_low_priority_monster(self, m: PgMonster):
+        lp_types = ['evolve', 'enhance', 'protected', 'awoken', 'vendor']
+        lp_substrings = ['tamadra']
+        lp_min_rarity = 2
+        name = m.name_na.lower()
+        
+        failed_type = m.type1.lower() in lp_types
+        failed_ss = any([x in name for x in lp_substrings])
+        failed_rarity = m.rarity < lp_min_rarity
+        failed_chibi = name == m.name_na and m.name_na != m.name_jp
+        failed_equip = m.is_equip
+        return failed_type or failed_ss or failed_rarity or failed_chibi or failed_equip
+    
+    def _is_low_priority_group(self, mg: MonsterGroup):
+        lp_grp_min_rarity = 5
+        max_rarity = max(m.rarity for m in mg.members)
+        failed_max_rarity = max_rarity < lp_grp_min_rarity
+        return failed_max_rarity
 
-def _map_awakenings_text(m: padguide2.PgMonster):
-    awakenings_row = ''
-    unique_awakenings = set(m.awakening_names)
-    for a in unique_awakenings:
-        count = m.awakening_names.count(a)
-        awakenings_row += ' {}x{}'.format(AWAKENING_NAME_MAP.get(a, a), count)
-    awakenings_row = awakenings_row.strip()
 
-    if not len(awakenings_row):
-        awakenings_row = 'No Awakenings'
+class NamedMonster(object):
+    def __init__(self, monster: PgMonster, monster_group: NamedMonsterGroup, prefixes: set, extra_nicknames: set):
+        # Must not hold onto monster or monster_group!
+        
+        # Hold on to the IDs instead
+        self.monster_no = monster.monster_no
+        self.monster_no_na = monster.monster_no_na
+        self.monster_no_jp = monster.monster_no_jp
+        
+        # ID of the root of the tree for this monster
+        self.base_monster_no = monster_group.base_monster_no
+        self.base_monster_no_na = monster_group.base_monster_no_na
+        
+        # This stuff is important for nickname generation
+        self.group_basenames = monster_group.basenames
+        self.prefixes = prefixes
+        
+        # Data used to determine how to rank the nicknames
+        self.is_low_priority = monster_group.is_low_priority or monster.is_equip
+        self.group_size = monster_group.group_size
+        self.rarity = monster.rarity
+        
+        # Used in fallback searches
+        self.name_na = monster.name_na
+        self.name_jp = monster.name_jp
+        
+        # These are just extra metadata
+        self.monster_basename = monster_group.monster_no_to_basename[self.monster_no]
+        self.group_computed_basename = monster_group.computed_basename
+        self.extra_nicknames = extra_nicknames
+        
+        # Compute any extra prefixes
+        if self.monster_basename in ('ana', 'ace'):
+            self.prefixes.add(self.monster_basename)
+        
+        # Compute extra basenames by checking for two-word basenames and using the second half
+        self.two_word_basenames = set()
+        for basename in self.group_basenames:
+            basename_words = basename.split(' ')
+            if len(basename_words) == 2:
+                self.two_word_basenames.add(basename_words[1])
+        
+        # The primary result nicknames
+        self.final_nicknames = set()
+        # Set the configured override nicknames
+        self.final_nicknames.update(self.extra_nicknames)
+        # Set the roma subname for JP monsters
+        if monster.roma_subname:
+            self.final_nicknames.add(monster.roma_subname)
+        
+        # For each basename, add nicknames
+        for basename in self.group_basenames:
+            # Add the basename directly
+            self.final_nicknames.add(basename)
+            # Add the prefix plus basename, and the prefix with a space between basename
+            for prefix in self.prefixes:
+                self.final_nicknames.add(prefix + basename)
+                self.final_nicknames.add(prefix + ' ' + basename)
+        
+        self.final_two_word_nicknames = set()
+        # Slightly different process for two-word basenames. Does this make sense? Who knows.
+        for basename in self.two_word_basenames:
+            self.final_two_word_nicknames.add(basename)
+            # Add the prefix plus basename, and the prefix with a space between basename
+            for prefix in self.prefixes:
+                self.final_two_word_nicknames.add(prefix + basename)
+                self.final_two_word_nicknames.add(prefix + ' ' + basename)
 
-    return awakenings_row
 
-# TODO: move to padguide2
 def compute_killers(*types):
     if 'Balance' in types:
         return ['Any']
@@ -1118,6 +2526,7 @@ def compute_killers(*types):
     for t in types:
         killers.update(type_to_killers_map.get(t, []))
     return sorted(killers)
+
 
 type_to_killers_map = {
     'God': ['Devil'],


### PR DESCRIPTION
Called ^id2 or ^idna2 to the user, find_monster_multiple_prefixes in the code. Currently has significantly less search logic than ^id but it will fallback to ^id immediately if there aren't 2+ prefixes present in the query.

TODO: Add support for a lot more prefixes, including manually set ones, allow prefixes to be suffixes, and also improve logic as needed